### PR TITLE
fix zAnim function ordering

### DIFF
--- a/src/Speed/Indep/SourceLists/zAnim.cpp
+++ b/src/Speed/Indep/SourceLists/zAnim.cpp
@@ -28,6 +28,8 @@
 
 #include "Speed/Indep/Src/Animation/AnimPart.cpp"
 
+#include "Speed/Indep/Src/Animation/AnimPrint.cpp"
+
 #include "Speed/Indep/Src/Animation/AnimScene.cpp"
 
 #include "Speed/Indep/Src/Animation/AnimSkeleton.cpp"

--- a/src/Speed/Indep/Src/Animation/AnimBank.cpp
+++ b/src/Speed/Indep/Src/Animation/AnimBank.cpp
@@ -45,6 +45,9 @@ EAGL4Anim::AnimBank *GetFirstAnimBank(const EAGL4::DynamicLoader *loader) {
     return firstBank;
 }
 
+// STRIPPED
+EAGL4Anim::AnimMemoryMap *CAnimBank::GetAnim(int bankID, int index) {}
+
 int CAnimBank::Initialize(char *data, int size) {
     m_pDynLoader = AnimBridgeNewDynamicLoader("EAGL4::DynamicLoder CAnimBank", data, size);
     m_DynLoaderSize = size;
@@ -79,9 +82,16 @@ void CAnimBank::Cleanup() {
     }
 }
 
+// STRIPPED
+void CAnimBank::PrintfAnimBankContents() {}
+
 void InitAnimBankSlotPool() {
     if (!AnimBankSlotPoolInitialized) {
+#ifdef EA_BUILD_A124
+        AnimBankSlotPool = bNewSlotPool(60, 81, "Anim_CNFSAnimBank_SlotPool", 0);
+#else
         AnimBankSlotPool = bNewSlotPool(60, 81, "Anim_CNFSAnimBank_SlotPool", GetVirtualMemoryAllocParams());
+#endif
         AnimBankSlotPoolInitialized = true;
     }
 }
@@ -94,15 +104,36 @@ void CloseAnimBankSlotPool() {
 
 bTList<CNFSAnimBank> g_loadedAnimBankList;
 
+#ifdef MILESTONE_OPT
+int NumAnimBanks = 0;
+int MaxNumAnimBanks = 0;
+
+// STRIPPED
+int GetMaxNumAnimBanks() {
+    return MaxNumAnimBanks;
+}
+#endif
+
 void *CNFSAnimBank::operator new(size_t size, const char *debug_name) {
     if (!AnimBankSlotPoolInitialized) {
         InitAnimBankSlotPool();
     }
 
+#ifdef MILESTONE_OPT
+    NumAnimBanks++;
+    if (MaxNumAnimBanks < NumAnimBanks) {
+        MaxNumAnimBanks = NumAnimBanks;
+    }
+#endif
+
     return bOMalloc(AnimBankSlotPool);
 }
 
 void CNFSAnimBank::operator delete(void *ptr) {
+#ifdef MILESTONE_OPT
+    NumAnimBanks--;
+#endif
+
     bFree(AnimBankSlotPool, ptr);
     if (bCountFreeSlots(AnimBankSlotPool) == bCountTotalSlots(AnimBankSlotPool)) {
         CloseAnimBankSlotPool();
@@ -160,6 +191,12 @@ int GetAnimFromBankByNamehash(uint32 namehash, EAGL4Anim::AnimBank **animBank, i
     }
     return false;
 }
+
+// STRIPPED
+struct AnimMemoryMap *GetAnimFromBank(uint32 namehash) {}
+
+// STRIPPED
+bool IsAnimInBank(uint32 namehash) {}
 
 int LoaderEAGLAnimations(bChunk *chunk) {
     if (chunk->GetID() == BCHUNK_EAGL_ANIMATIONS) {

--- a/src/Speed/Indep/Src/Animation/AnimCandidates.hpp
+++ b/src/Speed/Indep/Src/Animation/AnimCandidates.hpp
@@ -1,11 +1,11 @@
 #ifndef ANIMATION_ANIMCANDIDATES_H
 #define ANIMATION_ANIMCANDIDATES_H
 
-#include "Speed/Indep/bWare/Inc/bWare.hpp"
 #ifdef EA_PRAGMA_ONCE_SUPPORTED
 #pragma once
 #endif
 
+#include "Speed/Indep/bWare/Inc/bWare.hpp"
 #include "Speed/Indep/Src/World/TrackPositionMarker.hpp"
 #include "Speed/Indep/bWare/Inc/bMath.hpp"
 

--- a/src/Speed/Indep/Src/Animation/AnimChooseArrest.cpp
+++ b/src/Speed/Indep/Src/Animation/AnimChooseArrest.cpp
@@ -245,6 +245,7 @@ void NISListenerActivity::MessageBusted(const MPerpBusted &message) {
             nis->StartLocation(markerPos, markerAngle);
             nis->Load(CAnimChooser::Arrest, sceneName, cameraTrack, true);
         }
+#ifndef EA_BUILD_A124
     } else {
         GRaceParameters *parms = GRaceStatus::Get().GetRaceParameters();
         if (!parms) {
@@ -252,5 +253,9 @@ void NISListenerActivity::MessageBusted(const MPerpBusted &message) {
         } else {
             new EPause(0, 1, 0);
         }
+#endif
     }
 }
+
+// STRIPPED
+bool GetNearestRoadCentre(UMath::Vector3 &centre, const struct UMath::Vector3 &pos) {}

--- a/src/Speed/Indep/Src/Animation/AnimChooser.cpp
+++ b/src/Speed/Indep/Src/Animation/AnimChooser.cpp
@@ -6,3 +6,6 @@ CAnimChooser TheAnimChooser;
 CAnimChooser::CAnimChooser() {}
 
 CAnimChooser::~CAnimChooser() {}
+
+// STRIPPED
+char *CAnimChooser::ChooseAnim(eType type, char *animName, int &camera_track_number) {}

--- a/src/Speed/Indep/Src/Animation/AnimCtrl.cpp
+++ b/src/Speed/Indep/Src/Animation/AnimCtrl.cpp
@@ -24,6 +24,9 @@ void InitAnimCtrls() {
 #endif
 }
 
+// STRIPPED
+void CloseAnimCtrls() {}
+
 #ifdef MILESTONE_OPT
 static int NumAnimCtrls = 0;
 static int MaxNumAnimCtrls = 0;
@@ -97,6 +100,9 @@ void CAnimCtrl::SetLoopRange(uint32 loop_range_start, uint32 loop_range_end) {
     m_loop_range_end = loop_range_end;
     m_f_loop_end = m_loop_range_end * m_timeScale;
 }
+
+// STRIPPED
+int CAnimCtrl::CreateFnAnim(EAGL4Anim::AnimMemoryMap *memMap, int dof) {}
 
 int CAnimCtrl::CreateFnAnimFromBank(EAGL4Anim::AnimBank *animBank, int animIndex, int dof) {
     m_pFnAnim[dof] = animBank->NewFnAnim(animIndex);
@@ -212,6 +218,18 @@ int CAnimCtrl::AdvanceAnimTime(float timestep) {
     return result_anim_is_done;
 }
 
+// STRIPPED
+float CAnimCtrl::GetEvalTimeInSeconds() {}
+
+// STRIPPED
+void CAnimCtrl::SetEvalTimeInSeconds(float seconds) {}
+
+// STRIPPED
+float CAnimCtrl::GetAnimLengthInSeconds() {}
+
+// STRIPPED
+void CAnimCtrl::UpdateAnim() {}
+
 int Anim_Apply_Trans = 1;  // size: 0x4, address: 0x80415688
 int Anim_Apply_Rots = 1;   // size: 0x4, address: 0x8041568C
 int Anim_Apply_Scales = 1; // size: 0x4, address: 0x80415690
@@ -254,3 +272,6 @@ int CAnimCtrl::UpdateAnimPose(bool force_calc) {
     }
     return 0;
 }
+
+// STRIPPED
+void CAnimCtrl::PredictPositionAtTime(float time, struct bMatrix4 *world_position) {}

--- a/src/Speed/Indep/Src/Animation/AnimDirectory.hpp
+++ b/src/Speed/Indep/Src/Animation/AnimDirectory.hpp
@@ -1,10 +1,11 @@
 #ifndef ANIMATION_ANIMDIRECTORY_H
 #define ANIMATION_ANIMDIRECTORY_H
 
-#include "Speed/Indep/bWare/Inc/bWare.hpp"
 #ifdef EA_PRAGMA_ONCE_SUPPORTED
 #pragma once
 #endif
+
+#include "Speed/Indep/bWare/Inc/bWare.hpp"
 
 #define ANIM_SCENE_MAX (256)
 

--- a/src/Speed/Indep/Src/Animation/AnimEngineManager.cpp
+++ b/src/Speed/Indep/Src/Animation/AnimEngineManager.cpp
@@ -6,6 +6,11 @@
 #include "Speed/Indep/bWare/Inc/bMemory.hpp"
 #include "Speed/Indep/bWare/Inc/bWare.hpp"
 
+#ifdef EA_BUILD_A124
+// STRIPPED
+void DumpNFSAnimMemUsage() {}
+#endif
+
 void InitNFSAnimEngine() {
     CAnimEngineManager::Init();
     TheAnimPlayer.Init();
@@ -13,6 +18,24 @@ void InitNFSAnimEngine() {
 
 // STRIPPED
 void CloseNFSAnimEngine() {}
+
+// STRIPPED
+void ReportNFSAnimMemoryUsage() {}
+
+// STRIPPED
+void ResetNFSAnimMemory() {}
+
+// STRIPPED
+CAnimEngineManager::CAnimEngineManager() {}
+
+// STRIPPED
+CAnimEngineManager::~CAnimEngineManager() {}
+
+// STRIPPED
+void *MyEAGLNewOverride(size_t size, const char *name) {}
+
+// STRIPPED
+void MyEAGLDeleteOverride(void *ptr, size_t) {}
 
 void *MyEAGLMallocOverride(size_t size, const char *name) {
 #ifdef EA_BUILD_A124
@@ -32,5 +55,12 @@ void MyEAGLFreeOverride(void *ptr, size_t) {
 void CAnimEngineManager::Init() {
     EAGL4Internal::SetMallocOverride(&MyEAGLMallocOverride);
     EAGL4Internal::SetFreeOverride(&MyEAGLFreeOverride);
+#ifdef EA_BUILD_A124
+    EAGL4Anim::Init(0xC800, true);
+#else
     EAGL4Anim::Init(0x14000, false);
+#endif
 }
+
+// STRIPPED
+void CAnimEngineManager::Purge() {}

--- a/src/Speed/Indep/Src/Animation/AnimEntity_BasicCharacter.cpp
+++ b/src/Speed/Indep/Src/Animation/AnimEntity_BasicCharacter.cpp
@@ -237,6 +237,15 @@ void CBasicCharacterAnimEntity::Purge() {
     }
 }
 
+// STRIPPED
+void CBasicCharacterAnimEntity::Play() {}
+
+// STRIPPED
+void CBasicCharacterAnimEntity::Stop() {}
+
+// STRIPPED
+bool CBasicCharacterAnimEntity::IsPlaying() {}
+
 void CBasicCharacterAnimEntity::SetTime(float time) {
     if (mAnimCtrl) {
         mAnimCtrl->SetEvalTime(0.0f);
@@ -359,6 +368,18 @@ void CBasicCharacterAnimEntity::RenderEffects(eView *view, int is_reflection) {
         view->Render(&shadow_poly, CharacterShadowTexture, eGetIdentityMatrix(), 0, 0.0f);
     }
 }
+
+// STRIPPED
+void CBasicCharacterAnimEntity::SetCurrentEvalTime(float time, bool in_seconds) {}
+
+// STRIPPED
+float CBasicCharacterAnimEntity::GetCurrentEvalTime(bool in_seconds) {}
+
+// STRIPPED
+float CBasicCharacterAnimEntity::GetNumSecondsUntilThisFrame(float frame_number) {}
+
+// STRIPPED
+float CBasicCharacterAnimEntity::GetNumSecondsBetweenFrames(float start_frame, float end_frame) {}
 
 void CBasicCharacterAnimEntity::FindWorldBonePosition(int bone, bVector3 *position) {
     bMatrix4 world_matrix(*mSpaceNode->GetWorldMatrix());

--- a/src/Speed/Indep/Src/Animation/AnimEntity_WorldEntity.cpp
+++ b/src/Speed/Indep/Src/Animation/AnimEntity_WorldEntity.cpp
@@ -12,6 +12,7 @@
 #include "Speed/Indep/bWare/Inc/bWare.hpp"
 #include "WorldAnimInstanceDirectory.hpp"
 
+bool DisableWorldAnimations = false;    // size: 0x1, address: 0x804156F0
 static int NumWorldAnimEntities = 0;    // size: 0x4, address: 0x804156F4
 static int MaxNumWorldAnimEntities = 0; // size: 0x4, address: 0x804156F8
 // TODO move? they are static though
@@ -19,6 +20,11 @@ static int NumWorldAnimEntityTrees = 0;        // size: 0x4, address: 0x804156FC
 static int MaxNumWorldAnimEntityTrees = 0;     // size: 0x4, address: 0x80415700
 static int NumWorldAnimEntityTreeInfos = 0;    // size: 0x4, address: 0x80415704
 static int MaxNumWorldAnimEntityTreeInfos = 0; // size: 0x4, address: 0x80415708
+
+// STRIPPED
+int GetMaxWorldAnimEntities() {
+    return MaxNumWorldAnimEntities;
+}
 
 void *CWorldAnimEntity::operator new(size_t size, const char *debug_name) {
     NumWorldAnimEntities++;
@@ -33,6 +39,11 @@ void CWorldAnimEntity::operator delete(void *ptr) {
     bFree(TheWorldAnimInstanceDirectory.GetWorldAnimEntitySlotPool(), ptr);
 }
 
+// STRIPPED
+int GetMaxNumWorldAnimEntityTrees() {
+    return MaxNumWorldAnimEntityTrees;
+}
+
 void *CWorldAnimEntityTree::operator new(size_t size, const char *debug_name) {
     NumWorldAnimEntityTrees++;
     if (NumWorldAnimEntityTrees > MaxNumWorldAnimEntityTrees) {
@@ -44,6 +55,11 @@ void *CWorldAnimEntityTree::operator new(size_t size, const char *debug_name) {
 void CWorldAnimEntityTree::operator delete(void *ptr) {
     NumWorldAnimEntityTrees--;
     bFree(TheWorldAnimInstanceDirectory.GetWorldAnimEntityTreeSlotPool(), ptr);
+}
+
+// STRIPPED
+int GetMaxNumWorldAnimEntityTreeInfos() {
+    return MaxNumWorldAnimEntityTreeInfos;
 }
 
 void *WorldAnimEntityTreeInfo::operator new(size_t size, const char *debug_name) {
@@ -516,7 +532,8 @@ int UnloaderWorldAnimDirectoryData(bChunk *chunk) {
     return 1;
 }
 
-CWorldAnimEntity *CWorldAnimEntityTree::GetEntityByNameHash(unsigned int namehash) {
+// STRIPPED
+CWorldAnimEntity *CWorldAnimEntityTree::GetEntityByNameHash(uint32 namehash) {
     for (bPNode *node = instantiated_world_anim_entities.GetHead(); node != instantiated_world_anim_entities.EndOfList(); node = node->GetNext()) {
         CWorldAnimEntity *entity = reinterpret_cast<CWorldAnimEntity *>(node->GetObject());
         if (entity->GetInstanceNameHash() == namehash) {
@@ -564,3 +581,6 @@ void CWorldAnimEntityTree::Stop() {
         }
     }
 }
+
+// STRIPPED
+float CWorldAnimEntityTree::GetAnimLengthInSeconds() {}

--- a/src/Speed/Indep/Src/Animation/AnimLocator.cpp
+++ b/src/Speed/Indep/Src/Animation/AnimLocator.cpp
@@ -100,3 +100,6 @@ bool ANIM_GetWorldHeight(const UMath::Vector3 &pt, float &height, UMath::Vector3
         return true;
     }
 }
+
+// STRIPPED
+void MatrixFromNormal(const UMath::Vector3 &normal, const UMath::Vector4 &facing, UMath::Matrix4 &mat) {}

--- a/src/Speed/Indep/Src/Animation/AnimPart.cpp
+++ b/src/Speed/Indep/Src/Animation/AnimPart.cpp
@@ -16,10 +16,32 @@ CAnimPart::~CAnimPart() {
     Purge();
 }
 
+// STRIPPED
+void InitAnimPartSlotPool() {}
+
+// STRIPPED
+void CloseAnimPartSlotPool() {}
+
 #ifdef MILESTONE_OPT
 static int NumAnimParts = 0;
 static int MaxNumAnimParts = 0;
+
+// STRIPPED
+int GetMaxNumAnimParts() {
+    return MaxNumAnimParts;
+}
 #endif
+
+// STRIPPED
+void *CAnimPart::operator new(size_t size, const char *debug_name) {
+#ifdef MILESTONE_OPT
+    NumAnimParts++;
+    if (NumAnimParts > MaxNumAnimParts) {
+        MaxNumAnimParts = NumAnimParts;
+    }
+#endif
+    return bOMalloc(AnimPartSlotPool);
+}
 
 void CAnimPart::operator delete(void *ptr) {
 #ifdef MILESTONE_OPT

--- a/src/Speed/Indep/Src/Animation/AnimPlayer.cpp
+++ b/src/Speed/Indep/Src/Animation/AnimPlayer.cpp
@@ -1,5 +1,6 @@
 #include "AnimPlayer.hpp"
 #include "AnimDirectory.hpp"
+#include "AnimScene.hpp"
 #include "WorldAnimInstanceDirectory.hpp"
 #include "Speed/Indep/Src/Misc/bFile.hpp"
 #include "Speed/Indep/Src/World/CarLoader.hpp"
@@ -47,8 +48,24 @@ int gAnimCfg_Small_NIS_Size = 20000;
 extern int CarLoaderMemoryPoolNumber;
 void UpdateCopDoorPositions(float time_step);
 
+// STRIPPED
+void CAnimSettings::SetDebugPrintEnabled(bool enable) {
+    mDebugPrintEnabled = enable;
+}
+
 bool CAnimSettings::IsDebugPrintEnabled() {
     return mDebugPrintEnabled;
+}
+
+// STRIPPED
+char *GetDescription(uint32 anim_id) {
+    CAnimSceneData *scene_data = CAnimSceneData::FindAnimSceneData(anim_id);
+
+    if (scene_data) {
+        return scene_data->GetSceneInfo()->Description;
+    }
+
+    return nullptr;
 }
 
 CAnimPlayer::CAnimPlayer() {
@@ -60,26 +77,8 @@ CAnimPlayer::~CAnimPlayer() {
     KillWorldAnimScene(true, false);
 }
 
-bool CAnimPlayer::IsLoaded(uint32 anim_id) {
-    if (gAnimLoader_InProgress) {
-        return false;
-    }
-    CAnimSceneData *scene_data = CAnimSceneData::FindAnimSceneData(anim_id);
-    if (scene_data) {
-        m_audioQueued = false;
-        return true;
-    }
-    return false;
-}
-
-int CAnimPlayer::CreateAnimInstance(uint32 anim_id, int camera_track_number, int anim_candidate_type, int anim_candidate_index) {
-    CAnimSceneData *anim_scene_data = CAnimSceneData::FindAnimSceneData(anim_id);
-    int result = 0;
-    if (anim_scene_data) {
-        result = CreateAnimScene(anim_scene_data, camera_track_number, anim_candidate_type, anim_candidate_index);
-    }
-    return result;
-}
+// STRIPPED
+int GetAnimLoader_MaxSize() {}
 
 void AnimLoader_Init() {
     gAnimLoader_InProgress = true;
@@ -119,9 +118,7 @@ int AnimLoader_SizeNeeded() {
     }
 }
 
-void AnimLoader_Callback(int param_1) {
-    AnimLoader_NextStep();
-}
+void AnimLoader_Callback(int);
 
 void AnimLoader_LoadResourceFile(const char *filename) {
     int file_size = bFileSize(filename);
@@ -146,6 +143,16 @@ void AnimLoader_NextStep() {
         }
     }
 }
+
+void AnimLoader_Callback(int) {
+    AnimLoader_NextStep();
+}
+
+// STRIPPED
+void AnimLoader_UnloadAll() {}
+
+// STRIPPED
+void CAnimPlayer::StreamCued() {}
 
 // UNSOLVED
 bool CAnimPlayer::Load(uint32 anim_id, int camera_track_number, bool DisableZoneSwitching) {
@@ -249,6 +256,232 @@ bool CAnimPlayer::Unload(uint32 anim_id) {
     return false;
 }
 
+// STRIPPED
+bool CAnimPlayer::UnloadAll() {}
+
+// STRIPPED
+bool CAnimPlayer::UnloadCategory(eAnimCategory category_id) {}
+
+bool CAnimPlayer::IsLoaded(uint32 anim_id) {
+    if (gAnimLoader_InProgress) {
+        return false;
+    }
+    CAnimSceneData *scene_data = CAnimSceneData::FindAnimSceneData(anim_id);
+    if (scene_data) {
+        m_audioQueued = false;
+        return true;
+    }
+    return false;
+}
+
+int CAnimPlayer::CreateAnimInstance(uint32 anim_id, int camera_track_number, int anim_candidate_type, int anim_candidate_index) {
+    CAnimSceneData *anim_scene_data = CAnimSceneData::FindAnimSceneData(anim_id);
+    int result = 0;
+    if (anim_scene_data) {
+        result = CreateAnimScene(anim_scene_data, camera_track_number, anim_candidate_type, anim_candidate_index);
+    }
+    return result;
+}
+
+void CAnimPlayer::DeleteAnimInstance(AnimHandle anim_handle) {
+    DestroyAnimScene(anim_handle);
+}
+
+int CAnimPlayer::CreateAnimScene(CAnimSceneData *anim_scene_data, int camera_track_number, int anim_candidate_type, int anim_candidate_index) {
+    CAnimScene *anim_scene = new CAnimScene(anim_scene_data, camera_track_number, anim_candidate_type, anim_candidate_index);
+    if (anim_scene->Init()) {
+        mInstancedAnimSceneList.AddTail(anim_scene);
+        return anim_scene->GetHandle();
+    }
+    return 0;
+}
+
+void CAnimPlayer::DestroyAnimScene(AnimHandle anim_handle) {
+    CAnimScene *anim_scene = FindAnimScene(anim_handle);
+
+    if (anim_scene && anim_scene->Purge()) {
+        anim_scene->Remove();
+        delete anim_scene;
+    }
+}
+
+int CAnimPlayer::CreateAndPlayAnim(uint32 anim_id, int camera_track_number, int anim_candidate_type, int anim_candidate_index) {
+    AnimHandle anim_handle = CreateAnimInstance(anim_id, camera_track_number, anim_candidate_type, anim_candidate_index);
+    if (anim_handle == 0) {
+        return 0;
+    }
+    Play(anim_handle);
+    return anim_handle;
+}
+
+CAnimScene *CAnimPlayer::FindAnimScene(AnimHandle anim_handle) {
+    CAnimScene *anim_scene = mInstancedAnimSceneList.GetHead();
+    while (anim_scene != mInstancedAnimSceneList.EndOfList()) {
+        if (anim_handle == anim_scene->GetHandle()) {
+            return anim_scene;
+        }
+        anim_scene = anim_scene->GetNext();
+    }
+    return nullptr;
+}
+
+// STRIPPED
+int CAnimPlayer::FindHandle(eAnimCategory category_id) {}
+
+// STRIPPED
+int CAnimPlayer::GetSceneType(AnimHandle anim_handle) {}
+
+// STRIPPED
+bool CAnimPlayer::SetPropertyEnabled(AnimHandle anim_handle, eAnimProperty property_id, bool enable) {}
+
+// STRIPPED
+bool CAnimPlayer::IsPropertyEnabled(AnimHandle anim_handle, eAnimProperty property_id) {}
+
+// STRIPPED
+bool CAnimPlayer::AreAnyWithThisPropertyEnabled(eAnimProperty property_id) {}
+
+// STRIPPED
+bool CAnimPlayer::AreAnyControllingCamera() {}
+
+// STRIPPED
+bool CAnimPlayer::SetTime(AnimHandle anim_handle, float time) {}
+
+// STRIPPED
+bool CAnimPlayer::GetTime(AnimHandle anim_handle, float &time) {}
+
+// STRIPPED
+bool CAnimPlayer::Cue(AnimHandle anim_handle) {
+    CAnimScene *scene = FindAnimScene(anim_handle);
+
+    if (scene) {
+        return scene->Cue();
+    }
+
+    return false;
+}
+
+bool CAnimPlayer::Play(AnimHandle anim_handle) {
+    CAnimScene *scene = FindAnimScene(anim_handle);
+
+    if (scene) {
+        return scene->Play();
+    }
+
+    return false;
+}
+
+bool CAnimPlayer::Stop(AnimHandle anim_handle, bool delete_instance) {
+    CAnimScene *scene = FindAnimScene(anim_handle);
+    if (scene) {
+        bool stopped = scene->Stop();
+        if (stopped && delete_instance) {
+            DeleteAnimInstance(anim_handle);
+        }
+        return stopped;
+    }
+    return false;
+}
+
+// STRIPPED
+bool CAnimPlayer::Pause(int anim_handle) {
+    CAnimScene *scene = FindAnimScene(anim_handle);
+
+    if (scene) {
+        return scene->Pause();
+    }
+
+    return false;
+}
+
+// STRIPPED
+bool CAnimPlayer::UnPause(AnimHandle anim_handle) {
+    CAnimScene *scene = FindAnimScene(anim_handle);
+
+    if (scene) {
+        return scene->UnPause();
+    }
+
+    return false;
+}
+
+// STRIPPED
+bool CAnimPlayer::StopAll(bool delete_instances) {}
+
+// STRIPPED
+bool CAnimPlayer::StopCategory(eAnimCategory category_id, bool delete_instances) {}
+
+bool CAnimPlayer::PauseAll() {
+    bool any_success = false;
+
+    for (CAnimScene *anim_scene = mInstancedAnimSceneList.GetHead(); anim_scene != mInstancedAnimSceneList.EndOfList();
+         anim_scene = anim_scene->GetNext()) {
+
+        bool success = anim_scene->Pause();
+        if (!any_success) {
+            any_success = success;
+        }
+    }
+
+    return any_success;
+}
+
+bool CAnimPlayer::UnPauseAll() {
+    bool any_success = false;
+
+    for (CAnimScene *anim_scene = mInstancedAnimSceneList.GetHead(); anim_scene != mInstancedAnimSceneList.EndOfList();
+         anim_scene = anim_scene->GetNext()) {
+
+        bool success = anim_scene->UnPause();
+        if (!any_success) {
+            any_success = success;
+        }
+    }
+
+    return any_success;
+}
+
+// STRIPPED
+bool CAnimPlayer::IsCued(AnimHandle anim_handle) {}
+
+// STRIPPED
+bool CAnimPlayer::IsPlaying(AnimHandle anim_handle) {}
+
+// STRIPPED
+bool CAnimPlayer::IsStopped(AnimHandle anim_handle) {}
+
+// STRIPPED
+bool CAnimPlayer::IsPaused(AnimHandle anim_handle) {}
+
+// STRIPPED
+bool CAnimPlayer::IsFinished(AnimHandle anim_handle) {}
+
+// STRIPPED
+bool CAnimPlayer::AreAllPlaying() {}
+
+// STRIPPED
+bool CAnimPlayer::AreAllStopped() {}
+
+// STRIPPED
+bool CAnimPlayer::AreAllPaused() {}
+
+void CAnimPlayer::UpdateTime(float time_step) {
+    if (mWorldAnimScene != nullptr) {
+        mWorldAnimScene->UpdateTime(time_step);
+    }
+    UpdateCopDoorPositions(time_step);
+}
+
+void CAnimPlayer::BeginOnlinePause() {}
+
+void CAnimPlayer::EndOnlinePause() {}
+
+bool CAnimPlayer::Init() {
+    return true;
+}
+
+// STRIPPED
+void CAnimPlayer::Purge() {}
+
 void CAnimPlayer::InitWorldAnimScene() {
     if (!DisableWorldAnimations && !AnimCfg_DisableWorldAnimations) {
         int numEntries = TheWorldAnimInstanceDirectory.GetNumInstanceEntries();
@@ -285,76 +518,42 @@ deinit:
     TheWorldAnimInstanceDirectory.DeInit(full_unload, quickrace_drag_restart);
 }
 
-bool CAnimPlayer::Init() {
-    return true;
-}
+extern float NISCopCarDoorOpenAmount[4];
 
-void CAnimPlayer::UpdateTime(float time_step) {
-    if (mWorldAnimScene != nullptr) {
-        mWorldAnimScene->UpdateTime(time_step);
+float gCopCarDoorAnim_CurrentTime[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+float gCopCarDoorAnim_AnimLength[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+float gCopCarDoorAnim_StartPos[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+float gCopCarDoorAnim_Delta[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+
+void StartCopDoorAnim(int door, float startPos, float AnimLength, float endPos) {
+    if (door < 0 || 3 < door) {
+        return;
     }
-    UpdateCopDoorPositions(time_step);
-}
-
-bool CAnimPlayer::Play(AnimHandle anim_handle) {
-    CAnimScene *scene = FindAnimScene(anim_handle);
-
-    if (!scene) {
-        return false;
+    gCopCarDoorAnim_CurrentTime[door] = 0.0f;
+    if (AnimLength > 0.0f) {
+        gCopCarDoorAnim_AnimLength[door] = AnimLength;
+        gCopCarDoorAnim_StartPos[door] = startPos;
+        gCopCarDoorAnim_Delta[door] = endPos - startPos;
+    } else {
+        gCopCarDoorAnim_AnimLength[door] = 0.0f;
     }
-    return scene->Play();
+    NISCopCarDoorOpenAmount[door] = startPos;
 }
 
-bool CAnimPlayer::Stop(AnimHandle anim_handle, bool delete_instance) {
-    CAnimScene *scene = FindAnimScene(anim_handle);
-    if (scene) {
-        bool stopped = scene->Stop();
-        if (stopped && delete_instance) {
-            DeleteAnimInstance(anim_handle);
+void UpdateCopDoorPositions(float time) {
+    for (int door = 0; door < 4; door++) {
+        float animLength = gCopCarDoorAnim_AnimLength[door];
+        if (animLength != 0.0f) {
+            gCopCarDoorAnim_CurrentTime[door] = gCopCarDoorAnim_CurrentTime[door] + time;
+            if (gCopCarDoorAnim_CurrentTime[door] <= 0.0f) {
+                NISCopCarDoorOpenAmount[door] = gCopCarDoorAnim_StartPos[door];
+            } else if (gCopCarDoorAnim_CurrentTime[door] < animLength) {
+                float ratio = gCopCarDoorAnim_CurrentTime[door] / animLength;
+                NISCopCarDoorOpenAmount[door] = gCopCarDoorAnim_StartPos[door] + ratio * gCopCarDoorAnim_Delta[door];
+            } else {
+                gCopCarDoorAnim_AnimLength[door] = 0.0f;
+                NISCopCarDoorOpenAmount[door] = gCopCarDoorAnim_StartPos[door] + gCopCarDoorAnim_Delta[door];
+            }
         }
-        return stopped;
     }
-    return false;
-}
-
-CAnimScene *CAnimPlayer::FindAnimScene(AnimHandle anim_handle) {
-    CAnimScene *anim_scene = mInstancedAnimSceneList.GetHead();
-    while (anim_scene != mInstancedAnimSceneList.EndOfList()) {
-        if (anim_handle == anim_scene->GetHandle()) {
-            return anim_scene;
-        }
-        anim_scene = anim_scene->GetNext();
-    }
-    return nullptr;
-}
-
-void CAnimPlayer::DestroyAnimScene(AnimHandle anim_handle) {
-    CAnimScene *anim_scene = FindAnimScene(anim_handle);
-
-    if (anim_scene && anim_scene->Purge()) {
-        anim_scene->Remove();
-        delete anim_scene;
-    }
-}
-
-void CAnimPlayer::DeleteAnimInstance(AnimHandle anim_handle) {
-    DestroyAnimScene(anim_handle);
-}
-
-int CAnimPlayer::CreateAndPlayAnim(uint32 anim_id, int camera_track_number, int anim_candidate_type, int anim_candidate_index) {
-    AnimHandle anim_handle = CreateAnimInstance(anim_id, camera_track_number, anim_candidate_type, anim_candidate_index);
-    if (anim_handle == 0) {
-        return 0;
-    }
-    Play(anim_handle);
-    return anim_handle;
-}
-
-int CAnimPlayer::CreateAnimScene(CAnimSceneData *anim_scene_data, int camera_track_number, int anim_candidate_type, int anim_candidate_index) {
-    CAnimScene *anim_scene = new CAnimScene(anim_scene_data, camera_track_number, anim_candidate_type, anim_candidate_index);
-    if (anim_scene->Init()) {
-        mInstancedAnimSceneList.AddTail(anim_scene);
-        return anim_scene->GetHandle();
-    }
-    return 0;
 }

--- a/src/Speed/Indep/Src/Animation/AnimPlayer.hpp
+++ b/src/Speed/Indep/Src/Animation/AnimPlayer.hpp
@@ -1,7 +1,6 @@
 #ifndef ANIMATION_ANIMPLAYER_H
 #define ANIMATION_ANIMPLAYER_H
 
-#include "Speed/Indep/Src/Interfaces/Simables/IVehicle.h"
 #ifdef EA_PRAGMA_ONCE_SUPPORTED
 #pragma once
 #endif
@@ -9,17 +8,14 @@
 #include "AnimScene.hpp"
 #include "AnimWorldScene.hpp"
 #include "Speed/Indep/Src/Misc/ResourceLoader.hpp"
+#include "Speed/Indep/Src/Interfaces/Simables/IVehicle.h"
 
 class CAnimMarker : bTNode<CAnimMarker> {
   public:
-    CAnimMarker();
+    CAnimMarker(uint32 name_hash, float time);
     virtual ~CAnimMarker();
-    uint32 GetNameHash() {
-        return mNameHash;
-    };
-    float GetTime() {
-        return mTime;
-    };
+    uint32 GetNameHash();
+    float GetTime();
 
     static uint32 mMarkerHash_StartCountdown;
 

--- a/src/Speed/Indep/Src/Animation/AnimPrint.cpp
+++ b/src/Speed/Indep/Src/Animation/AnimPrint.cpp
@@ -1,0 +1,8 @@
+// STRIPPED
+class AnimPrint {
+  public:
+    static void Matrix(char *text, struct bMatrix4 *m);
+};
+
+// STRIPPED
+void AnimPrint::Matrix(char *text, struct bMatrix4 *m) {}

--- a/src/Speed/Indep/Src/Animation/AnimScene.cpp
+++ b/src/Speed/Indep/Src/Animation/AnimScene.cpp
@@ -17,15 +17,9 @@
 
 uint32 skel_ROOT_hash = bStringHash("ROOT");
 extern int AnimCfg_DebugOutput;
-extern float NISCopCarDoorOpenAmount[4];
 
 bTList<CAnimSceneData> g_loadedAnimSceneDataList;
 CarAnimationState gCarAnimationStates[16];
-
-float gCopCarDoorAnim_CurrentTime[4] = {0.0f, 0.0f, 0.0f, 0.0f};
-float gCopCarDoorAnim_AnimLength[4] = {0.0f, 0.0f, 0.0f, 0.0f};
-float gCopCarDoorAnim_StartPos[4] = {0.0f, 0.0f, 0.0f, 0.0f};
-float gCopCarDoorAnim_Delta[4] = {0.0f, 0.0f, 0.0f, 0.0f};
 
 SlotPool *AnimPartSlotPool = nullptr;
 
@@ -54,45 +48,6 @@ void ResetCarAnimState(IVehicle *vehicle) {
     }
 }
 
-void StartCopDoorAnim(int door, float startPos, float AnimLength, float endPos) {
-    if (static_cast<unsigned int>(door) > 3) {
-        return;
-    }
-    gCopCarDoorAnim_CurrentTime[door] = 0.0f;
-    if (AnimLength > 0.0f) {
-        gCopCarDoorAnim_AnimLength[door] = AnimLength;
-        gCopCarDoorAnim_StartPos[door] = startPos;
-        gCopCarDoorAnim_Delta[door] = endPos - startPos;
-    } else {
-        gCopCarDoorAnim_AnimLength[door] = 0.0f;
-    }
-    NISCopCarDoorOpenAmount[door] = startPos;
-}
-
-void UpdateCopDoorPositions(float time) {
-    for (int door = 0; door < 4; door++) {
-        float animLength = gCopCarDoorAnim_AnimLength[door];
-        if (animLength != 0.0f) {
-            gCopCarDoorAnim_CurrentTime[door] = gCopCarDoorAnim_CurrentTime[door] + time;
-            if (gCopCarDoorAnim_CurrentTime[door] <= 0.0f) {
-                NISCopCarDoorOpenAmount[door] = gCopCarDoorAnim_StartPos[door];
-            } else if (gCopCarDoorAnim_CurrentTime[door] < animLength) {
-                float ratio = gCopCarDoorAnim_CurrentTime[door] / animLength;
-                NISCopCarDoorOpenAmount[door] = gCopCarDoorAnim_StartPos[door] + ratio * gCopCarDoorAnim_Delta[door];
-            } else {
-                gCopCarDoorAnim_AnimLength[door] = 0.0f;
-                NISCopCarDoorOpenAmount[door] = gCopCarDoorAnim_StartPos[door] + gCopCarDoorAnim_Delta[door];
-            }
-        }
-    }
-}
-
-CAnimSceneData::CAnimSceneData(bChunk *chunk)
-    : mChunk(chunk), //
-      mNisScene(nullptr) {}
-
-CAnimSceneData::~CAnimSceneData() {}
-
 CAnimSceneData *CAnimSceneData::FindAnimSceneData(uint32 anim_id) {
     CAnimSceneData *scene_data = static_cast<CAnimSceneData *>(g_loadedAnimSceneDataList.GetHead());
     while (scene_data != g_loadedAnimSceneDataList.EndOfList()) {
@@ -103,6 +58,12 @@ CAnimSceneData *CAnimSceneData::FindAnimSceneData(uint32 anim_id) {
     }
     return nullptr;
 }
+
+CAnimSceneData::CAnimSceneData(bChunk *chunk)
+    : mChunk(chunk), //
+      mNisScene(nullptr) {}
+
+CAnimSceneData::~CAnimSceneData() {}
 
 void CAnimSceneData::EndianSwapHeaderData() {
     bPlatEndianSwap(reinterpret_cast<int32 *>(mNisScene));
@@ -126,6 +87,9 @@ void CAnimSceneData::AddEntityData(void *data, int size) {
     CAnimEntityData *aed = new CAnimEntityData(*reinterpret_cast<unsigned int *>(data), data, size);
     mAnimEntityDataList.AddTail(aed);
 }
+
+// STRIPPED
+void CAnimSceneData::RemoveAllEntityData() {}
 
 CAnimSceneData *CreateAnimSceneData(bChunk *nested_chunk, bChunk *sub_chunk) {
     CAnimSceneData *anim_scene_data = new CAnimSceneData(nested_chunk);
@@ -185,6 +149,22 @@ int UnloaderAnimSceneData(bChunk *chunk) {
     return 0;
 }
 
+// STRIPPED
+CAnimMarker::CAnimMarker(uint32 name_hash, float time) {}
+
+// STRIPPED
+CAnimMarker::~CAnimMarker() {}
+
+// STRIPPED
+uint32 CAnimMarker::GetNameHash() {
+    return mNameHash;
+}
+
+// STRIPPED
+float CAnimMarker::GetTime() {
+    return mTime;
+};
+
 CAnimProperty::CAnimProperty(eAnimProperty type, bool enabled)
     : mType(type), //
       mEnabled(enabled) {}
@@ -203,8 +183,12 @@ bool CAnimProperty::IsEnabled() {
     return mEnabled != 0;
 }
 
-int CAnimScene::GetHandle() {
-    return mHandle;
+int CAnimScene::GenerateHandle() {
+    mHandleCounter++;
+    if (mHandleCounter > 0xFFFF) {
+        mHandleCounter = 1;
+    }
+    return mHandleCounter;
 }
 
 CAnimScene::CAnimScene(CAnimSceneData *anim_scene_data, int camera_track_number, int anim_candidate_type, int anim_candidate_index)
@@ -229,12 +213,8 @@ CAnimScene::CAnimScene(CAnimSceneData *anim_scene_data, int camera_track_number,
 
 CAnimScene::~CAnimScene() {}
 
-int CAnimScene::GenerateHandle() {
-    mHandleCounter++;
-    if (mHandleCounter > 0xFFFF) {
-        mHandleCounter = 1;
-    }
-    return mHandleCounter;
+int CAnimScene::GetHandle() {
+    return mHandle;
 }
 
 uint32 CAnimScene::GetAnimID() {
@@ -258,32 +238,8 @@ int CAnimScene::GetCameraTrackNumber() {
     return mCameraTrackNumber;
 }
 
-bool CAnimScene::Play() {
-    ChangePlayStatus(Playing);
-    return true;
-}
-
-bool CAnimScene::Stop() {
-    ChangePlayStatus(Stopped);
-    return true;
-}
-
-bool CAnimScene::Pause() {
-    ChangePlayStatus(Paused);
-    return true;
-}
-
-bool CAnimScene::UnPause() {
-    ChangePlayStatus(Playing);
-    return true;
-}
-
-bool CAnimScene::IsPlaying() {
-    return (uint32)mPlayStatus > (uint32)Paused;
-}
-
-bool CAnimScene::IsPaused() {
-    return mPlayStatus == Paused;
+const char *CAnimScene::GetAnimDescription() {
+    return mAnimSceneData->GetSceneInfo()->Description;
 }
 
 bool CAnimScene::SetPropertyEnabled(eAnimProperty property_id, bool enable) {
@@ -305,6 +261,11 @@ bool CAnimScene::IsPropertyEnabled(eAnimProperty property_id) {
         return false;
     }
     return anim_property->IsEnabled();
+}
+
+// STRIPPED
+bool CAnimScene::IsBoundToGame() {
+    return mIsBoundToGame;
 }
 
 bool CAnimScene::BindToGame() {
@@ -330,6 +291,96 @@ bool CAnimScene::UnBindToGame() {
     return true;
 }
 
+void CAnimScene::ChangePlayStatus(ePlayStatus new_status) {
+    ePlayStatus current_status = mPlayStatus;
+
+    switch (current_status) {
+        case Stopped:
+            if (new_status < Stopped) {
+                return;
+            }
+            if (new_status <= Paused) {
+                return;
+            }
+            if (new_status != Playing) {
+                return;
+            }
+            ResetTime();
+            BindToGame();
+            mPlayStatus = new_status;
+            return;
+        case Paused:
+            switch (new_status) {
+                case Paused:
+                    return;
+                case Stopped:
+                    mPlayStatus = new_status;
+                    UnBindToGame();
+                    ResetTime();
+                    return;
+                case Playing:
+                    break;
+                default:
+                    return;
+            }
+            break;
+        case Playing:
+            if (new_status == Paused) {
+                break;
+            }
+            if (new_status > Paused) {
+                return;
+            }
+            if (new_status != Stopped) {
+                return;
+            }
+            mPlayStatus = new_status;
+            UnBindToGame();
+            ResetTime();
+            return;
+        default:
+            return;
+    }
+    mPlayStatus = new_status;
+}
+
+// STRIPPED
+bool CAnimScene::Cue() {}
+
+bool CAnimScene::Play() {
+    ChangePlayStatus(Playing);
+    return true;
+}
+
+bool CAnimScene::Stop() {
+    ChangePlayStatus(Stopped);
+    return true;
+}
+
+bool CAnimScene::Pause() {
+    ChangePlayStatus(Paused);
+    return true;
+}
+
+bool CAnimScene::UnPause() {
+    ChangePlayStatus(Playing);
+    return true;
+}
+
+// STRIPPED
+bool CAnimScene::IsCued() {}
+
+bool CAnimScene::IsPlaying() {
+    return (uint32)mPlayStatus > (uint32)Paused;
+}
+
+// STRIPPED
+bool CAnimScene::IsStopped() {}
+
+bool CAnimScene::IsPaused() {
+    return mPlayStatus == Paused;
+}
+
 void CAnimScene::ResetTime() {
     SetTime(mTimeStart);
 }
@@ -349,6 +400,9 @@ void CAnimScene::SetTime(float time) {
     mTimeElapsed = time;
     mTimeDelta = 0.0f;
 }
+
+// STRIPPED
+void CAnimScene::GetTime(float &time) {}
 
 void CAnimScene::UpdateTime(float time_step) {
     if (!IsPlaying()) {
@@ -414,6 +468,9 @@ void CAnimScene::AddProperty(eAnimProperty property_id, bool enabled) {
     }
 }
 
+// STRIPPED
+void CAnimScene::RemoveProperties() {}
+
 CAnimProperty *CAnimScene::FindProperty(eAnimProperty property_id) {
     CAnimProperty *anim_property = static_cast<CAnimProperty *>(mAnimPropertyList.GetHead());
 
@@ -424,59 +481,6 @@ CAnimProperty *CAnimScene::FindProperty(eAnimProperty property_id) {
         anim_property = anim_property->GetNext();
     }
     return nullptr;
-}
-
-void CAnimScene::ChangePlayStatus(ePlayStatus new_status) {
-    ePlayStatus current_status = mPlayStatus;
-
-    switch (current_status) {
-        case Stopped:
-            if (new_status < Stopped) {
-                return;
-            }
-            if (new_status <= Paused) {
-                return;
-            }
-            if (new_status != Playing) {
-                return;
-            }
-            ResetTime();
-            BindToGame();
-            mPlayStatus = new_status;
-            return;
-        case Paused:
-            switch (new_status) {
-                case Paused:
-                    return;
-                case Stopped:
-                    mPlayStatus = new_status;
-                    UnBindToGame();
-                    ResetTime();
-                    return;
-                case Playing:
-                    break;
-                default:
-                    return;
-            }
-            break;
-        case Playing:
-            if (new_status == Paused) {
-                break;
-            }
-            if (new_status > Paused) {
-                return;
-            }
-            if (new_status != Stopped) {
-                return;
-            }
-            mPlayStatus = new_status;
-            UnBindToGame();
-            ResetTime();
-            return;
-        default:
-            return;
-    }
-    mPlayStatus = new_status;
 }
 
 bool CAnimScene::Init() {
@@ -537,7 +541,13 @@ bool CAnimScene::Purge() {
     return true;
 }
 
+// STRIPPED
+void CAnimScene::ForceCarToAnimCarPosition(Car *car, int car_num) {}
+
 void CAnimScene::ForcePlayerToAnimCarPosition(int player_num, int car_num) {}
+
+// STRIPPED
+// int GetPositionInRace(RacingCar *pRacingCar) {}
 
 void CAnimScene::ClearCarAnimStates() {
     for (int i = 0; i <= 15; i++) {
@@ -588,6 +598,9 @@ void CAnimScene::InitCarAnimStatesFromNIS() {
         }
     }
 }
+
+// STRIPPED
+int CAnimScene::FindCurrentWorldCarIndex(Car *car) {}
 
 void CAnimScene::SetCarAnimationPositions() {
     ClearCarAnimStates();
@@ -843,32 +856,4 @@ void RenderAnimSceneEffects(eView *view, int exc_flag) {
             scene->RenderEffects(view, exc_flag & 0x800);
         }
     }
-}
-
-float CAnimScene::GetTimeElapsed() {
-    return mTimeElapsed;
-}
-
-float CAnimScene::GetTimeStart() {
-    return mTimeStart;
-}
-
-float CAnimScene::GetTimeTotalLength() {
-    return mTimeTotalLength;
-}
-
-bool CAnimScene::IsControllingCamera() {
-    return mControllingCamera;
-}
-
-bool CAnimScene::IsCameraFixingElevation() {
-    return true;
-}
-
-const bMatrix4 &CAnimScene::GetSceneRotationMatrix() {
-    return mSceneRotationMatrix;
-}
-
-const bMatrix4 &CAnimScene::GetSceneTransformMatrix() {
-    return mSceneTransformMatrix;
 }

--- a/src/Speed/Indep/Src/Animation/AnimScene.hpp
+++ b/src/Speed/Indep/Src/Animation/AnimScene.hpp
@@ -184,13 +184,27 @@ class CAnimScene : public ICEScene, public bTNode<CAnimScene> {
     bool Pause() override;
     bool UnPause() override;
     bool IsPlaying() override;
-    float GetTimeElapsed() override;
-    float GetTimeStart() override;
-    float GetTimeTotalLength() override;
-    bool IsControllingCamera() override;
-    bool IsCameraFixingElevation() override;
-    const bMatrix4 &GetSceneRotationMatrix() override;
-    const bMatrix4 &GetSceneTransformMatrix() override;
+    float GetTimeElapsed() override {
+        return mTimeElapsed;
+    };
+    float GetTimeStart() override {
+        return mTimeStart;
+    };
+    float GetTimeTotalLength() override {
+        return mTimeTotalLength;
+    };
+    bool IsControllingCamera() override {
+        return mControllingCamera;
+    };
+    bool IsCameraFixingElevation() override {
+        return true;
+    };
+    const bMatrix4 &GetSceneRotationMatrix() override {
+        return mSceneRotationMatrix;
+    };
+    const bMatrix4 &GetSceneTransformMatrix() override {
+        return mSceneTransformMatrix;
+    };
 
   private:
     static int mHandleCounter;

--- a/src/Speed/Indep/Src/Animation/AnimSkeleton.cpp
+++ b/src/Speed/Indep/Src/Animation/AnimSkeleton.cpp
@@ -37,6 +37,11 @@ void CloseAnimSkelSlotPool() {
 #ifdef MILESTONE_OPT
 static int NumAnimSkels = 0;
 static int MaxNumAnimSkels = 0;
+
+// STRIPPED
+int GetMaxNumAnimSkels() {
+    return MaxNumAnimSkels;
+}
 #endif
 
 void *CAnimSkeleton::operator new(size_t size, const char *debug_name) {
@@ -108,6 +113,9 @@ void CAnimSkeleton::DynamicLoadResolve() {
         }
     }
 }
+
+// STRIPPED
+void CAnimSkeleton::PrintfSkeletonBoneData() {}
 
 CAnimSkeleton *GetSkeletonFromList(uint32 namehash) {
     CAnimSkeleton *skel_list = g_loadedSkeletonList.GetHead();

--- a/src/Speed/Indep/Src/Animation/AnimWorldScene.cpp
+++ b/src/Speed/Indep/Src/Animation/AnimWorldScene.cpp
@@ -6,9 +6,8 @@
 #include "Speed/Indep/bWare/Inc/bWare.hpp"
 
 extern int AnimCfg_DisableWorldAnimations;
-extern bool DisableWorldAnimations;
-extern bool PrintWorldAnimationStuff;
-extern RaceParameters TheRaceParameters;
+bool PrintWorldAnimationStuff = false;
+RaceParameters TheRaceParameters;
 
 CAnimWorldScene::CAnimWorldScene() : mHandle(0) {
     mHandle = bStringHash("WorldAnimations");
@@ -19,6 +18,9 @@ void CAnimWorldScene::ClearAllAnimations() {
         delete mInstancedAnimTreeList.RemoveTail();
     }
 }
+
+// STRIPPED
+CWorldAnimEntityTree *CAnimWorldScene::GetAnimTree(int instance_id) {}
 
 CWorldAnimEntityTree *CAnimWorldScene::GetAnimTreeFromHash(uint32 instanceHash) {
     for (CWorldAnimEntityTree *tree = mInstancedAnimTreeList.GetHead(); tree != mInstancedAnimTreeList.EndOfList(); tree = tree->GetNext()) {
@@ -32,6 +34,20 @@ CWorldAnimEntityTree *CAnimWorldScene::GetAnimTreeFromHash(uint32 instanceHash) 
 CAnimWorldScene::~CAnimWorldScene() {
     ClearAllAnimations();
 }
+
+void CAnimWorldScene::UpdateTime(float time_step) {
+    if (!AnimCfg_DisableWorldAnimations && !DisableWorldAnimations) {
+        for (CWorldAnimEntityTree *tree = mInstancedAnimTreeList.GetHead(); tree != mInstancedAnimTreeList.EndOfList(); tree = tree->GetNext()) {
+            for (bPNode *node = tree->instantiated_world_anim_entities.GetHead(); node != tree->instantiated_world_anim_entities.EndOfList();
+                 node = node->GetNext()) {
+                reinterpret_cast<IAnimEntity *>(node->GetpObject())->UpdateTimeStep(time_step);
+            }
+        }
+    }
+}
+
+// STRIPPED
+bMatrix4 *CAnimWorldScene::GetAnimLocation(int SceneID) {}
 
 CWorldAnimEntityTree *CAnimWorldScene::InstantiateAnimTree(WorldAnimInstance *instance) {
     if (AnimCfg_DisableWorldAnimations || DisableWorldAnimations) {
@@ -159,31 +175,22 @@ CWorldAnimEntityTree *CAnimWorldScene::InstantiateAnimTree(WorldAnimInstance *in
     return new_tree;
 }
 
-void CAnimWorldScene::UpdateTime(float time_step) {
-    if (!AnimCfg_DisableWorldAnimations && !DisableWorldAnimations) {
-        for (CWorldAnimEntityTree *tree = mInstancedAnimTreeList.GetHead(); tree != mInstancedAnimTreeList.EndOfList(); tree = tree->GetNext()) {
-            for (bPNode *node = tree->instantiated_world_anim_entities.GetHead(); node != tree->instantiated_world_anim_entities.EndOfList();
-                 node = node->GetNext()) {
-                reinterpret_cast<IAnimEntity *>(node->GetpObject())->UpdateTimeStep(time_step);
-            }
-        }
-    }
-}
-
 void ControlWorldAnim(unsigned int fAnimTreeNameHash, float fTimeSet, bool fAnimPause, bool fAnimHide) {
     if (TheAnimPlayer.GetWorldAnimScene()) {
-        CWorldAnimEntityTree *tree = TheAnimPlayer.GetWorldAnimScene()->GetAnimTreeFromHash(fAnimTreeNameHash);
-        if (tree) {
-            if (fTimeSet >= 0.0f) {
-                tree->SetTime(fTimeSet);
-            }
-            if (fAnimHide) {
-                tree->Stop();
-            } else if (fAnimPause) {
-                tree->Pause();
-            } else {
-                tree->Play();
-            }
+        CWorldAnimEntityTree *animTree = TheAnimPlayer.GetWorldAnimScene()->GetAnimTreeFromHash(fAnimTreeNameHash);
+        if (!animTree) {
+            return;
+        }
+
+        if (fTimeSet >= 0.0f) {
+            animTree->SetTime(fTimeSet);
+        }
+        if (fAnimHide) {
+            animTree->Stop();
+        } else if (fAnimPause) {
+            animTree->Pause();
+        } else {
+            animTree->Play();
         }
     }
 }
@@ -239,3 +246,6 @@ void CloseAllGarageDoors() {
     ControlWorldAnim(bStringHash("EN_Chopshop_12"), 0.0f, true, false);
     ControlWorldAnim(bStringHash("EN_Chopshop_55"), 0.0f, true, false);
 }
+
+// STRIPPED
+void CAnimWorldScene::DoSnapshot(ReplaySnapshot *snapshot) {}

--- a/src/Speed/Indep/Src/Animation/WorldAnimCtrl.cpp
+++ b/src/Speed/Indep/Src/Animation/WorldAnimCtrl.cpp
@@ -14,6 +14,11 @@ struct WorldAnimInstanceDirectoryLayout {
     SlotPool *WorldAnimCtrlSlotPool;
 };
 
+// STRIPPED
+int GetMaxNumWorldAnimCtrls() {
+    return MaxNumWorldAnimCtrls;
+}
+
 void *CWorldAnimCtrl::operator new(size_t size, const char *debug_name) {
     NumWorldAnimCtrls++;
     if (NumWorldAnimCtrls > MaxNumWorldAnimCtrls) {
@@ -35,52 +40,12 @@ CWorldAnimCtrl::~CWorldAnimCtrl() {
     Purge();
 }
 
+// STRIPPED
+void CWorldAnimCtrl::Init() {}
+
 void CWorldAnimCtrl::Purge() {
     Cleanup();
     Clear();
-}
-
-void CWorldAnimCtrl::Play() {
-    PlayState = eACPS_PLAYING;
-}
-
-void CWorldAnimCtrl::Pause() {
-    PlayState = eACPS_PAUSED;
-}
-
-void CWorldAnimCtrl::Stop() {
-    m_evalTime = 0.0f;
-    PlayState = eACPS_STOPPED;
-}
-
-void CWorldAnimCtrl::SetLoopRange(uint32 loop_range_start, uint32 loop_range_end) {
-    m_loop_range_end = loop_range_end;
-    m_loop_range_start = loop_range_start;
-    m_flags |= 0x40;
-}
-
-float CWorldAnimCtrl::GetLoopRangeScaledStart() {
-    return static_cast<float>(m_loop_range_start) * GetEffectiveTimeScale();
-}
-
-float CWorldAnimCtrl::GetLoopRangeScaledEnd() {
-    return static_cast<float>(m_loop_range_end) * GetEffectiveTimeScale();
-}
-
-void CWorldAnimCtrl::ApplySpeedModifier(float speed_modifier) {
-    m_f_speed_modifier = speed_modifier;
-}
-
-void CWorldAnimCtrl::JumpToEndForTrigger() {
-    m_evalTime = m_animLength;
-    PlayState = eACPS_PAUSED;
-    PlayDirection = eACPD_REV;
-}
-
-void CWorldAnimCtrl::JumpToBeginForTrigger() {
-    PlayState = eACPS_PAUSED;
-    m_evalTime = 0.0f;
-    PlayDirection = eACPD_FWD;
 }
 
 void CWorldAnimCtrl::Clear() {
@@ -106,16 +71,6 @@ void CWorldAnimCtrl::Clear() {
     MasterDelayElapsed = 0.0f;
 }
 
-void CWorldAnimCtrl::Cleanup() {
-    m_animPart.Purge();
-    for (int i = 0; i < 4; i++) {
-        if (m_pFnAnim[i]) {
-            EAGL4Anim::MemoryPoolManager::DeleteFnAnim(m_pFnAnim[i]);
-            m_pFnAnim[i] = nullptr;
-        }
-    }
-}
-
 void CWorldAnimCtrl::SetEvalTime(float time) {
     m_evalTime = time;
     PlayDirection = eACPD_FWD;
@@ -134,9 +89,32 @@ void CWorldAnimCtrl::SetEvalTime(float time) {
     }
 }
 
-float CWorldAnimCtrl::GetAnimLengthInSeconds() {
-    return m_animLength / 30 / GetEffectiveTimeScale();
+void CWorldAnimCtrl::Cleanup() {
+    m_animPart.Purge();
+    for (int i = 0; i < 4; i++) {
+        if (m_pFnAnim[i]) {
+            EAGL4Anim::MemoryPoolManager::DeleteFnAnim(m_pFnAnim[i]);
+            m_pFnAnim[i] = nullptr;
+        }
+    }
 }
+
+void CWorldAnimCtrl::SetLoopRange(uint32 loop_range_start, uint32 loop_range_end) {
+    m_loop_range_end = loop_range_end;
+    m_loop_range_start = loop_range_start;
+    m_flags |= 0x40;
+}
+
+float CWorldAnimCtrl::GetLoopRangeScaledStart() {
+    return m_loop_range_start * GetEffectiveTimeScale();
+}
+
+float CWorldAnimCtrl::GetLoopRangeScaledEnd() {
+    return m_loop_range_end * GetEffectiveTimeScale();
+}
+
+// STRIPPED
+int CWorldAnimCtrl::CreateFnAnim(EAGL4Anim::AnimMemoryMap *memMap, int dof) {}
 
 int CWorldAnimCtrl::CreateFnAnimFromBank(EAGL4Anim::AnimBank *animBank, int animIndex, int dof) {
     m_pFnAnim[dof] = animBank->NewFnAnim(animIndex);
@@ -148,6 +126,58 @@ int CWorldAnimCtrl::CreateFnAnimFromBank(EAGL4Anim::AnimBank *animBank, int anim
     }
     return 0;
 }
+
+int CWorldAnimCtrl::CreateFnAnimFromNamehash(uint32 namehash, int dof) {
+    EAGL4Anim::AnimBank *animBank = nullptr;
+    int item_index = 0;
+    if (GetAnimFromBankByNamehash(namehash, &animBank, &item_index)) {
+        CreateFnAnimFromBank(animBank, item_index, dof);
+        m_isAllocated = 1;
+        return 1;
+    }
+    return 0;
+}
+
+void CWorldAnimCtrl::Play() {
+    PlayState = eACPS_PLAYING;
+}
+
+void CWorldAnimCtrl::Stop() {
+    m_evalTime = 0.0f;
+    PlayState = eACPS_STOPPED;
+}
+
+void CWorldAnimCtrl::Pause() {
+    PlayState = eACPS_PAUSED;
+}
+
+// STRIPPED
+void CWorldAnimCtrl::AdvanceAnim() {}
+
+// STRIPPED
+void CWorldAnimCtrl::GetFlagString(uint32 flag, char *buffer, int size) {}
+
+void CWorldAnimCtrl::JumpToEndForTrigger() {
+    m_evalTime = m_animLength;
+    PlayState = eACPS_PAUSED;
+    PlayDirection = eACPD_REV;
+}
+
+void CWorldAnimCtrl::JumpToBeginForTrigger() {
+    PlayState = eACPS_PAUSED;
+    m_evalTime = 0.0f;
+    PlayDirection = eACPD_FWD;
+}
+
+void CWorldAnimCtrl::ApplySpeedModifier(float speed_modifier) {
+    m_f_speed_modifier = speed_modifier;
+}
+
+// STRIPPED
+bool CWorldAnimCtrl::IsCurrentlyDelayingBeforeWorldStart() {}
+
+// STRIPPED
+bool CWorldAnimCtrl::IsCurrentlyDelayingBetweenLoops() {}
 
 // UNSOLVED
 int CWorldAnimCtrl::AdvanceAnimTime(float timestep) {
@@ -261,6 +291,23 @@ int CWorldAnimCtrl::AdvanceAnimTime(float timestep) {
     return result_anim_is_done;
 }
 
+// STRIPPED
+float CWorldAnimCtrl::GetEvalTimeInSeconds() {
+    return m_evalTime / 30 / GetEffectiveTimeScale();
+}
+
+// STRIPPED
+void CWorldAnimCtrl::SetEvalTimeInSeconds(float seconds) {
+    m_evalTime = seconds * 30 * GetEffectiveTimeScale();
+}
+
+float CWorldAnimCtrl::GetAnimLengthInSeconds() {
+    return m_animLength / 30 / GetEffectiveTimeScale();
+}
+
+// STRIPPED
+void CWorldAnimCtrl::UpdateAnim() {}
+
 int CWorldAnimCtrl::UpdateAnimPose() {
     EAGL4Anim::Skeleton *world_skel = m_animPart.GetSkeleton()->GetEAGLSkeleton();
     float *sqtBuffer = m_animPart.GetSQTptr();
@@ -293,13 +340,8 @@ int CWorldAnimCtrl::UpdateAnimPose() {
     return 0;
 }
 
-int CWorldAnimCtrl::CreateFnAnimFromNamehash(uint32 namehash, int dof) {
-    EAGL4Anim::AnimBank *animBank = nullptr;
-    int item_index = 0;
-    if (GetAnimFromBankByNamehash(namehash, &animBank, &item_index)) {
-        CreateFnAnimFromBank(animBank, item_index, dof);
-        m_isAllocated = 1;
-        return 1;
-    }
-    return 0;
-}
+// STRIPPED
+void CWorldAnimCtrl::PredictPositionAtTime(float time, bMatrix4 *world_position) {}
+
+// STRIPPED
+void CWorldAnimCtrl::DoSnapshot(ReplaySnapshot *snapshot) {}

--- a/src/Speed/Indep/Src/Animation/WorldAnimInstanceDirectory.cpp
+++ b/src/Speed/Indep/Src/Animation/WorldAnimInstanceDirectory.cpp
@@ -9,11 +9,12 @@
 extern int AnimCfg_DisableWorldAnimations;
 
 WorldAnimInstanceDirectory TheWorldAnimInstanceDirectory; // size: 0x50, address: 0x80457718
-bool PrintWorldAnimationStuff = false;                    // size: 0x1, address: 0x8041589C
-bool DisableWorldAnimations = false;                      // size: 0x1, address: 0x804156F0
 
 static int NumWorldAnimInstanceEntries = 0; // size: 0x4, address: 0x80415898
 static int MaxWorldAnimInstances = 0;       // size: 0x4, address: 0x80415894
+
+// STRIPPED
+int GetMaxSlotPoolSizes_ForInstances() {}
 
 void *WorldAnimInstanceEntry::operator new(size_t size, const char *debug_name) {
     NumWorldAnimInstanceEntries++;
@@ -27,6 +28,9 @@ void WorldAnimInstanceEntry::operator delete(void *ptr) {
     NumWorldAnimInstanceEntries--;
     bFree(TheWorldAnimInstanceDirectory.GetWorldAnimInstanceEntrySlotPool(), ptr);
 }
+
+// STRIPPED
+void DumpWorldAnimMemUsage() {}
 
 WorldAnimInstanceDirectory::WorldAnimInstanceDirectory() {
     mInitialized = false;
@@ -53,6 +57,9 @@ WorldAnimEntityTreeInfo *WorldAnimInstanceDirectory::GetAnimTreeInfo(uint32 anim
     return nullptr;
 }
 
+// STRIPPED
+bool GetAnimPosition(int instance_id, uint32 entity_hash, bVector3 *pos_out, bool *is_between_loops) {}
+
 void WorldAnimInstanceDirectory::AddLoadedAnimTreeInfo(WorldAnimEntityTreeInfo *anim_tree_info) {
     if (AnimCfg_DisableWorldAnimations || DisableWorldAnimations) {
         return;
@@ -62,6 +69,9 @@ void WorldAnimInstanceDirectory::AddLoadedAnimTreeInfo(WorldAnimEntityTreeInfo *
     }
     mLoadedWorldAnimTrees.AddTail(anim_tree_info);
 }
+
+// STRIPPED
+WorldAnimEntityInfo *WorldAnimInstanceDirectory::GetAnimEntityInfo(uint32 anim_entity_name_hash) {}
 
 void WorldAnimInstanceDirectory::AddLoadedAnimEntityInfo(WorldAnimEntityInfo *anim_entity_info) {
     if (AnimCfg_DisableWorldAnimations || DisableWorldAnimations) {
@@ -224,6 +234,10 @@ void WorldAnimInstanceDirectory::Init() {
 #endif
 }
 
+WorldAnimInstanceDirectory::~WorldAnimInstanceDirectory() {
+    DeInit(true, false);
+}
+
 void WorldAnimInstanceDirectory::DeInit(bool full_unload, bool quickrace_drag_restart) {
     if (AnimCfg_DisableWorldAnimations || DisableWorldAnimations || !full_unload) {
         return;
@@ -296,3 +310,9 @@ int UnloaderWorldAnimInstanceEntry(bChunk *chunk) {
 
     return 1;
 }
+
+// STRIPPED
+IControlScenario *WorldAnimInstanceDirectory::GetControlScenario(eControlScenarioType cst) {}
+
+// STRIPPED
+CWorldAnimEntityTree *WorldAnimInstanceDirectory::GetAnimationAssociatedWithTriggerZone(uint32 trigger_zone_hash) {}


### PR DESCRIPTION
fixes zAnim function ordering to match dwarf

also 
- adds missing definitions of stripped functions in their correct places
- fixes some `#includes` above the `#pragma`
- fixes a couple small matches
- reorders some globals to match dwarf. 