### PR TITLE
zPhysics

### DIFF
--- a/config/GOWE69/config.yml
+++ b/config/GOWE69/config.yml
@@ -33,6 +33,13 @@ block_relocations:
 # literal, but it collides with the address of a real function.
 - target: .text:0x8003b900
 
+# UCrc32("smackable")'s hash 0x804C146E collides with snddrv+0x10AE, so the
+# delinker relocates the lis/ori pair that materialises it.
+- source: .text:0x8021f0b0
+  end: .text:0x8021f0c4
+- source: .text:0x8021fe78
+  end: .text:0x8021fe84
+
 - target: .text:0x80135100
 - target: .text:0x80135000
 - target: .text:0x80134001

--- a/config/GOWE69/config.yml
+++ b/config/GOWE69/config.yml
@@ -29,6 +29,10 @@ block_relocations:
 # - source: .text:0x800F9368
 #   end: .text:0x800F9370
 
+# The bChunk ID 0x8003B900 that LoaderBounds/UnloaderBounds compare against is a
+# literal, but it collides with the address of a real function.
+- target: .text:0x8003b900
+
 - target: .text:0x80135100
 - target: .text:0x80135000
 - target: .text:0x80134001

--- a/src/Speed/Indep/Libs/Support/Utility/UBitArray.h
+++ b/src/Speed/Indep/Libs/Support/Utility/UBitArray.h
@@ -21,7 +21,7 @@ template <typename T, int N> struct BitArray {
     }
 
     bool operator!=(const BitArray &other) const {
-        for (int i = 0; i < NUM_ELEMENTS(this->Words); i++) {
+        for (unsigned int i = 0; i < NUM_ELEMENTS(this->Words); i++) {
             if (Words[i] != other.Words[i]) {
                 return true;
             }
@@ -51,7 +51,7 @@ template <typename T, int N> struct BitArray {
     }
 
     void Clear() {
-        for (int i = 0; i < NUM_ELEMENTS(this->Words); i++) {
+        for (unsigned int i = 0; i < NUM_ELEMENTS(this->Words); i++) {
             Words[i] = 0;
         }
     }

--- a/src/Speed/Indep/Libs/Support/Utility/UBitArray.h
+++ b/src/Speed/Indep/Libs/Support/Utility/UBitArray.h
@@ -33,6 +33,15 @@ template <typename T, int N> struct BitArray {
         return (Words[index / kBitsPerWord] >> (index % kBitsPerWord)) & 1;
     }
 
+    bool Test() const {
+        for (int i = 0; i < NUM_ELEMENTS(this->Words); i++) {
+            if (Words[i]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     void Set(unsigned int index) {
         Words[index / kBitsPerWord] |= static_cast<T>(1) << (index % kBitsPerWord);
     }

--- a/src/Speed/Indep/Libs/Support/Utility/UBitArray.h
+++ b/src/Speed/Indep/Libs/Support/Utility/UBitArray.h
@@ -13,6 +13,12 @@ template <typename T, int N> struct BitArray {
         }
     }
 
+    BitArray(const BitArray &src) {
+        for (unsigned int i = 0; i < NUM_ELEMENTS(this->Words); i++) {
+            Words[i] = src.Words[i];
+        }
+    }
+
     const BitArray &operator=(const BitArray &src) {
         for (unsigned int i = 0; i < NUM_ELEMENTS(this->Words); i++) {
             Words[i] = src.Words[i];

--- a/src/Speed/Indep/Libs/Support/Utility/UCOM.h
+++ b/src/Speed/Indep/Libs/Support/Utility/UCOM.h
@@ -177,16 +177,17 @@ template <typename T, typename U, typename V> class Factory {
     ~Factory() {}
 
     static _PRODUCT CreateInstance(_PRODUCT_SIGNATURE sig, _BUILD_PARAMETERS params);
-    // TODO
-    //  {
-    //     for (const Prototype *f = Prototype::GetHead(); f != nullptr; f = f->GetNext()) {
-    //         if (f->mSignature == sig) {
-    //             return f->mConstructor(params);
-    //         }
-    //     }
-    //     return nullptr;
-    // }
 };
+
+template <typename T, typename U, typename V>
+U *Factory<T, U, V>::CreateInstance(V sig, T params) {
+    for (const Prototype *f = Prototype::GetHead(); f != nullptr; f = f->GetNext()) {
+        if (f->mSignature == sig) {
+            return f->mConstructor(params);
+        }
+    }
+    return nullptr;
+}
 
 #define IMPLEMENT_FACTORY(_Factory_) template <> _Factory_::Prototype *_Factory_::Prototype::mHead = NULL;
 

--- a/src/Speed/Indep/Libs/Support/Utility/UCollections.h
+++ b/src/Speed/Indep/Libs/Support/Utility/UCollections.h
@@ -83,7 +83,14 @@ template <typename Handle, typename T, int Size> class Instanceable {
     }
 
   private:
-    class _List : public FixedVector<_KeyedNode, Size, 16> {};
+    class _List : public _Storage<_KeyedNode, Size> {
+      public:
+        _List() {
+            this->reserve(Size);
+        }
+
+        ~_List() override {}
+    };
 
     static uintptr_t _mHNext;
     static _List _mList;

--- a/src/Speed/Indep/Libs/Support/Utility/UCollections.h
+++ b/src/Speed/Indep/Libs/Support/Utility/UCollections.h
@@ -118,7 +118,10 @@ template <typename T, int Size> class GarbageNode {
             int refcount; // offset 0x4, size 0x4
         };
 
-        Collector() {}
+        Collector() {
+            _mDirty.reserve(Size);
+            _mClean.reserve(Size);
+        }
 
         // TODO match dwarf
         void Collect() {

--- a/src/Speed/Indep/Libs/Support/Utility/UCollections.h
+++ b/src/Speed/Indep/Libs/Support/Utility/UCollections.h
@@ -5,6 +5,7 @@
 #pragma once
 #endif
 
+#include "Speed/Indep/Libs/Support/Utility/UCrc.h"
 #include "Speed/Indep/Libs/Support/Utility/UTLVector.h"
 #include "UStandard.h"
 
@@ -235,11 +236,35 @@ template <typename T, int Size> class GarbageNode {
 
 template <typename T, typename Tag> class Container {
   public:
-    class Elements {
+    class Elements : public UTL::Std::list<T *, Tag> {
       public:
-        Elements();
-        ~Elements();
+        Elements() {}
+        ~Elements() {}
     };
+
+    void AddElement(T *e) {
+        _mElements.push_back(e);
+    }
+
+    template <typename P> T *BuildElement(UCrc32 sig, const P &parms) {
+        T *e = T::CreateInstance(sig, parms);
+        if (e != nullptr) {
+            _mElements.push_back(e);
+        }
+        return e;
+    }
+
+    bool DestroyElement(T &el) {
+        typename Elements::iterator last = _mElements.end();
+        for (typename Elements::iterator first = _mElements.begin(); first != last; first++) {
+            if (*first == &el) {
+                _mElements.erase(first);
+                T::Destroy(&el);
+                return true;
+            }
+        }
+        return false;
+    }
 
   private:
     Elements _mElements;

--- a/src/Speed/Indep/Libs/Support/Utility/UCollections.h
+++ b/src/Speed/Indep/Libs/Support/Utility/UCollections.h
@@ -254,6 +254,17 @@ template <typename T, typename Tag> class Container {
         return e;
     }
 
+    ~Container() {
+        typename Elements::iterator last = _mElements.end();
+        for (typename Elements::iterator first = _mElements.begin(); first != last; ++first) {
+            T *e = *first;
+            if (e != nullptr) {
+                T::Destroy(e);
+            }
+        }
+        _mElements.clear();
+    }
+
     bool DestroyElement(T &el) {
         typename Elements::iterator last = _mElements.end();
         for (typename Elements::iterator first = _mElements.begin(); first != last; first++) {

--- a/src/Speed/Indep/Libs/Support/Utility/UCrc.h
+++ b/src/Speed/Indep/Libs/Support/Utility/UCrc.h
@@ -7,22 +7,26 @@
 
 #include "Speed/Indep/Src/Misc/attribuserinclude.h"
 #include "Speed/Indep/Libs/Support/Miscellaneous/StringHash.h"
+#include "Speed/Indep/bWare/Inc/Strings.hpp"
 
 class bHash32 {
     unsigned int mCRC;
 
   public:
     bHash32() {}
-    bHash32(const char *name) {}
-    bHash32(const bHash32 &from) {}
-    bHash32(unsigned int crc) {}
+    bHash32(const bHash32 &from) : mCRC(from.mCRC) {}
+    bHash32(const char *name) : mCRC(bStringHashUpper(name)) {}
+    bHash32(unsigned int crc) : mCRC(crc) {}
 
     const bHash32 &operator=(const bHash32 &from) {
         this->mCRC = from.mCRC;
         return *this;
     }
 
-    bHash32 &operator=(const char *from) {}
+    bHash32 &operator=(const char *from) {
+        this->mCRC = bStringHashUpper(from);
+        return *this;
+    }
 
     unsigned int GetValue() const {
         return mCRC;

--- a/src/Speed/Indep/Libs/Support/Utility/UListable.h
+++ b/src/Speed/Indep/Libs/Support/Utility/UListable.h
@@ -56,6 +56,7 @@ template <typename T, int U> class Listable {
 
     typedef void (*ForEachFunc)(pointer);
     typedef bool (*ComparisonFunc)(pointer, pointer);
+    typedef bool (*ConstComparisonFunc)(const T *, const T *);
 
   protected:
     Listable() {
@@ -83,6 +84,10 @@ template <typename T, int U> class Listable {
     }
 
     static void Sort(ComparisonFunc pred) {
+        std::sort(_mTable.begin(), _mTable.end(), pred);
+    }
+
+    static void Sort(ConstComparisonFunc pred) {
         std::sort(_mTable.begin(), _mTable.end(), pred);
     }
 

--- a/src/Speed/Indep/Libs/Support/Utility/UMath.h
+++ b/src/Speed/Indep/Libs/Support/Utility/UMath.h
@@ -105,6 +105,10 @@ inline void Clear(Vector3 &r) {
 #endif
 }
 
+inline void Copy(const Vector3 &a, Vector3 &r) {
+    r = a;
+}
+
 inline void Copy(const Matrix4 &a, Matrix4 &r) {
     VU0_MATRIX4Copy(a, r);
 }
@@ -131,6 +135,10 @@ inline void Transpose(const Vector4 &q, Vector4 &r) {
 
 inline const Vector3 &ExtractAxis(const Matrix4 &m, unsigned int row) {
     return *reinterpret_cast<const Vector3 *>(&m[row]);
+}
+
+inline Vector3 &ExtractAxis(Matrix4 &m, unsigned int row) {
+    return *reinterpret_cast<Vector3 *>(&m[row]);
 }
 
 inline void ExtractXAxis(const Vector4 &q, Vector3 &r) {

--- a/src/Speed/Indep/Libs/Support/Utility/UMath.h
+++ b/src/Speed/Indep/Libs/Support/Utility/UMath.h
@@ -206,6 +206,10 @@ inline void Unitxyz(const Vector4 &a, Vector4 &r) {
     VU0_v4unitxyz(a, r);
 }
 
+inline void Unitxyz(Vector4 &a) {
+    VU0_v4unitxyz(a, a);
+}
+
 inline void MultXRot(const UMath::Matrix4 &m, float a, UMath::Matrix4 &r) {
     MATRIX4_multxrot(&m, a, &r);
 }
@@ -284,6 +288,14 @@ inline void ScaleAddxyz(const Vector4 &a, const float s, const Vector4 &b, Vecto
 
 inline void AddScale(const Vector3 &a, const Vector3 &b, const float s, Vector3 &r) {
     VU0_v3addscale(a, b, s, r);
+}
+
+inline void AddScale(const Vector4 &a, const Vector4 &b, const float s, Vector4 &r) {
+    VU0_v4addscale(a, b, s, r);
+}
+
+inline void AddScalexyz(const Vector4 &a, const Vector4 &b, const float s, Vector4 &r) {
+    VU0_v4addscalexyz(a, b, s, r);
 }
 
 inline void Sub(const Vector3 &a, const Vector3 &b, Vector3 &r) {

--- a/src/Speed/Indep/Libs/Support/Utility/UMath.h
+++ b/src/Speed/Indep/Libs/Support/Utility/UMath.h
@@ -435,7 +435,7 @@ inline float ASina(const float x) {
     return VU0_ASin(x);
 }
 
-inline float Atan2d(float o, float a) {
+inline float Atan2d(const float o, const float a) {
     return ANGLE2DEG(VU0_Atan2(o, a));
 }
 

--- a/src/Speed/Indep/Libs/Support/Utility/UQueue.h
+++ b/src/Speed/Indep/Libs/Support/Utility/UQueue.h
@@ -17,7 +17,7 @@ template <typename T, int U> class UCircularQueue {
         this->Size = 0;
         this->Head = -1;
         this->Tail = 0;
-        this->MaxSize = 50;
+        this->MaxSize = U;
     }
 
     void enqueue(const T &insert) {

--- a/src/Speed/Indep/Libs/Support/Utility/UQueue.h
+++ b/src/Speed/Indep/Libs/Support/Utility/UQueue.h
@@ -50,9 +50,13 @@ template <typename T, int U> class UCircularQueue {
         return this->Elements[this->Head];
     }
 
-    // T &operator[](int i) {
-    // int newindex;
-    // }
+    T &operator[](int i) {
+        int newindex = this->Head - i;
+        if (newindex < 0) {
+            newindex = newindex + this->MaxSize;
+        }
+        return this->Elements[newindex];
+    }
 
     void reset() {
         this->Size = 0;

--- a/src/Speed/Indep/Libs/Support/Utility/UVectorMath.h
+++ b/src/Speed/Indep/Libs/Support/Utility/UVectorMath.h
@@ -275,6 +275,8 @@ void VU0_v3scale(const UMath::Vector3 &a, const float scaleby, UMath::Vector3 &r
 void VU0_v3scale(const UMath::Vector3 &a, const UMath::Vector3 &b, UMath::Vector3 &result);
 void VU0_v3scaleadd(const UMath::Vector3 &a, const float scaleby, const UMath::Vector3 &b, UMath::Vector3 &result);
 void VU0_v3addscale(const UMath::Vector3 &a, const UMath::Vector3 &b, const float scaleby, UMath::Vector3 &result);
+void VU0_v4addscale(const UMath::Vector4 &a, const UMath::Vector4 &b, const float scaleby, UMath::Vector4 &result);
+void VU0_v4addscalexyz(const UMath::Vector4 &a, const UMath::Vector4 &b, const float scaleby, UMath::Vector4 &result);
 void VU0_v3sub(const UMath::Vector3 &a, const UMath::Vector3 &b, UMath::Vector3 &result);
 float VU0_v3dotprod(const UMath::Vector3 &a, const UMath::Vector3 &b);
 float VU0_v3distancesquare(const UMath::Vector3 &p1, const UMath::Vector3 &p2);

--- a/src/Speed/Indep/SourceLists/zPhysics.cpp
+++ b/src/Speed/Indep/SourceLists/zPhysics.cpp
@@ -9,6 +9,8 @@
 
 #include "Speed/Indep/Src/Physics/Common/PhysicsObject.cpp"
 
+#include "Speed/Indep/Src/Physics/Common/Smackable.cpp"
+
 #include "Speed/Indep/Src/Physics/Common/Wheel.cpp"
 
 #include "Speed/Indep/Src/Physics/Common/VehicleBehaviors.cpp"

--- a/src/Speed/Indep/SourceLists/zPhysics.cpp
+++ b/src/Speed/Indep/SourceLists/zPhysics.cpp
@@ -3,6 +3,8 @@
 #pragma warning(disable : 4716)
 #endif
 
+#include "Speed/Indep/Src/Physics/SmackableTrigger.cpp"
+
 #include "Speed/Indep/Src/Physics/Common/Wheel.cpp"
 
 #include "Speed/Indep/Src/Physics/Common/VehicleSystem.cpp"

--- a/src/Speed/Indep/SourceLists/zPhysics.cpp
+++ b/src/Speed/Indep/SourceLists/zPhysics.cpp
@@ -18,3 +18,5 @@
 #include "Speed/Indep/Src/Physics/PhysicsUpgrades.cpp"
 
 #include "Speed/Indep/Src/Physics/PhysicsInfo.cpp"
+
+#include "Speed/Indep/Src/Physics/PhysicsTunings.cpp"

--- a/src/Speed/Indep/SourceLists/zPhysics.cpp
+++ b/src/Speed/Indep/SourceLists/zPhysics.cpp
@@ -13,4 +13,6 @@
 
 #include "Speed/Indep/Src/Physics/Common/Behavior.cpp"
 
+#include "Speed/Indep/Src/Physics/Common/Bounds.cpp"
+
 #include "Speed/Indep/Src/Physics/PhysicsInfo.cpp"

--- a/src/Speed/Indep/SourceLists/zPhysics.cpp
+++ b/src/Speed/Indep/SourceLists/zPhysics.cpp
@@ -5,6 +5,8 @@
 
 #include "Speed/Indep/Src/Physics/SmackableTrigger.cpp"
 
+#include "Speed/Indep/Src/Physics/Common/PhysicsObject.cpp"
+
 #include "Speed/Indep/Src/Physics/Common/Wheel.cpp"
 
 #include "Speed/Indep/Src/Physics/Common/VehicleBehaviors.cpp"

--- a/src/Speed/Indep/SourceLists/zPhysics.cpp
+++ b/src/Speed/Indep/SourceLists/zPhysics.cpp
@@ -21,6 +21,8 @@
 
 #include "Speed/Indep/Src/Physics/Common/Bounds.cpp"
 
+#include "Speed/Indep/Src/Physics/Common/SmokeableInfo.cpp"
+
 #include "Speed/Indep/Src/Physics/PhysicsUpgrades.cpp"
 
 #include "Speed/Indep/Src/Physics/PhysicsInfo.cpp"

--- a/src/Speed/Indep/SourceLists/zPhysics.cpp
+++ b/src/Speed/Indep/SourceLists/zPhysics.cpp
@@ -7,6 +7,8 @@
 
 #include "Speed/Indep/Src/Physics/Common/Explosion.cpp"
 
+#include "Speed/Indep/Src/Physics/Common/PVehicle.cpp"
+
 #include "Speed/Indep/Src/Physics/Common/PhysicsObject.cpp"
 
 #include "Speed/Indep/Src/Physics/Common/Smackable.cpp"

--- a/src/Speed/Indep/SourceLists/zPhysics.cpp
+++ b/src/Speed/Indep/SourceLists/zPhysics.cpp
@@ -7,6 +7,10 @@
 
 #include "Speed/Indep/Src/Physics/Common/Wheel.cpp"
 
+#include "Speed/Indep/Src/Physics/Common/VehicleBehaviors.cpp"
+
 #include "Speed/Indep/Src/Physics/Common/VehicleSystem.cpp"
+
+#include "Speed/Indep/Src/Physics/Common/Behavior.cpp"
 
 #include "Speed/Indep/Src/Physics/PhysicsInfo.cpp"

--- a/src/Speed/Indep/SourceLists/zPhysics.cpp
+++ b/src/Speed/Indep/SourceLists/zPhysics.cpp
@@ -5,6 +5,8 @@
 
 #include "Speed/Indep/Src/Physics/SmackableTrigger.cpp"
 
+#include "Speed/Indep/Src/Physics/Common/Explosion.cpp"
+
 #include "Speed/Indep/Src/Physics/Common/PhysicsObject.cpp"
 
 #include "Speed/Indep/Src/Physics/Common/Wheel.cpp"

--- a/src/Speed/Indep/SourceLists/zPhysics.cpp
+++ b/src/Speed/Indep/SourceLists/zPhysics.cpp
@@ -15,4 +15,6 @@
 
 #include "Speed/Indep/Src/Physics/Common/Bounds.cpp"
 
+#include "Speed/Indep/Src/Physics/PhysicsUpgrades.cpp"
+
 #include "Speed/Indep/Src/Physics/PhysicsInfo.cpp"

--- a/src/Speed/Indep/Src/AI/AIAvoidable.h
+++ b/src/Speed/Indep/Src/AI/AIAvoidable.h
@@ -46,7 +46,9 @@ class ALIGN_16 AIAvoidable {
     virtual ~AIAvoidable();
     virtual bool OnUpdateAvoidable(UMath::Vector3 &pos, float &sweep) = 0;
 
-    // void SetAvoidableObject(UTL::COM::IUnknown *pUnk) {}
+    void SetAvoidableObject(UTL::COM::IUnknown *pUnk) {
+        mUnk = pUnk;
+    }
 
   private:
     static void OnOverLap(AIAvoidable &a0, AIAvoidable &a1, float dT);

--- a/src/Speed/Indep/Src/Frontend/Database/VehicleDB.hpp
+++ b/src/Speed/Indep/Src/Frontend/Database/VehicleDB.hpp
@@ -50,6 +50,8 @@ struct FECustomizationRecord {
 
     USE_FASTALLOC(FECustomizationRecord)
 
+    FECustomizationRecord();
+
     void Default();
     void BecomePreset(PresetCar *preset);
     bool WriteRecordIntoPhysics(Attrib::Gen::pvehicle &vehicle) const;

--- a/src/Speed/Indep/Src/Frontend/Database/VehicleDB.hpp
+++ b/src/Speed/Indep/Src/Frontend/Database/VehicleDB.hpp
@@ -5,13 +5,10 @@
 #pragma once
 #endif
 
-#include "Speed/Indep/Libs/Support/Utility/FastMem.h"
 #include "Speed/Indep/Src/Gameplay/GInfractionManager.h"
 #include "Speed/Indep/Src/Physics/PhysicsTunings.h"
 #include "Speed/Indep/Src/Physics/PhysicsUpgrades.hpp"
 #include "Speed/Indep/Src/World/CarInfo.hpp"
-
-struct PresetCar;
 
 // total size: 0x14
 struct FECarRecord {
@@ -31,32 +28,6 @@ struct FECustomizationRecord {
     }
 
     void WriteRecordIntoRide(RideInfo *ride) const;
-
-    // TODO: zPhysics added everything from here to WritePhysicsIntoRecord; re-check against the Frontend work when that branch lands.
-    void SetTuning(Physics::Tunings::Path id, float value) {
-        this->Tunings[this->ActiveTuning].Value[id] = value;
-    }
-
-    float GetTuning(Physics::Tunings::Path id) const {
-        return this->Tunings[this->ActiveTuning].Value[id];
-    }
-
-    const Physics::Tunings *GetTunings() const {
-        return &this->Tunings[this->ActiveTuning];
-    }
-
-    Physics::Tunings *GetTunings() {
-        return &this->Tunings[this->ActiveTuning];
-    }
-
-    USE_FASTALLOC(FECustomizationRecord)
-
-    FECustomizationRecord();
-
-    void Default();
-    void BecomePreset(PresetCar *preset);
-    bool WriteRecordIntoPhysics(Attrib::Gen::pvehicle &vehicle) const;
-    bool WritePhysicsIntoRecord(const Attrib::Gen::pvehicle &vehicle);
 
     short InstalledPartIndices[139];             // offset 0x0, size 0x116
     Physics::Upgrades::Package InstalledPhysics; // offset 0x118, size 0x20

--- a/src/Speed/Indep/Src/Frontend/Database/VehicleDB.hpp
+++ b/src/Speed/Indep/Src/Frontend/Database/VehicleDB.hpp
@@ -32,6 +32,7 @@ struct FECustomizationRecord {
 
     void WriteRecordIntoRide(RideInfo *ride) const;
 
+    // TODO: zPhysics added everything from here to WritePhysicsIntoRecord; re-check against the Frontend work when that branch lands.
     void SetTuning(Physics::Tunings::Path id, float value) {
         this->Tunings[this->ActiveTuning].Value[id] = value;
     }

--- a/src/Speed/Indep/Src/Frontend/Database/VehicleDB.hpp
+++ b/src/Speed/Indep/Src/Frontend/Database/VehicleDB.hpp
@@ -5,6 +5,7 @@
 #pragma once
 #endif
 
+#include "Speed/Indep/Libs/Support/Utility/FastMem.h"
 #include "Speed/Indep/Src/Gameplay/GInfractionManager.h"
 #include "Speed/Indep/Src/Physics/PhysicsTunings.h"
 #include "Speed/Indep/Src/Physics/PhysicsUpgrades.hpp"
@@ -46,6 +47,8 @@ struct FECustomizationRecord {
     Physics::Tunings *GetTunings() {
         return &this->Tunings[this->ActiveTuning];
     }
+
+    USE_FASTALLOC(FECustomizationRecord)
 
     void Default();
     void BecomePreset(PresetCar *preset);

--- a/src/Speed/Indep/Src/Frontend/Database/VehicleDB.hpp
+++ b/src/Speed/Indep/Src/Frontend/Database/VehicleDB.hpp
@@ -10,6 +10,8 @@
 #include "Speed/Indep/Src/Physics/PhysicsUpgrades.hpp"
 #include "Speed/Indep/Src/World/CarInfo.hpp"
 
+struct PresetCar;
+
 // total size: 0x14
 struct FECarRecord {
     unsigned int Handle;         // offset 0x0, size 0x4
@@ -28,6 +30,27 @@ struct FECustomizationRecord {
     }
 
     void WriteRecordIntoRide(RideInfo *ride) const;
+
+    void SetTuning(Physics::Tunings::Path id, float value) {
+        this->Tunings[this->ActiveTuning].Value[id] = value;
+    }
+
+    float GetTuning(Physics::Tunings::Path id) const {
+        return this->Tunings[this->ActiveTuning].Value[id];
+    }
+
+    const Physics::Tunings *GetTunings() const {
+        return &this->Tunings[this->ActiveTuning];
+    }
+
+    Physics::Tunings *GetTunings() {
+        return &this->Tunings[this->ActiveTuning];
+    }
+
+    void Default();
+    void BecomePreset(PresetCar *preset);
+    bool WriteRecordIntoPhysics(Attrib::Gen::pvehicle &vehicle) const;
+    bool WritePhysicsIntoRecord(const Attrib::Gen::pvehicle &vehicle);
 
     short InstalledPartIndices[139];             // offset 0x0, size 0x116
     Physics::Upgrades::Package InstalledPhysics; // offset 0x118, size 0x20

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/acceltrans.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/acceltrans.h
@@ -49,10 +49,10 @@ struct acceltrans : Instance {
         return 0xff77f451;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0xff77f451, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/acceltrans.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/acceltrans.h
@@ -49,7 +49,7 @@ struct acceltrans : Instance {
         return 0xff77f451;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/aivehicle.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/aivehicle.h
@@ -52,10 +52,10 @@ struct aivehicle : Instance {
         return 0x22515733;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0x22515733, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/aivehicle.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/aivehicle.h
@@ -52,7 +52,7 @@ struct aivehicle : Instance {
         return 0x22515733;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/aud_moment_strm.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/aud_moment_strm.h
@@ -50,7 +50,7 @@ struct aud_moment_strm : Instance {
         return 0xd2410816;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/aud_moment_strm.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/aud_moment_strm.h
@@ -50,10 +50,10 @@ struct aud_moment_strm : Instance {
         return 0xd2410816;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0xd2410816, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/aud_stitch_loop.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/aud_stitch_loop.h
@@ -29,10 +29,10 @@ struct aud_stitch_loop : Instance {
         return 0x3473edcd;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0x3473edcd, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/aud_stitch_loop.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/aud_stitch_loop.h
@@ -29,7 +29,7 @@ struct aud_stitch_loop : Instance {
         return 0x3473edcd;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/audioimpact.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/audioimpact.h
@@ -34,7 +34,7 @@ struct audioimpact : Instance {
         return 0xfbffb107;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/audioimpact.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/audioimpact.h
@@ -34,10 +34,10 @@ struct audioimpact : Instance {
         return 0xfbffb107;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0xfbffb107, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/audioscrape.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/audioscrape.h
@@ -29,7 +29,7 @@ struct audioscrape : Instance {
         return 0x11b47832;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/audioscrape.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/audioscrape.h
@@ -29,10 +29,10 @@ struct audioscrape : Instance {
         return 0x11b47832;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0x11b47832, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/audiosystem.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/audiosystem.h
@@ -64,7 +64,7 @@ struct audiosystem : Instance {
         return 0xd3c18f03;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/audiosystem.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/audiosystem.h
@@ -64,10 +64,10 @@ struct audiosystem : Instance {
         return 0xd3c18f03;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0xd3c18f03, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/brakes.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/brakes.h
@@ -45,10 +45,10 @@ struct brakes : Instance {
         return 0x36350867;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0x36350867, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/brakes.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/brakes.h
@@ -45,7 +45,7 @@ struct brakes : Instance {
         return 0x36350867;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/camerainfo.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/camerainfo.h
@@ -66,7 +66,7 @@ struct camerainfo : Instance {
         return 0x93c171e4;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/camerainfo.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/camerainfo.h
@@ -66,10 +66,10 @@ struct camerainfo : Instance {
         return 0x93c171e4;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0x93c171e4, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/chassis.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/chassis.h
@@ -78,10 +78,10 @@ struct chassis : Instance {
         return 0xafa210f0;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0xafa210f0, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/chassis.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/chassis.h
@@ -78,7 +78,7 @@ struct chassis : Instance {
         return 0xafa210f0;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/chopperspecs.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/chopperspecs.h
@@ -88,7 +88,7 @@ struct chopperspecs : Instance {
         return 0x5d898ee7;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/chopperspecs.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/chopperspecs.h
@@ -88,10 +88,10 @@ struct chopperspecs : Instance {
         return 0x5d898ee7;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0x5d898ee7, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/collisionreactions.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/collisionreactions.h
@@ -48,7 +48,7 @@ struct collisionreactions : Instance {
         return 0xb32682f1;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/collisionreactions.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/collisionreactions.h
@@ -48,10 +48,10 @@ struct collisionreactions : Instance {
         return 0xb32682f1;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0xb32682f1, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/controller.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/controller.h
@@ -194,7 +194,7 @@ struct controller : Instance {
         return 0x2dee1998;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/controller.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/controller.h
@@ -194,10 +194,10 @@ struct controller : Instance {
         return 0x2dee1998;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0x2dee1998, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/damagespecs.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/damagespecs.h
@@ -72,7 +72,7 @@ struct damagespecs : Instance {
         return 0xc1f0b434;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/damagespecs.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/damagespecs.h
@@ -72,10 +72,10 @@ struct damagespecs : Instance {
         return 0xc1f0b434;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0xc1f0b434, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/ecar.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/ecar.h
@@ -112,7 +112,7 @@ struct ecar : Instance {
         return 0xa5b543b7;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/ecar.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/ecar.h
@@ -112,10 +112,10 @@ struct ecar : Instance {
         return 0xa5b543b7;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0xa5b543b7, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/effects.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/effects.h
@@ -62,10 +62,10 @@ struct effects : Instance {
         return 0xebcee74c;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0xebcee74c, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/effects.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/effects.h
@@ -62,7 +62,7 @@ struct effects : Instance {
         return 0xebcee74c;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/emitterdata.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/emitterdata.h
@@ -129,10 +129,10 @@ struct emitterdata : Instance {
         return 0xb30b18af;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0xb30b18af, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/emitterdata.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/emitterdata.h
@@ -129,7 +129,7 @@ struct emitterdata : Instance {
         return 0xb30b18af;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/emittergroup.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/emittergroup.h
@@ -50,7 +50,7 @@ struct emittergroup : Instance {
         return 0xaba86e60;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/emittergroup.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/emittergroup.h
@@ -50,10 +50,10 @@ struct emittergroup : Instance {
         return 0xaba86e60;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0xaba86e60, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/emitteruv.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/emitteruv.h
@@ -48,10 +48,10 @@ struct emitteruv : Instance {
         return 0xe4983a7d;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0xe4983a7d, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/emitteruv.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/emitteruv.h
@@ -48,7 +48,7 @@ struct emitteruv : Instance {
         return 0xe4983a7d;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/engine.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/engine.h
@@ -56,7 +56,7 @@ struct engine : Instance {
         return 0xf1f5fbc7;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/engine.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/engine.h
@@ -56,10 +56,10 @@ struct engine : Instance {
         return 0xf1f5fbc7;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0xf1f5fbc7, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/engineaudio.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/engineaudio.h
@@ -112,7 +112,7 @@ struct engineaudio : Instance {
         return 0x50eab0e6;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/engineaudio.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/engineaudio.h
@@ -112,10 +112,10 @@ struct engineaudio : Instance {
         return 0x50eab0e6;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0x50eab0e6, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/explosion.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/explosion.h
@@ -52,7 +52,7 @@ struct explosion : Instance {
         return 0x6434f1fb;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/explosion.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/explosion.h
@@ -52,10 +52,10 @@ struct explosion : Instance {
         return 0x6434f1fb;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0x6434f1fb, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/fecooling.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/fecooling.h
@@ -38,7 +38,7 @@ struct fecooling : Instance {
         return 0x5d417978;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/fecooling.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/fecooling.h
@@ -38,10 +38,10 @@ struct fecooling : Instance {
         return 0x5d417978;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0x5d417978, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/frontend.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/frontend.h
@@ -116,7 +116,7 @@ struct frontend : Instance {
         return 0x85885722;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/frontend.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/frontend.h
@@ -116,10 +116,10 @@ struct frontend : Instance {
         return 0x85885722;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0x85885722, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/fuelcell_effect.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/fuelcell_effect.h
@@ -43,7 +43,7 @@ struct fuelcell_effect : Instance {
         return 0x6f5943f1;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/fuelcell_effect.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/fuelcell_effect.h
@@ -43,10 +43,10 @@ struct fuelcell_effect : Instance {
         return 0x6f5943f1;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0x6f5943f1, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/fuelcell_emitter.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/fuelcell_emitter.h
@@ -78,10 +78,10 @@ struct fuelcell_emitter : Instance {
         return 0xb267a856;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0xb267a856, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/fuelcell_emitter.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/fuelcell_emitter.h
@@ -78,7 +78,7 @@ struct fuelcell_emitter : Instance {
         return 0xb267a856;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/gameplay.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/gameplay.h
@@ -262,10 +262,10 @@ struct gameplay : Instance {
         return 0x5cea9d46;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0x5cea9d46, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/gameplay.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/gameplay.h
@@ -262,7 +262,7 @@ struct gameplay : Instance {
         return 0x5cea9d46;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/induction.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/induction.h
@@ -54,10 +54,10 @@ struct induction : Instance {
         return 0xc92a0142;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0xc92a0142, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/induction.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/induction.h
@@ -54,7 +54,7 @@ struct induction : Instance {
         return 0xc92a0142;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/infractions.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/infractions.h
@@ -42,7 +42,7 @@ struct infractions : Instance {
         return 0x2870de90;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/infractions.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/infractions.h
@@ -42,10 +42,10 @@ struct infractions : Instance {
         return 0x2870de90;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0x2870de90, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/junkman.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/junkman.h
@@ -34,7 +34,7 @@ struct junkman : Instance {
         return 0x171737e9;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/junkman.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/junkman.h
@@ -34,10 +34,10 @@ struct junkman : Instance {
         return 0x171737e9;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0x171737e9, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/light_flares_cg.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/light_flares_cg.h
@@ -56,10 +56,10 @@ struct light_flares_cg : Instance {
         return 0xc7c5806d;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0xc7c5806d, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/light_flares_cg.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/light_flares_cg.h
@@ -56,7 +56,7 @@ struct light_flares_cg : Instance {
         return 0xc7c5806d;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/lightmaterials.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/lightmaterials.h
@@ -100,7 +100,7 @@ struct lightmaterials : Instance {
         return 0xd32a743f;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/lightmaterials.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/lightmaterials.h
@@ -100,10 +100,10 @@ struct lightmaterials : Instance {
         return 0xd32a743f;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0xd32a743f, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/lightshaders.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/lightshaders.h
@@ -30,7 +30,7 @@ struct lightshaders : Instance {
         return 0xbc8c1aa3;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/lightshaders.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/lightshaders.h
@@ -30,10 +30,10 @@ struct lightshaders : Instance {
         return 0xbc8c1aa3;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0xbc8c1aa3, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/milestonetypes.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/milestonetypes.h
@@ -46,10 +46,10 @@ struct milestonetypes : Instance {
         return 0xe4c3d904;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0xe4c3d904, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/milestonetypes.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/milestonetypes.h
@@ -46,7 +46,7 @@ struct milestonetypes : Instance {
         return 0xe4c3d904;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/music.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/music.h
@@ -48,10 +48,10 @@ struct music : Instance {
         return 0x565465f8;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0x565465f8, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/music.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/music.h
@@ -48,7 +48,7 @@ struct music : Instance {
         return 0x565465f8;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/nos.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/nos.h
@@ -55,7 +55,7 @@ struct nos : Instance {
         return 0xb1669f64;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/nos.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/nos.h
@@ -55,10 +55,10 @@ struct nos : Instance {
         return 0xb1669f64;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0xb1669f64, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/ocean.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/ocean.h
@@ -31,7 +31,7 @@ struct ocean : Instance {
         return 0x093d7c56;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/ocean.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/ocean.h
@@ -31,10 +31,10 @@ struct ocean : Instance {
         return 0x093d7c56;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0x093d7c56, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/presetride.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/presetride.h
@@ -34,7 +34,7 @@ struct presetride : Instance {
         return 0x27e73952;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/presetride.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/presetride.h
@@ -34,10 +34,10 @@ struct presetride : Instance {
         return 0x27e73952;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0x27e73952, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/pursuitescalation.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/pursuitescalation.h
@@ -31,10 +31,10 @@ struct pursuitescalation : Instance {
         return 0xd6d4330b;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0xd6d4330b, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/pursuitescalation.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/pursuitescalation.h
@@ -31,7 +31,7 @@ struct pursuitescalation : Instance {
         return 0xd6d4330b;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/pursuitlevels.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/pursuitlevels.h
@@ -128,7 +128,7 @@ struct pursuitlevels : Instance {
         return 0x551e22b3;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/pursuitlevels.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/pursuitlevels.h
@@ -128,10 +128,10 @@ struct pursuitlevels : Instance {
         return 0x551e22b3;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0x551e22b3, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/pursuitsupport.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/pursuitsupport.h
@@ -31,7 +31,7 @@ struct pursuitsupport : Instance {
         return 0x77b93104;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/pursuitsupport.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/pursuitsupport.h
@@ -31,10 +31,10 @@ struct pursuitsupport : Instance {
         return 0x77b93104;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0x77b93104, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/pvehicle.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/pvehicle.h
@@ -121,10 +121,10 @@ struct pvehicle : Instance {
         return 0x4a97ec8f;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0x4a97ec8f, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/pvehicle.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/pvehicle.h
@@ -145,10 +145,7 @@ struct pvehicle : Instance {
         operator=(rhs.GetBase());
         return *this;
     }
-    const pvehicle &operator=(const Instance &rhs) {
-        Instance::operator=(rhs);
-        return *this;
-    }
+    const pvehicle &operator=(const Instance &rhs);
     bool BEHAVIOR_MECHANIC_AUDIO(TAttrib<Attrib::StringKey> &result) const;
     bool BEHAVIOR_MECHANIC_AUDIO(Attrib::StringKey &result) const;
     const Attrib::StringKey &BEHAVIOR_MECHANIC_AUDIO() const;

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/pvehicle.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/pvehicle.h
@@ -121,7 +121,7 @@ struct pvehicle : Instance {
         return 0x4a97ec8f;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/rigidbodyspecs.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/rigidbodyspecs.h
@@ -89,10 +89,10 @@ struct rigidbodyspecs : Instance {
         return 0x7c90bb38;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0x7c90bb38, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/rigidbodyspecs.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/rigidbodyspecs.h
@@ -89,7 +89,7 @@ struct rigidbodyspecs : Instance {
         return 0x7c90bb38;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/shiftpattern.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/shiftpattern.h
@@ -83,10 +83,10 @@ struct shiftpattern : Instance {
         return 0xdb01b754;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0xdb01b754, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/shiftpattern.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/shiftpattern.h
@@ -83,7 +83,7 @@ struct shiftpattern : Instance {
         return 0xdb01b754;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/simsurface.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/simsurface.h
@@ -80,10 +80,10 @@ struct simsurface : Instance {
         return 0xfb111fef;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0xfb111fef, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/simsurface.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/simsurface.h
@@ -80,7 +80,7 @@ struct simsurface : Instance {
         return 0xfb111fef;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/smackable.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/smackable.h
@@ -76,7 +76,7 @@ struct smackable : Instance {
         return 0xce70d7db;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/smackable.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/smackable.h
@@ -76,10 +76,10 @@ struct smackable : Instance {
         return 0xce70d7db;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0xce70d7db, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/speech.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/speech.h
@@ -75,10 +75,10 @@ struct speech : Instance {
         return 0xc593dd47;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0xc593dd47, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/speech.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/speech.h
@@ -75,7 +75,7 @@ struct speech : Instance {
         return 0xc593dd47;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/speechtune.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/speechtune.h
@@ -119,7 +119,7 @@ struct speechtune : Instance {
         return 0xbc683501;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/speechtune.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/speechtune.h
@@ -119,10 +119,10 @@ struct speechtune : Instance {
         return 0xbc683501;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0xbc683501, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/system.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/system.h
@@ -44,7 +44,7 @@ struct system : Instance {
         return 0x4e8dce05;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/system.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/system.h
@@ -44,10 +44,10 @@ struct system : Instance {
         return 0x4e8dce05;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0x4e8dce05, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/timeofdaylighting.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/timeofdaylighting.h
@@ -63,10 +63,10 @@ struct timeofdaylighting : Instance {
         return 0x399ed882;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0x399ed882, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/timeofdaylighting.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/timeofdaylighting.h
@@ -63,7 +63,7 @@ struct timeofdaylighting : Instance {
         return 0x399ed882;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/tires.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/tires.h
@@ -58,7 +58,7 @@ struct tires : Instance {
         return 0xbd38d1ca;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/tires.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/tires.h
@@ -58,10 +58,10 @@ struct tires : Instance {
         return 0xbd38d1ca;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0xbd38d1ca, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/trafficpattern.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/trafficpattern.h
@@ -46,10 +46,10 @@ struct trafficpattern : Instance {
         return 0x20d08342;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0x20d08342, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/trafficpattern.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/trafficpattern.h
@@ -46,7 +46,7 @@ struct trafficpattern : Instance {
         return 0x20d08342;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/transmission.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/transmission.h
@@ -61,10 +61,10 @@ struct transmission : Instance {
         return 0x07a7a3e5;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0x07a7a3e5, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/transmission.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/transmission.h
@@ -61,7 +61,7 @@ struct transmission : Instance {
         return 0x07a7a3e5;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/turbosfx.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/turbosfx.h
@@ -51,10 +51,10 @@ struct turbosfx : Instance {
         return 0x55624a85;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0x55624a85, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/turbosfx.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/turbosfx.h
@@ -51,7 +51,7 @@ struct turbosfx : Instance {
         return 0x55624a85;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/visuallook.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/visuallook.h
@@ -56,7 +56,7 @@ struct visuallook : Instance {
         return 0x339f7d3d;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/visuallook.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/visuallook.h
@@ -56,10 +56,10 @@ struct visuallook : Instance {
         return 0x339f7d3d;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0x339f7d3d, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/visuallookeffect.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/visuallookeffect.h
@@ -52,7 +52,7 @@ struct visuallookeffect : Instance {
         return 0x6ab2d241;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/visuallookeffect.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/visuallookeffect.h
@@ -52,10 +52,10 @@ struct visuallookeffect : Instance {
         return 0x6ab2d241;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0x6ab2d241, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/visuallooktransition.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/visuallooktransition.h
@@ -34,10 +34,10 @@ struct visuallooktransition : Instance {
         return 0x0f409aa6;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0x0f409aa6, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/visuallooktransition.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/visuallooktransition.h
@@ -34,7 +34,7 @@ struct visuallooktransition : Instance {
         return 0x0f409aa6;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/visualrgbtweaker.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/visualrgbtweaker.h
@@ -30,10 +30,10 @@ struct visualrgbtweaker : Instance {
         return 0xaf1837ca;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0xaf1837ca, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/visualrgbtweaker.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/visualrgbtweaker.h
@@ -30,7 +30,7 @@ struct visualrgbtweaker : Instance {
         return 0xaf1837ca;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/world.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/world.h
@@ -59,10 +59,10 @@ struct world : Instance {
         return 0x6d90da55;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(0x6d90da55, dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
-        return GenerateUniqueKey(name, registerName);
+        return GUKeyInternal(ClassKey(), name, registerName);
     }
     void Change(const Collection *c) {
         Instance::Change(c);

--- a/src/Speed/Indep/Src/Generated/AttribSys/Classes/world.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/Classes/world.h
@@ -59,7 +59,7 @@ struct world : Instance {
         return 0x6d90da55;
     }
     void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {
-        ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+        ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
     }
     Key GenerateUniqueKey(const char *name, bool registerName) const {
         return GUKeyInternal(ClassKey(), name, registerName);

--- a/src/Speed/Indep/Src/Generated/AttribSys/GenericAccessor.h
+++ b/src/Speed/Indep/Src/Generated/AttribSys/GenericAccessor.h
@@ -145,6 +145,10 @@ class GenericAccessor : private Instance {
         ATTRIB_CODEGEN_GETLENGTH(0x511abd7b);
     }
 
+    const StringKey &BEHAVIOR_ORDER(unsigned int index) const {
+        ATTRIB_CODEGEN_GETVALUEINDEXED(StringKey, 0x104e9d16, index);
+    }
+
     bool BEHAVIOR_ORDER(StringKey &val, unsigned int index) const {
         ATTRIB_CODEGEN_GETVALIDATTRIB(StringKey, 0x104e9d16, index, val);
     }

--- a/src/Speed/Indep/Src/Interfaces/SimEntities/IEntity.h
+++ b/src/Speed/Indep/Src/Interfaces/SimEntities/IEntity.h
@@ -23,15 +23,15 @@ class IEntity : public UTL::COM::IUnknown,
   public:
     DECL_INTERFACE(IEntity);
 
-    virtual void AttachPhysics(ISimable *object);
-    virtual void DetachPhysics();
-    virtual ISimable *GetSimable() const;
-    virtual const UMath::Vector3 &GetPosition() const;
-    virtual bool SetPosition(UMath::Vector3 &position);
-    virtual void Kill();
-    virtual bool Attach(IUnknown *object);
-    virtual bool Detach(IUnknown *object);
-    virtual const UTL::Std::list<IAttachable *, _type_IAttachableList> *GetAttachments() const;
+    virtual void AttachPhysics(ISimable *object) = 0;
+    virtual void DetachPhysics() = 0;
+    virtual ISimable *GetSimable() const = 0;
+    virtual const UMath::Vector3 &GetPosition() const = 0;
+    virtual bool SetPosition(UMath::Vector3 &position) = 0;
+    virtual void Kill() = 0;
+    virtual bool Attach(IUnknown *object) = 0;
+    virtual bool Detach(IUnknown *object) = 0;
+    virtual const UTL::Std::list<IAttachable *, _type_IAttachableList> *GetAttachments() const = 0;
 };
 
 }; // namespace Sim

--- a/src/Speed/Indep/Src/Interfaces/SimModels/IPlaceableScenery.h
+++ b/src/Speed/Indep/Src/Interfaces/SimModels/IPlaceableScenery.h
@@ -10,9 +10,9 @@ class IPlaceableScenery : public UTL::COM::IUnknown, public UTL::Collections::Co
   public:
     DECL_INTERFACE(IPlaceableScenery);
 
-    virtual void PickUp();
-    virtual bool Place(const UMath::Matrix4 &transform, bool snap_to_ground);
-    virtual void Destroy();
+    virtual void PickUp() = 0;
+    virtual bool Place(const UMath::Matrix4 &transform, bool snap_to_ground) = 0;
+    virtual void Destroy() = 0;
 
     static IPlaceableScenery *CreateInstance(const char *name, Attrib::Key attributes);
 };

--- a/src/Speed/Indep/Src/Interfaces/SimModels/IPlaceableScenery.h
+++ b/src/Speed/Indep/Src/Interfaces/SimModels/IPlaceableScenery.h
@@ -10,9 +10,9 @@ class IPlaceableScenery : public UTL::COM::IUnknown, public UTL::Collections::Co
   public:
     DECL_INTERFACE(IPlaceableScenery);
 
-    virtual void Destroy() = 0;
-    virtual bool Place(const UMath::Matrix4 &transform, bool snap_to_ground) = 0;
     virtual void PickUp() = 0;
+    virtual bool Place(const UMath::Matrix4 &transform, bool snap_to_ground) = 0;
+    virtual void Destroy() = 0;
 
     static IPlaceableScenery *CreateInstance(const char *name, Attrib::Key attributes);
 };

--- a/src/Speed/Indep/Src/Interfaces/SimModels/IPlaceableScenery.h
+++ b/src/Speed/Indep/Src/Interfaces/SimModels/IPlaceableScenery.h
@@ -10,9 +10,9 @@ class IPlaceableScenery : public UTL::COM::IUnknown, public UTL::Collections::Co
   public:
     DECL_INTERFACE(IPlaceableScenery);
 
-    virtual void PickUp() = 0;
-    virtual bool Place(const UMath::Matrix4 &transform, bool snap_to_ground) = 0;
     virtual void Destroy() = 0;
+    virtual bool Place(const UMath::Matrix4 &transform, bool snap_to_ground) = 0;
+    virtual void PickUp() = 0;
 
     static IPlaceableScenery *CreateInstance(const char *name, Attrib::Key attributes);
 };

--- a/src/Speed/Indep/Src/Interfaces/SimModels/ISceneryModel.h
+++ b/src/Speed/Indep/Src/Interfaces/SimModels/ISceneryModel.h
@@ -9,11 +9,11 @@ class ISceneryModel : public UTL::COM::IUnknown {
   public:
     DECL_INTERFACE(ISceneryModel);
 
-    virtual unsigned int GetSpawnerID() {}
-    virtual void RestoreScene();
-    virtual bool GetSceneryTransform(UMath::Matrix4) const;
-    virtual void WakeUp();
-    virtual bool IsExcluded(unsigned int scenery_exclusion_flag) {}
+    virtual bool GetSceneryTransform(UMath::Matrix4 &matrix) const = 0;
+    virtual void RestoreScene() = 0;
+    virtual unsigned int GetSpawnerID() const = 0;
+    virtual void WakeUp() = 0;
+    virtual bool IsExcluded(unsigned int scenery_exclusion_flag) const = 0;
 };
 
 #endif

--- a/src/Speed/Indep/Src/Interfaces/SimModels/ITriggerableModel.h
+++ b/src/Speed/Indep/Src/Interfaces/SimModels/ITriggerableModel.h
@@ -8,7 +8,7 @@ class ITriggerableModel : public UTL::COM::IUnknown {
   public:
     DECL_INTERFACE(ITriggerableModel);
 
-    virtual void PlaceTrigger(const UMath::Matrix4 &matrix, bool enable);
+    virtual void PlaceTrigger(const UMath::Matrix4 &matrix, bool enable) = 0;
 };
 
 #endif

--- a/src/Speed/Indep/Src/Interfaces/Simables/IEffects.h
+++ b/src/Speed/Indep/Src/Interfaces/Simables/IEffects.h
@@ -1,4 +1,29 @@
-#ifndef IEFFECTS_H
-#define IEFFECTS_H
+#ifndef INTERFACES_SIMABLES_IEFFECTS_H
+#define INTERFACES_SIMABLES_IEFFECTS_H
+
+#ifdef EA_PRAGMA_ONCE_SUPPORTED
+#pragma once
+#endif
+
+#include "Speed/Indep/Libs/Support/Utility/UCOM.h"
+
+class IEffects : public UTL::COM::IUnknown {
+  public:
+    static HINTERFACE _IHandle() {
+        return (HINTERFACE)_IHandle;
+    }
+
+    IEffects(UTL::COM::Object *owner) : UTL::COM::IUnknown(owner, _IHandle()) {}
+
+    virtual ~IEffects() {}
+
+    virtual void HitGround();
+    virtual void HitWorld();
+    virtual void HitObject();
+    virtual void ScrapeObject();
+    virtual void ScrapeGround();
+    virtual void ScrapeWorld();
+    virtual void Purge();
+};
 
 #endif

--- a/src/Speed/Indep/Src/Interfaces/Simables/IEffects.h
+++ b/src/Speed/Indep/Src/Interfaces/Simables/IEffects.h
@@ -17,13 +17,13 @@ class IEffects : public UTL::COM::IUnknown {
 
     virtual ~IEffects() {}
 
-    virtual void HitGround();
-    virtual void HitWorld();
-    virtual void HitObject();
-    virtual void ScrapeObject();
-    virtual void ScrapeGround();
-    virtual void ScrapeWorld();
-    virtual void Purge();
+    virtual void HitGround() = 0;
+    virtual void HitWorld() = 0;
+    virtual void HitObject() = 0;
+    virtual void ScrapeObject() = 0;
+    virtual void ScrapeGround() = 0;
+    virtual void ScrapeWorld() = 0;
+    virtual void Purge() = 0;
 };
 
 #endif

--- a/src/Speed/Indep/Src/Interfaces/Simables/IExplodeable.h
+++ b/src/Speed/Indep/Src/Interfaces/Simables/IExplodeable.h
@@ -1,4 +1,16 @@
 #ifndef IEXPLODEABLE_H
 #define IEXPLODEABLE_H
 
+#include "Speed/Indep/Libs/Support/Utility/UCOM.h"
+#include "Speed/Indep/Libs/Support/Utility/UTypes.h"
+
+class IExplosion;
+
+class IExplodeable : public UTL::COM::IUnknown {
+  public:
+    DECL_INTERFACE(IExplodeable);
+
+    virtual bool OnExplosion(const UMath::Vector3 &normal, const UMath::Vector3 &position, float dT, IExplosion *explosion) = 0;
+};
+
 #endif

--- a/src/Speed/Indep/Src/Interfaces/Simables/IRecordablePlayer.h
+++ b/src/Speed/Indep/Src/Interfaces/Simables/IRecordablePlayer.h
@@ -1,0 +1,31 @@
+#ifndef _IRecordablePlayer
+#define _IRecordablePlayer
+
+#ifdef EA_PRAGMA_ONCE_SUPPORTED
+#pragma once
+#endif
+
+#include "Speed/Indep/Libs/Support/Utility/UCOM.h"
+#include "Speed/Indep/Libs/Support/Utility/UListable.h"
+
+struct IRecordablePlayer : public UTL::COM::IUnknown,
+                           public UTL::Collections::Listable<IRecordablePlayer, 8> {
+    static HINTERFACE _IHandle() { return (HINTERFACE)_IHandle; }
+
+    IRecordablePlayer(UTL::COM::Object *owner) : UTL::COM::IUnknown(owner, _IHandle()) {}
+
+    virtual ~IRecordablePlayer() {}
+
+    virtual void StartRecording() = 0;
+    virtual void StopRecording() = 0;
+    virtual void StartPlayback() = 0;
+    virtual void Pause() = 0;
+    virtual void UnPause() = 0;
+    virtual float GetTimeTotalLength() = 0;
+    virtual float GetTimeElapsed() = 0;
+    virtual void SetTime() = 0;
+    virtual void StopPlayback() = 0;
+    virtual unsigned int GetPacketSize() = 0;
+};
+
+#endif

--- a/src/Speed/Indep/Src/Interfaces/Simables/IVehicle.h
+++ b/src/Speed/Indep/Src/Interfaces/Simables/IVehicle.h
@@ -68,7 +68,7 @@ class IVehicle : public UTL::COM::IUnknown, public UTL::Collections::ListableSet
     virtual float GetSpeed() const = 0;
     virtual void SetSpeed(float speed) = 0;
     virtual float GetAbsoluteSpeed() const = 0;
-    virtual bool IsGlareOn(VehicleFX::ID glare) const = 0;
+    virtual bool IsGlareOn(VehicleFX::ID glare) = 0;
     virtual void GlareOn(VehicleFX::ID glare) = 0;
     virtual void GlareOff(VehicleFX::ID glare) = 0;
     virtual bool IsCollidingWithSoftBarrier() = 0;

--- a/src/Speed/Indep/Src/Main/EventSequencer.h
+++ b/src/Speed/Indep/Src/Main/EventSequencer.h
@@ -45,7 +45,7 @@ class IContext : public UTL::COM::IUnknown {
   public:
     DECL_INTERFACE(IContext);
 
-    virtual bool SetDynamicData(const System *system, EventDynamicData *data);
+    virtual bool SetDynamicData(const System *system, EventDynamicData *data) = 0;
 };
 
 // TODO DECLAREHANDLE in new UTL.h

--- a/src/Speed/Indep/Src/Main/stubs.h
+++ b/src/Speed/Indep/Src/Main/stubs.h
@@ -5,6 +5,8 @@
 #pragma once
 #endif
 
+inline void dbattrib(float min1, float max1, unsigned int attr1, float min2, float max2, unsigned int attr2) {}
 
+inline void dbattrib(int min1, int max1, unsigned int attr1, int min2, int max2, unsigned int attr2) {}
 
 #endif

--- a/src/Speed/Indep/Src/Misc/MWAttribUserTypes.h
+++ b/src/Speed/Indep/Src/Misc/MWAttribUserTypes.h
@@ -68,6 +68,8 @@ struct CarBodyMotion {
 
 // total size: 0x8
 struct AxlePair {
+    AxlePair() : Front(0.0f), Rear(0.0f) {}
+
     float Front; // offset 0x0, size 0x4
     float Rear;  // offset 0x4, size 0x4
 

--- a/src/Speed/Indep/Src/Misc/attribuserinclude.h
+++ b/src/Speed/Indep/Src/Misc/attribuserinclude.h
@@ -46,10 +46,7 @@ class StringKey {
     }
 
     bool IsNotEmpty() const {
-        if (this->mString != nullptr) {
-            return this->mString[0] != 0;
-        }
-        return false;
+        return this->mString != nullptr && this->mString[0] != 0;
     }
 
     bool IsEmpty() const {

--- a/src/Speed/Indep/Src/Misc/attribuserinclude.h
+++ b/src/Speed/Indep/Src/Misc/attribuserinclude.h
@@ -49,7 +49,10 @@ class StringKey {
         if (this->mString == nullptr) {
             return false;
         }
-        return this->mString[0] != 0;
+        if (this->mString[0] == 0) {
+            return false;
+        }
+        return true;
     }
 
     bool IsEmpty() const {

--- a/src/Speed/Indep/Src/Misc/attribuserinclude.h
+++ b/src/Speed/Indep/Src/Misc/attribuserinclude.h
@@ -45,6 +45,13 @@ class StringKey {
         return this->mHash32;
     }
 
+    bool IsNotEmpty() const {
+        if (this->mString != nullptr) {
+            return this->mString[0] != 0;
+        }
+        return false;
+    }
+
     bool IsEmpty() const {
         if (this->mString != nullptr) {
             return this->mString[0] == 0;

--- a/src/Speed/Indep/Src/Misc/attribuserinclude.h
+++ b/src/Speed/Indep/Src/Misc/attribuserinclude.h
@@ -46,7 +46,10 @@ class StringKey {
     }
 
     bool IsNotEmpty() const {
-        return this->mString != nullptr && this->mString[0] != 0;
+        if (this->mString == nullptr) {
+            return false;
+        }
+        return this->mString[0] != 0;
     }
 
     bool IsEmpty() const {

--- a/src/Speed/Indep/Src/Physics/Behavior.h
+++ b/src/Speed/Indep/Src/Physics/Behavior.h
@@ -10,6 +10,12 @@
 
 // total size: 0x10
 struct BehaviorParams {
+    BehaviorParams(const Sim::Param &params, struct PhysicsObject *owner, const UCrc32 &mechanic, const UCrc32 &signature)
+        : fparams(params), //
+          fowner(owner),   //
+          fSig(signature), //
+          fMechanic(mechanic) {}
+
     const Sim::Param &fparams;    // offset 0x0, size 0x4
     struct PhysicsObject *fowner; // offset 0x4, size 0x4
     const UCrc32 &fSig;           // offset 0x8, size 0x4
@@ -52,6 +58,10 @@ class Behavior : public Sim::Object, public UTL::COM::Factory<const BehaviorPara
     }
 
     void Pause(bool pause);
+
+    static void Destroy(Behavior *b) {
+        delete b;
+    }
 
     virtual void Reset() = 0;
 

--- a/src/Speed/Indep/Src/Physics/Behavior.h
+++ b/src/Speed/Indep/Src/Physics/Behavior.h
@@ -4,17 +4,16 @@
 #include "Speed/Indep/Libs/Support/Utility/FastMem.h"
 #include "Speed/Indep/Libs/Support/Utility/UCrc.h"
 #include "Speed/Indep/Src/Interfaces/Simables/ISimable.h"
-#include "Speed/Indep/Src/Physics/PhysicsObject.h"
 #include "Speed/Indep/Src/Sim/SimObject.h"
 #include "Speed/Indep/Src/Sim/SimProfile.h"
 #include "Speed/Indep/Tools/AttribSys/Runtime/AttribSys.h"
 
 // total size: 0x10
 struct BehaviorParams {
-    const Sim::Param &fparams; // offset 0x0, size 0x4
-    PhysicsObject *fowner;     // offset 0x4, size 0x4
-    const UCrc32 &fSig;        // offset 0x8, size 0x4
-    const UCrc32 &fMechanic;   // offset 0xC, size 0x4
+    const Sim::Param &fparams;    // offset 0x0, size 0x4
+    struct PhysicsObject *fowner; // offset 0x4, size 0x4
+    const UCrc32 &fSig;           // offset 0x8, size 0x4
+    const UCrc32 &fMechanic;      // offset 0xC, size 0x4
 };
 
 // total size: 0x4C
@@ -38,10 +37,21 @@ class Behavior : public Sim::Object, public UTL::COM::Factory<const BehaviorPara
         return this->mIOwner;
     }
 
+    void DoSimulate(float dT) {
+        Sim::Profile::Scope profile(this->mProfile);
+        this->OnTaskSimulate(dT);
+    }
+
+    void BehaviorChanged(const UCrc32 &mechanic) {
+        this->OnBehaviorChange(mechanic);
+    }
+
     void EnableProfile(const char *name) {
         Sim::Profile::Release(this->mProfile);
         this->mProfile = Sim::Profile::Create();
     }
+
+    void Pause(bool pause);
 
     virtual void Reset() = 0;
 

--- a/src/Speed/Indep/Src/Physics/Behavior.h
+++ b/src/Speed/Indep/Src/Physics/Behavior.h
@@ -108,6 +108,7 @@ template <typename T> class BehaviorSpecsPtr : public AttributeStructPtr<T> {
         // TODO
     }
 
+
     Attrib::Key LookupKey(const ISimable *owner, int index) {
         const Attrib::Instance &owneratr = owner->GetAttributes();
         if (!owneratr.IsValid()) {

--- a/src/Speed/Indep/Src/Physics/Behavior.h
+++ b/src/Speed/Indep/Src/Physics/Behavior.h
@@ -104,9 +104,7 @@ template <typename T> class BehaviorSpecsPtr : public AttributeStructPtr<T> {
   public:
     BehaviorSpecsPtr(Behavior *behavior, int index) : AttributeStructPtr<T>(LookupKey(behavior->GetOwner(), index)) {}
 
-    BehaviorSpecsPtr(ISimable *owner, int index) : AttributeStructPtr<T>(0) {
-        // TODO
-    }
+    BehaviorSpecsPtr(ISimable *owner, int index) : AttributeStructPtr<T>(LookupKey(owner, index)) {}
 
 
     Attrib::Key LookupKey(const ISimable *owner, int index) {

--- a/src/Speed/Indep/Src/Physics/Behaviors/RigidBody.cpp
+++ b/src/Speed/Indep/Src/Physics/Behaviors/RigidBody.cpp
@@ -8,6 +8,7 @@
 #include "Speed/Indep/Src/Interfaces/Simables/ISimable.h"
 #include "Speed/Indep/Src/Main/EventSequencer.h"
 #include "Speed/Indep/Src/Physics/Dynamics.h"
+#include "Speed/Indep/Src/Physics/PhysicsObject.h"
 #include "Speed/Indep/Src/Physics/Dynamics/Articulation.h"
 #include "Speed/Indep/Src/Physics/Dynamics/Collision.h"
 #include "Speed/Indep/Src/Sim/Collision.h"

--- a/src/Speed/Indep/Src/Physics/Bounds.h
+++ b/src/Speed/Indep/Src/Physics/Bounds.h
@@ -7,10 +7,12 @@
 #include "Speed/Indep/Libs/Support/Utility/FastMem.h"
 #include "Speed/Indep/Libs/Support/Utility/UCOM.h"
 #include "Speed/Indep/Libs/Support/Utility/UCollections.h"
+#include "Speed/Indep/Libs/Support/Utility/UStandard.h"
 #include "Speed/Indep/Libs/Support/Utility/UCrc.h"
 #include "Speed/Indep/Src/Sim/SimSurface.h"
 #include "Speed/Indep/bWare/Inc/bChunk.hpp"
 #include "Speed/Indep/bWare/Inc/bList.hpp"
+#include "Speed/Indep/bWare/Inc/bWare.hpp"
 
 DECLARE_CONTAINER_TYPE(CollisionBoundsTable);
 
@@ -41,6 +43,12 @@ struct _V3c {
         to.z = static_cast<float>(z) / COLLISION_GEOM_VECTOR_PRESSICION;
     }
 
+    void EndianSwap() {
+        bPlatEndianSwap(&this->x);
+        bPlatEndianSwap(&this->y);
+        bPlatEndianSwap(&this->z);
+    }
+
     int16 x; // offset 0x0, size 0x2
     int16 y; // offset 0x2, size 0x2
     int16 z; // offset 0x4, size 0x2
@@ -53,6 +61,13 @@ struct _Q4c {
         to.y = static_cast<float>(this->y) / COLLISION_GEOM_QUAT_PRECISION;
         to.z = static_cast<float>(this->z) / COLLISION_GEOM_QUAT_PRECISION;
         to.w = static_cast<float>(this->w) / COLLISION_GEOM_QUAT_PRECISION;
+    }
+
+    void EndianSwap() {
+        bPlatEndianSwap(&this->x);
+        bPlatEndianSwap(&this->y);
+        bPlatEndianSwap(&this->z);
+        bPlatEndianSwap(&this->w);
     }
 
     int16 x; // offset 0x0, size 0x2
@@ -194,12 +209,11 @@ class BoundsPack : public bTNode<BoundsPack> {
         struct Collection *Collection; // offset 0x4, size 0x4
     };
 
-    class Table : public _STL::vector<Pair, UTL::Std::Allocator<Pair, _type_CollisionBoundsTable> > {
+    class Table : public UTL::Std::vector<Pair, _type_CollisionBoundsTable> {
       public:
         void Add(Collection *collection) {
             Pair pair(collection->fNameHash, collection);
-            iterator pos = _STL::upper_bound(this->begin(), this->end(), pair);
-            this->insert(pos, pair);
+            this->insert(_STL::upper_bound(this->begin(), this->end(), pair), pair);
         }
 
         Collection *Find(UCrc32 name);

--- a/src/Speed/Indep/Src/Physics/Bounds.h
+++ b/src/Speed/Indep/Src/Physics/Bounds.h
@@ -7,12 +7,14 @@
 #include "Speed/Indep/Libs/Support/Utility/FastMem.h"
 #include "Speed/Indep/Libs/Support/Utility/UCOM.h"
 #include "Speed/Indep/Libs/Support/Utility/UCollections.h"
-#include "Speed/Indep/Libs/Support/Utility/UStandard.h"
 #include "Speed/Indep/Libs/Support/Utility/UCrc.h"
+#include "Speed/Indep/Libs/Support/Utility/UStandard.h"
 #include "Speed/Indep/Src/Sim/SimSurface.h"
 #include "Speed/Indep/bWare/Inc/bChunk.hpp"
 #include "Speed/Indep/bWare/Inc/bList.hpp"
 #include "Speed/Indep/bWare/Inc/bWare.hpp"
+
+#include <algorithm>
 
 DECLARE_CONTAINER_TYPE(CollisionBoundsTable);
 

--- a/src/Speed/Indep/Src/Physics/Bounds.h
+++ b/src/Speed/Indep/Src/Physics/Bounds.h
@@ -213,7 +213,7 @@ class BoundsPack : public bTNode<BoundsPack> {
       public:
         void Add(Collection *collection) {
             Pair pair(collection->fNameHash, collection);
-            this->insert(_STL::upper_bound(this->begin(), this->end(), pair), pair);
+            this->insert(std::upper_bound(this->begin(), this->end(), pair), pair);
         }
 
         Collection *Find(UCrc32 name);

--- a/src/Speed/Indep/Src/Physics/Bounds.h
+++ b/src/Speed/Indep/Src/Physics/Bounds.h
@@ -4,9 +4,15 @@
 #define COLLISION_GEOM_VECTOR_PRESSICION 1000.f
 #define COLLISION_GEOM_QUAT_PRECISION 32767.f
 
+#include "Speed/Indep/Libs/Support/Utility/FastMem.h"
 #include "Speed/Indep/Libs/Support/Utility/UCOM.h"
+#include "Speed/Indep/Libs/Support/Utility/UCollections.h"
 #include "Speed/Indep/Libs/Support/Utility/UCrc.h"
 #include "Speed/Indep/Src/Sim/SimSurface.h"
+#include "Speed/Indep/bWare/Inc/bChunk.hpp"
+#include "Speed/Indep/bWare/Inc/bList.hpp"
+
+DECLARE_CONTAINER_TYPE(CollisionBoundsTable);
 
 namespace CollisionGeometry {
 
@@ -35,7 +41,6 @@ struct _V3c {
         to.z = static_cast<float>(z) / COLLISION_GEOM_VECTOR_PRESSICION;
     }
 
-  private:
     int16 x; // offset 0x0, size 0x2
     int16 y; // offset 0x2, size 0x2
     int16 z; // offset 0x4, size 0x2
@@ -50,7 +55,6 @@ struct _Q4c {
         to.w = static_cast<float>(this->w) / COLLISION_GEOM_QUAT_PRECISION;
     }
 
-  private:
     int16 x; // offset 0x0, size 0x2
     int16 y; // offset 0x2, size 0x2
     int16 z; // offset 0x4, size 0x2
@@ -82,8 +86,12 @@ struct Bounds {
         this->fPivot.Decompress(to);
     }
 
+    void GetPosition(UMath::Vector3 &to) const {
+        this->fPosition.Decompress(to);
+    }
+
     void GetHalfDimensions(UMath::Vector3 &to) const {
-        fHalfDimensions.Decompress(to);
+        this->fHalfDimensions.Decompress(to);
     }
 
     const Bounds *GetChild(unsigned int idx) const;
@@ -124,20 +132,104 @@ class IBoundable : public UTL::COM::IUnknown {
 
 // total size: 0x10
 struct Collection : public BoundsHeader {
-    Bounds *const GetRoot() const;
+    Bounds *GetBounds() {
+        return reinterpret_cast<Bounds *>(this + 1);
+    }
+
+    const Bounds *GetBounds() const {
+        return reinterpret_cast<const Bounds *>(this + 1);
+    }
+
+    PCloudHeader *GetPCHeader();
+    const PCloudHeader *GetPCHeader() const;
+    PCloud *GetPCloud();
+    const PCloud *GetPCloud() const;
+
+    const Bounds *GetRoot() const;
     const Bounds *GetChild(const Bounds *parent, unsigned int idx) const;
     const Bounds *GetChild(const Bounds *parent, UCrc32 name) const;
+    const PCloud *GetPointCloud(const Bounds *parent) const;
 
-    Bounds *const GetBounds(UCrc32 hash_name) const;
+    const Bounds *GetBounds(UCrc32 hash_name) const;
+    void Init();
     bool AddTo(IBoundable *irbc, const Bounds *root, const SimSurface &defsurface, bool parsechildren) const;
+    bool AddNode(IBoundable *iboundable, const Bounds *geom, const SimSurface &defsurface, bool ischild) const;
 };
 
 inline const Bounds *Bounds::GetChild(unsigned int idx) const {
-    return fCollection->GetChild(this, idx);
+    return this->fCollection->GetChild(this, idx);
 }
+
 inline const Bounds *Bounds::GetChild(UCrc32 namehash) const {
-    return fCollection->GetChild(this, namehash);
+    return this->fCollection->GetChild(this, namehash);
 }
+
+inline PCloudHeader *Collection::GetPCHeader() {
+    return reinterpret_cast<PCloudHeader *>(&this->GetBounds()[this->fNumBounds]);
+}
+
+inline const PCloudHeader *Collection::GetPCHeader() const {
+    return reinterpret_cast<const PCloudHeader *>(&this->GetBounds()[this->fNumBounds]);
+}
+
+inline PCloud *Collection::GetPCloud() {
+    return reinterpret_cast<PCloud *>(this->GetPCHeader() + 1);
+}
+
+inline const PCloud *Collection::GetPCloud() const {
+    return reinterpret_cast<const PCloud *>(this->GetPCHeader() + 1);
+}
+
+// total size: 0x1C
+class BoundsPack : public bTNode<BoundsPack> {
+    // total size: 0x8
+    struct Pair {
+        Pair(UCrc32 name, struct Collection *collection) : Name(name), Collection(collection) {}
+
+        bool operator<(const Pair &rhs) const {
+            return this->Name < rhs.Name;
+        }
+
+        UCrc32 Name;                   // offset 0x0, size 0x4
+        struct Collection *Collection; // offset 0x4, size 0x4
+    };
+
+    class Table : public _STL::vector<Pair, UTL::Std::Allocator<Pair, _type_CollisionBoundsTable> > {
+      public:
+        void Add(Collection *collection) {
+            Pair pair(collection->fNameHash, collection);
+            iterator pos = _STL::upper_bound(this->begin(), this->end(), pair);
+            this->insert(pos, pair);
+        }
+
+        Collection *Find(UCrc32 name);
+    };
+
+  public:
+    USE_FASTALLOC(BoundsPack);
+
+    BoundsPack(bChunk *pack);
+
+    const bChunk *GetHeader() const {
+        return this->mChunk;
+    }
+
+    const Collection *Find(UCrc32 name) {
+        return this->mTable.Find(UCrc32(name));
+    }
+
+  private:
+    const bChunk *mChunk; // offset 0x8, size 0x4
+    Table mTable;         // offset 0xC, size 0x10
+};
+
+// total size: 0x8
+struct Collections : public bTList<BoundsPack> {
+    ~Collections() {}
+
+    BoundsPack *Find(const bChunk *header);
+    const Collection *Find(UCrc32 name);
+};
 
 const Collection *Lookup(UCrc32 object_name_hash);
 bool CreateJoint(IBoundable *ifemale, struct UCrc32 femalenode_name, IBoundable *imale, UCrc32 malenode_name, UMath::Vector3 *out_female,

--- a/src/Speed/Indep/Src/Physics/Common/Behavior.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Behavior.cpp
@@ -2,6 +2,17 @@
 #include "Speed/Indep/Src/Generated/AttribSys/GenericAccessor.h"
 #include "Speed/Indep/Src/Physics/PhysicsObject.h"
 
+Attrib::StringKey BEHAVIOR_MECHANIC_AI("BEHAVIOR_MECHANIC_AI");
+Attrib::StringKey BEHAVIOR_MECHANIC_RIGIDBODY("BEHAVIOR_MECHANIC_RIGIDBODY");
+Attrib::StringKey BEHAVIOR_MECHANIC_INPUT("BEHAVIOR_MECHANIC_INPUT");
+Attrib::StringKey BEHAVIOR_MECHANIC_SUSPENSION("BEHAVIOR_MECHANIC_SUSPENSION");
+Attrib::StringKey BEHAVIOR_MECHANIC_ENGINE("BEHAVIOR_MECHANIC_ENGINE");
+Attrib::StringKey BEHAVIOR_MECHANIC_DAMAGE("BEHAVIOR_MECHANIC_DAMAGE");
+Attrib::StringKey BEHAVIOR_MECHANIC_DRAW("BEHAVIOR_MECHANIC_DRAW");
+Attrib::StringKey BEHAVIOR_MECHANIC_AUDIO("BEHAVIOR_MECHANIC_AUDIO");
+Attrib::StringKey BEHAVIOR_MECHANIC_EFFECTS("BEHAVIOR_MECHANIC_EFFECTS");
+Attrib::StringKey BEHAVIOR_MECHANIC_RESET("BEHAVIOR_MECHANIC_RESET");
+
 Behavior::Behavior(const BehaviorParams &params, unsigned int num_interfaces)
     : Sim::Object(num_interfaces + 1),   //
       mPaused(false),                    //

--- a/src/Speed/Indep/Src/Physics/Common/Behavior.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Behavior.cpp
@@ -1,0 +1,33 @@
+#include "Speed/Indep/Src/Physics/Behavior.h"
+#include "Speed/Indep/Src/Generated/AttribSys/GenericAccessor.h"
+#include "Speed/Indep/Src/Physics/PhysicsObject.h"
+
+Behavior::Behavior(const BehaviorParams &params, unsigned int num_interfaces)
+    : Sim::Object(num_interfaces + 1),   //
+      mPaused(false),                    //
+      mOwner(params.fowner),             //
+      mIOwner(params.fowner),            //
+      mMechanic(params.fMechanic),       //
+      mSignature(params.fSig),           //
+      mPriority(0),                      //
+      mProfile(nullptr) {
+    const Attrib::Instance &attribs = params.fowner->GetAttributes();
+    unsigned int count = attribs->Num_BEHAVIOR_ORDER();
+    while (this->mPriority < count) {
+        if (attribs->BEHAVIOR_ORDER(this->mPriority) == this->mMechanic) {
+            break;
+        }
+        this->mPriority = this->mPriority + 1;
+    }
+}
+
+void Behavior::Pause(bool pause) {
+    if (this->mPaused != pause) {
+        this->mPaused = pause;
+        if (pause) {
+            this->OnPause();
+        } else {
+            this->OnUnPause();
+        }
+    }
+}

--- a/src/Speed/Indep/Src/Physics/Common/Bounds.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Bounds.cpp
@@ -16,7 +16,7 @@ namespace CollisionGeometry {
 static Collections TheCollections;
 
 inline Collection *BoundsPack::Table::Find(UCrc32 name) {
-    Pair *iter = std::lower_bound(this->begin(), this->end(), Pair(name, nullptr));
+    iterator iter = std::lower_bound(this->begin(), this->end(), Pair(name, nullptr));
     if (iter != this->end() && iter->Name == name) {
         return iter->Collection;
     }

--- a/src/Speed/Indep/Src/Physics/Common/Bounds.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Bounds.cpp
@@ -1,5 +1,6 @@
 #include "Speed/Indep/Src/Physics/Bounds.h"
 #include "Speed/Indep/Libs/Support/Utility/UMath.h"
+#include "Speed/Indep/Src/Physics/Behaviors/RigidBody.h"
 #include "Speed/Indep/Src/Physics/Dynamics.h"
 #include "Speed/Indep/bWare/Inc/bWare.hpp"
 
@@ -242,6 +243,135 @@ bool Collection::AddNode(IBoundable *iboundable, const Bounds *geom, const SimSu
     }
 
     return result;
+}
+
+bool CreateJoint(IBoundable *ifemale, UCrc32 femalenode_name, IBoundable *imale, UCrc32 malenode_name, UMath::Vector3 *out_female,
+                 UMath::Vector3 *out_male, unsigned int joint_flags) {
+    const Bounds *female_node = ifemale->GetGeometryNode();
+    const Bounds *male_node = imale->GetGeometryNode();
+
+    if (female_node == nullptr || male_node == nullptr) {
+        return false;
+    }
+
+    IDynamicsEntity *ide_female;
+    if (!ifemale->QueryInterface(&ide_female)) {
+        return false;
+    }
+
+    IDynamicsEntity *ide_male;
+    if (!imale->QueryInterface(&ide_male)) {
+        return false;
+    }
+
+    const Bounds *male_connector = nullptr;
+    for (unsigned int i = 0; i < male_node->fNumChildren; i++) {
+        const Bounds *child = male_node->GetChild(i);
+        if (child->fNameHash == malenode_name && (child->fFlags & kBounds_Joint_Male)) {
+            male_connector = child;
+            break;
+        }
+    }
+
+    if (male_connector == nullptr) {
+        return false;
+    }
+
+    const Bounds *female_connector = nullptr;
+    for (unsigned int i = 0; i < female_node->fNumChildren; i++) {
+        const Bounds *child = female_node->GetChild(i);
+        if (child->fNameHash == femalenode_name && (child->fFlags & kBounds_Joint_Female)) {
+            female_connector = child;
+            break;
+        }
+    }
+
+    if (female_connector == nullptr) {
+        return false;
+    }
+
+    UMath::Vector3 lever_male;
+    UMath::Vector3 lever_female;
+    male_connector->GetPosition(lever_male);
+    female_connector->GetPosition(lever_female);
+
+    if (out_female != nullptr) {
+        *out_female = lever_female;
+    }
+    if (out_male != nullptr) {
+        *out_male = lever_male;
+    }
+
+    Dynamics::Articulation::HJOINT__ *hjoint = Dynamics::Articulation::Create(ide_female, lever_female, ide_male, lever_male,
+                                                                             static_cast<Dynamics::Articulation::eJointFlags>(joint_flags));
+    if (hjoint == nullptr) {
+        return false;
+    }
+
+    static UMath::Matrix4 fix;
+    fix.v0 = UMath::Vector4Make(1.0f, 0.0f, 0.0f, 0.0f);
+    fix.v1 = UMath::Vector4Make(0.0f, 0.0f, -1.0f, 0.0f);
+    fix.v2 = UMath::Vector4Make(0.0f, 1.0f, 0.0f, 0.0f);
+    fix.v3 = UMath::Vector4Make(0.0f, 0.0f, 0.0f, 1.0f);
+
+    for (unsigned int i = 0; i < female_connector->fNumChildren; i++) {
+        const Bounds *constraint = female_connector->GetChild(i);
+        if ((constraint->fFlags & (kBounds_Constraint_Conical | kBounds_Constraint_Prismatic)) == 0) {
+            continue;
+        }
+
+        const Bounds *post = nullptr;
+        for (unsigned int j = 0; j < male_connector->fNumChildren; j++) {
+            const Bounds *malechild = male_connector->GetChild(j);
+            if ((malechild->fFlags & kBounds_Male_Post) && malechild->fNameHash == constraint->fNameHash) {
+                post = malechild;
+                break;
+            }
+        }
+
+        if (post == nullptr) {
+            continue;
+        }
+
+        UMath::Vector4 q;
+        UMath::Matrix4 constraint_mat;
+        UMath::Vector3 constraint_dim;
+        UMath::Vector4 constraint_orientation;
+        UMath::Vector4 female_connector_orientation;
+
+        constraint->GetHalfDimensions(constraint_dim);
+        constraint->GetOrientation(constraint_orientation);
+        female_connector->GetOrientation(female_connector_orientation);
+        UMath::Mult(female_connector_orientation, constraint_orientation, q);
+        UMath::QuaternionToMatrix4(q, constraint_mat);
+        UMath::Mult(fix, constraint_mat, constraint_mat);
+
+        UMath::Matrix4 post_mat;
+        UMath::Vector3 post_dim;
+        UMath::Vector4 post_orientation;
+        UMath::Vector4 male_connector_orientation;
+
+        post->GetHalfDimensions(post_dim);
+        post->GetOrientation(post_orientation);
+        male_connector->GetOrientation(male_connector_orientation);
+        UMath::Mult(male_connector_orientation, post_orientation, q);
+        UMath::QuaternionToMatrix4(q, post_mat);
+        UMath::Mult(fix, post_mat, post_mat);
+
+        if (constraint->fFlags & kBounds_Constraint_Conical) {
+            UMath::Vector3 post = UMath::Vector4To3(post_mat.v2);
+            UMath::Scale(post, post_dim.y + post_dim.y);
+            float angle = UMath::Atan2d(constraint_dim.x, constraint_dim.y + constraint_dim.y);
+            Dynamics::Articulation::Constrain(hjoint, ide_female, constraint_mat, angle, angle, post, Dynamics::Articulation::CONICAL);
+        } else if (constraint->fFlags & kBounds_Constraint_Prismatic) {
+            UMath::Vector3 post = UMath::Vector4To3(post_mat.v2);
+            UMath::Scale(post, post_dim.y + post_dim.y);
+            float angle = UMath::Atan2d(constraint_dim.x, constraint_dim.y + constraint_dim.y);
+            Dynamics::Articulation::Constrain(hjoint, ide_female, constraint_mat, angle, angle, post, Dynamics::Articulation::PRISMATIC);
+        }
+    }
+
+    return true;
 }
 
 const Collection *Lookup(UCrc32 object_name_hash) {

--- a/src/Speed/Indep/Src/Physics/Common/Bounds.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Bounds.cpp
@@ -1,0 +1,280 @@
+#include "Speed/Indep/Src/Physics/Bounds.h"
+#include "Speed/Indep/Libs/Support/Utility/UMath.h"
+#include "Speed/Indep/Src/Physics/Dynamics.h"
+#include "Speed/Indep/bWare/Inc/bWare.hpp"
+
+inline void bPlatEndianSwap(UMath::Vector4 *v) {
+    ::bPlatEndianSwap(&v->x);
+    ::bPlatEndianSwap(&v->y);
+    ::bPlatEndianSwap(&v->z);
+    ::bPlatEndianSwap(&v->w);
+}
+
+namespace CollisionGeometry {
+
+static Collections TheCollections;
+
+BoundsPack::BoundsPack(bChunk *pack) : mChunk(pack) {
+    bChunk *last_chunk = reinterpret_cast<bChunk *>(reinterpret_cast<char *>(pack) + pack->Size + 8);
+    int count = 0;
+    for (bChunk *chunk = pack->GetFirstChunk(); chunk < last_chunk; chunk = chunk->GetNext()) {
+        count = count + 1;
+    }
+    this->mTable.reserve(count);
+
+    for (bChunk *chunk = pack->GetFirstChunk(); chunk < last_chunk; chunk = chunk->GetNext()) {
+        BoundsHeader *pheader = reinterpret_cast<BoundsHeader *>(chunk->GetAlignedData(16));
+        UCrc32 name(pheader->fNameHash);
+        ::bPlatEndianSwap(&name);
+
+        Collection *collection = this->mTable.Find(UCrc32(name));
+        if (collection == nullptr) {
+            collection = reinterpret_cast<Collection *>(pheader);
+            collection->Init();
+            this->mTable.Add(collection);
+        }
+    }
+}
+
+inline Collection *BoundsPack::Table::Find(UCrc32 name) {
+    Pair *iter = _STL::lower_bound(this->begin(), this->end(), Pair(name, nullptr));
+    if (iter != this->end() && iter->Name == name) {
+        return iter->Collection;
+    }
+    return nullptr;
+}
+
+BoundsPack *Collections::Find(const bChunk *header) {
+    for (BoundsPack *pack = this->GetHead(); pack != this->EndOfList(); pack = pack->GetNext()) {
+        if (pack->GetHeader() == header) {
+            return pack;
+        }
+    }
+    return nullptr;
+}
+
+const Collection *Collections::Find(UCrc32 name) {
+    for (BoundsPack *pack = this->GetHead(); pack != this->EndOfList(); pack = pack->GetNext()) {
+        const Collection *collection = pack->Find(UCrc32(name));
+        if (collection != nullptr) {
+            return collection;
+        }
+    }
+    return nullptr;
+}
+
+const Bounds *Collection::GetRoot() const {
+    if (this->fNumBounds > 0) {
+        return this->GetBounds();
+    }
+    return nullptr;
+}
+
+const Bounds *Collection::GetChild(const Bounds *parent, UCrc32 name) const {
+    if (parent->fChildIndex >= 0) {
+        for (int idx = 0; idx < static_cast<int>(parent->fNumChildren); idx++) {
+            const Bounds *bnds = &this->GetBounds()[parent->fChildIndex + idx];
+            if (bnds->fNameHash == name) {
+                return bnds;
+            }
+        }
+    }
+    return nullptr;
+}
+
+const Bounds *Collection::GetChild(const Bounds *parent, unsigned int idx) const {
+    if (idx < parent->fNumChildren && parent->fChildIndex >= 0) {
+        return &this->GetBounds()[parent->fChildIndex + idx];
+    }
+    return nullptr;
+}
+
+const PCloud *Collection::GetPointCloud(const Bounds *parent) const {
+    if (this->GetPCHeader()->fNumPClouds > 0 && parent->fPCloudIndex >= 0) {
+        const PCloud *pcloud = this->GetPCloud();
+        for (int i = 0; i < this->GetPCHeader()->fNumPClouds; i++) {
+            if (i == static_cast<int>(parent->fPCloudIndex)) {
+                return pcloud;
+            }
+            pcloud = reinterpret_cast<const PCloud *>(pcloud->fPList + pcloud->fNumVerts);
+        }
+    }
+    return nullptr;
+}
+
+const Bounds *Collection::GetBounds(UCrc32 hash_name) const {
+    if (hash_name != UCrc32::kNull) {
+        for (int i = 0; i < this->fNumBounds; i++) {
+            if (this->GetBounds()[i].fNameHash == hash_name) {
+                return &this->GetBounds()[i];
+            }
+        }
+    }
+    return nullptr;
+}
+
+void Collection::Init() {
+    if (this->fIsResolved == 0) {
+        ::bPlatEndianSwap(&this->fNameHash);
+        ::bPlatEndianSwap(&this->fNumBounds);
+        if (this->fIsResolved == 0) {
+            int i;
+            PCloud *pcloud;
+            for (i = 0; i < this->fNumBounds; i++) {
+                Bounds &bounds = this->GetBounds()[i];
+                ::bPlatEndianSwap(&bounds.fPosition.x);
+                ::bPlatEndianSwap(&bounds.fPosition.y);
+                ::bPlatEndianSwap(&bounds.fPosition.z);
+                ::bPlatEndianSwap(&bounds.fHalfDimensions.x);
+                ::bPlatEndianSwap(&bounds.fHalfDimensions.y);
+                ::bPlatEndianSwap(&bounds.fHalfDimensions.z);
+                ::bPlatEndianSwap(&bounds.fOrientation.x);
+                ::bPlatEndianSwap(&bounds.fOrientation.y);
+                ::bPlatEndianSwap(&bounds.fOrientation.z);
+                ::bPlatEndianSwap(&bounds.fOrientation.w);
+                ::bPlatEndianSwap(&bounds.fPivot.x);
+                ::bPlatEndianSwap(&bounds.fPivot.y);
+                ::bPlatEndianSwap(&bounds.fPivot.z);
+                ::bPlatEndianSwap(&bounds.fChildIndex);
+                ::bPlatEndianSwap(&bounds.fRadius);
+                ::bPlatEndianSwap(&bounds.fFlags);
+                ::bPlatEndianSwap(&bounds.fNameHash);
+                ::bPlatEndianSwap(&bounds.fSurface);
+            }
+            ::bPlatEndianSwap(&this->GetPCHeader()->fNumPClouds);
+            pcloud = this->GetPCloud();
+            i = 0;
+            while (i < this->GetPCHeader()->fNumPClouds) {
+                ::bPlatEndianSwap(&pcloud->fNumVerts);
+                i = i + 1;
+                pcloud->fPList = reinterpret_cast<UMath::Vector4 *>(pcloud + 1);
+                for (int j = 0; j < pcloud->fNumVerts; j++) {
+                    ::bPlatEndianSwap(&pcloud->fPList[j]);
+                }
+                pcloud = reinterpret_cast<PCloud *>(pcloud->fPList + pcloud->fNumVerts);
+            }
+            this->fIsResolved = 1;
+        }
+    } else {
+        PCloud *pcloud = this->GetPCloud();
+        for (int i = 0; i < this->GetPCHeader()->fNumPClouds; i++) {
+            pcloud->fPList = reinterpret_cast<UMath::Vector4 *>(pcloud + 1);
+            pcloud = reinterpret_cast<PCloud *>(pcloud->fPList + pcloud->fNumVerts);
+        }
+    }
+
+    for (int i = 0; i < this->fNumBounds; i++) {
+        this->GetBounds()[i].fCollection = this;
+    }
+}
+
+bool Collection::AddTo(IBoundable *irbc, const Bounds *root, const SimSurface &defsurface, bool parsechildren) const {
+    bool added = false;
+    if (root != nullptr) {
+        if (parsechildren && root->fNumChildren != 0) {
+            for (unsigned int i = 0; i < root->fNumChildren; i++) {
+                const Bounds *geom = this->GetChild(root, i);
+                if (this->AddNode(irbc, geom, defsurface, true)) {
+                    added = true;
+                }
+            }
+        }
+        if (!added) {
+            if (this->AddNode(irbc, root, defsurface, false)) {
+                added = true;
+            }
+        }
+    }
+    return added;
+}
+
+bool Collection::AddNode(IBoundable *iboundable, const Bounds *geom, const SimSurface &defsurface, bool ischild) const {
+    bool result = false;
+    UMath::Vector3 offset;
+    UMath::Vector3 dim;
+    UMath::Vector4 orientation;
+    UMath::Matrix4 invmat;
+
+    geom->GetHalfDimensions(dim);
+    geom->GetPosition(offset);
+    geom->GetOrientation(orientation);
+
+    invmat = UMath::Matrix4::kIdentity;
+    SimSurface surface(defsurface);
+    unsigned short flags = geom->fFlags;
+
+    if (geom->fSurface.GetValue() != 0) {
+        SimSurface found(SimSurface::Lookup(geom->fSurface));
+        surface.Change(found.GetConstCollection());
+        if (surface.GetConstCollection() == SimSurface::kNull.GetConstCollection()) {
+            surface.Change(defsurface.GetConstCollection());
+        }
+    }
+
+    if (ischild && (flags & kBounds_Internal)) {
+        result = false;
+    } else {
+        if (!ischild) {
+            UMath::QuaternionToMatrix4(orientation, invmat);
+            invmat[3].x = offset.x;
+            invmat[3].y = offset.y;
+            invmat[3].z = offset.z;
+            invmat[3].w = 1.0f;
+            OrthoInverse(invmat);
+            offset = UMath::Vector3::kZero;
+            orientation = UMath::Vector4::kIdentity;
+        }
+
+        if (flags & (kBounds_PrimVsWorld | kBounds_PrimVsObjects | kBounds_PrimVsGround)) {
+            if (iboundable->AddCollisionPrimitive(geom->fNameHash, dim, geom->fRadius, offset, surface, orientation,
+                                                  static_cast<BoundFlags>(flags))) {
+                result = true;
+            }
+        }
+
+        const PCloud *pcloud;
+        if ((flags & kBounds_MeshVsGround) && (pcloud = this->GetPointCloud(geom)) != nullptr && pcloud->fNumVerts > 0) {
+            if (ischild) {
+                iboundable->AddCollisionMesh(geom->fNameHash, pcloud->fPList, pcloud->fNumVerts, surface, static_cast<BoundFlags>(flags), true);
+            } else {
+                UMath::Vector4 tmp[16];
+                int i = 0;
+                do {
+                    UMath::Vector4 in = pcloud->fPList[i];
+                    UMath::RotateTranslate(in, invmat, tmp[i]);
+                    i++;
+                } while (i < pcloud->fNumVerts);
+                iboundable->AddCollisionMesh(geom->fNameHash, tmp, pcloud->fNumVerts, surface, static_cast<BoundFlags>(flags), false);
+            }
+            result = true;
+        }
+    }
+
+    return result;
+}
+
+const Collection *Lookup(UCrc32 object_name_hash) {
+    return TheCollections.Find(UCrc32(object_name_hash));
+}
+
+}; // namespace CollisionGeometry
+
+int LoaderBounds(bChunk *chunk) {
+    if (chunk->GetID() != 0x8003b900) {
+        return 0;
+    }
+    CollisionGeometry::TheCollections.AddHead(new CollisionGeometry::BoundsPack(chunk));
+    return 1;
+}
+
+int UnloaderBounds(bChunk *chunk) {
+    if (chunk->GetID() != 0x8003b900) {
+        return 0;
+    }
+    CollisionGeometry::BoundsPack *pack = CollisionGeometry::TheCollections.Find(chunk);
+    if (pack != nullptr) {
+        CollisionGeometry::TheCollections.Remove(pack);
+        delete pack;
+    }
+    return 1;
+}

--- a/src/Speed/Indep/Src/Physics/Common/Bounds.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Bounds.cpp
@@ -11,9 +11,9 @@ inline void bPlatEndianSwap(UMath::Vector4 *v) {
     ::bPlatEndianSwap(&v->w);
 }
 
-namespace CollisionGeometry {
+static CollisionGeometry::Collections TheCollections;
 
-static Collections TheCollections;
+namespace CollisionGeometry {
 
 inline Collection *BoundsPack::Table::Find(UCrc32 name) {
     iterator iter = std::lower_bound(this->begin(), this->end(), Pair(name, nullptr));
@@ -384,7 +384,7 @@ int LoaderBounds(bChunk *chunk) {
     if (chunk->GetID() != 0x8003b900) {
         return 0;
     }
-    CollisionGeometry::TheCollections.AddHead(new CollisionGeometry::BoundsPack(chunk));
+    TheCollections.AddHead(new CollisionGeometry::BoundsPack(chunk));
     return 1;
 }
 
@@ -392,9 +392,9 @@ int UnloaderBounds(bChunk *chunk) {
     if (chunk->GetID() != 0x8003b900) {
         return 0;
     }
-    CollisionGeometry::BoundsPack *pack = CollisionGeometry::TheCollections.Find(chunk);
+    CollisionGeometry::BoundsPack *pack = TheCollections.Find(chunk);
     if (pack != nullptr) {
-        CollisionGeometry::TheCollections.Remove(pack);
+        TheCollections.Remove(pack);
         delete pack;
     }
     return 1;

--- a/src/Speed/Indep/Src/Physics/Common/Bounds.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Bounds.cpp
@@ -192,53 +192,50 @@ bool Collection::AddNode(IBoundable *iboundable, const Bounds *geom, const SimSu
     geom->GetHalfDimensions(dim);
     geom->GetPosition(offset);
     geom->GetOrientation(orientation);
-
     invmat = UMath::Matrix4::kIdentity;
     SimSurface surface(defsurface);
-    unsigned short flags = geom->fFlags;
 
     if (geom->fSurface.GetValue() != 0) {
-        SimSurface found(SimSurface::Lookup(geom->fSurface));
-        surface.Change(found.GetConstCollection());
-        if (surface.GetConstCollection() == SimSurface::kNull.GetConstCollection()) {
-            surface.Change(defsurface.GetConstCollection());
+        surface = SimSurface(SimSurface::Lookup(geom->fSurface));
+        if (surface == SimSurface::kNull) {
+            surface = defsurface;
         }
     }
 
-    if (ischild && (flags & kBounds_Internal)) {
+    if (ischild == true && (geom->fFlags & kBounds_Internal)) {
         result = false;
-    } else {
-        if (!ischild) {
-            UMath::QuaternionToMatrix4(orientation, invmat);
-            invmat[3].x = offset.x;
-            invmat[3].y = offset.y;
-            invmat[3].z = offset.z;
-            invmat[3].w = 1.0f;
-            OrthoInverse(invmat);
-            offset = UMath::Vector3::kZero;
-            orientation = UMath::Vector4::kIdentity;
-        }
+        return result;
+    }
 
-        if (flags & (kBounds_PrimVsWorld | kBounds_PrimVsObjects | kBounds_PrimVsGround)) {
-            if (iboundable->AddCollisionPrimitive(geom->fNameHash, dim, geom->fRadius, offset, surface, orientation,
-                                                  static_cast<BoundFlags>(flags))) {
-                result = true;
-            }
-        }
+    if (!ischild) {
+        UMath::QuaternionToMatrix4(orientation, invmat);
+        invmat.v3 = UMath::Vector4Make(offset, 1.0f);
+        OrthoInverse(invmat);
+        offset = UMath::Vector3::kZero;
+        orientation = UMath::Vector4::kIdentity;
+    }
 
-        const PCloud *pcloud;
-        if ((flags & kBounds_MeshVsGround) && (pcloud = this->GetPointCloud(geom)) != nullptr && pcloud->fNumVerts > 0) {
-            if (ischild) {
-                iboundable->AddCollisionMesh(geom->fNameHash, pcloud->fPList, pcloud->fNumVerts, surface, static_cast<BoundFlags>(flags), true);
-            } else {
+    if (geom->fFlags & (kBounds_PrimVsWorld | kBounds_PrimVsObjects | kBounds_PrimVsGround)) {
+        if (iboundable->AddCollisionPrimitive(geom->fNameHash, dim, geom->fRadius, offset, surface, orientation,
+                                              static_cast<BoundFlags>(geom->fFlags))) {
+            result = true;
+        }
+    }
+
+    if (geom->fFlags & kBounds_MeshVsGround) {
+        const PCloud *pcloud = this->GetPointCloud(geom);
+        if (pcloud != nullptr && pcloud->fNumVerts > 0) {
+            if (!ischild) {
                 UMath::Vector4 tmp[16];
-                int i = 0;
-                do {
+                for (int i = 0; i < pcloud->fNumVerts; i++) {
                     UMath::Vector4 in = pcloud->fPList[i];
+                    in.w = 1.0f;
                     UMath::RotateTranslate(in, invmat, tmp[i]);
-                    i++;
-                } while (i < pcloud->fNumVerts);
-                iboundable->AddCollisionMesh(geom->fNameHash, tmp, pcloud->fNumVerts, surface, static_cast<BoundFlags>(flags), false);
+                }
+                iboundable->AddCollisionMesh(geom->fNameHash, tmp, pcloud->fNumVerts, surface, static_cast<BoundFlags>(geom->fFlags), false);
+            } else {
+                iboundable->AddCollisionMesh(geom->fNameHash, pcloud->fPList, pcloud->fNumVerts, surface, static_cast<BoundFlags>(geom->fFlags),
+                                             true);
             }
             result = true;
         }

--- a/src/Speed/Indep/Src/Physics/Common/Bounds.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Bounds.cpp
@@ -14,34 +14,35 @@ namespace CollisionGeometry {
 
 static Collections TheCollections;
 
-BoundsPack::BoundsPack(bChunk *pack) : mChunk(pack) {
-    bChunk *last_chunk = reinterpret_cast<bChunk *>(reinterpret_cast<char *>(pack) + pack->Size + 8);
-    int count = 0;
-    for (bChunk *chunk = pack->GetFirstChunk(); chunk < last_chunk; chunk = chunk->GetNext()) {
-        count = count + 1;
-    }
-    this->mTable.reserve(count);
-
-    for (bChunk *chunk = pack->GetFirstChunk(); chunk < last_chunk; chunk = chunk->GetNext()) {
-        BoundsHeader *pheader = reinterpret_cast<BoundsHeader *>(chunk->GetAlignedData(16));
-        UCrc32 name(pheader->fNameHash);
-        ::bPlatEndianSwap(&name);
-
-        Collection *collection = this->mTable.Find(UCrc32(name));
-        if (collection == nullptr) {
-            collection = reinterpret_cast<Collection *>(pheader);
-            collection->Init();
-            this->mTable.Add(collection);
-        }
-    }
-}
-
 inline Collection *BoundsPack::Table::Find(UCrc32 name) {
     Pair *iter = _STL::lower_bound(this->begin(), this->end(), Pair(name, nullptr));
     if (iter != this->end() && iter->Name == name) {
         return iter->Collection;
     }
     return nullptr;
+}
+
+BoundsPack::BoundsPack(bChunk *pack) : mChunk(pack) {
+    bChunk *chunk;
+    int count = 0;
+    bChunk *last_chunk = pack->GetLastChunk();
+    for (chunk = pack->GetFirstChunk(); chunk < last_chunk; chunk = chunk->GetNext()) {
+        count = count + 1;
+    }
+    this->mTable.reserve(count);
+
+    for (chunk = pack->GetFirstChunk(); chunk < last_chunk; chunk = chunk->GetNext()) {
+        BoundsHeader *pheader = reinterpret_cast<BoundsHeader *>(chunk->GetAlignedData(16));
+        UCrc32 name(pheader->fNameHash);
+        if (pheader->fIsResolved == 0) {
+            ::bPlatEndianSwap(&name);
+        }
+
+        if (this->mTable.Find(UCrc32(name)) == nullptr) {
+            reinterpret_cast<Collection *>(pheader)->Init();
+            this->mTable.Add(reinterpret_cast<Collection *>(pheader));
+        }
+    }
 }
 
 BoundsPack *Collections::Find(const bChunk *header) {
@@ -117,44 +118,37 @@ void Collection::Init() {
     if (this->fIsResolved == 0) {
         ::bPlatEndianSwap(&this->fNameHash);
         ::bPlatEndianSwap(&this->fNumBounds);
-        if (this->fIsResolved == 0) {
-            int i;
-            PCloud *pcloud;
-            for (i = 0; i < this->fNumBounds; i++) {
-                Bounds &bounds = this->GetBounds()[i];
-                ::bPlatEndianSwap(&bounds.fPosition.x);
-                ::bPlatEndianSwap(&bounds.fPosition.y);
-                ::bPlatEndianSwap(&bounds.fPosition.z);
-                ::bPlatEndianSwap(&bounds.fHalfDimensions.x);
-                ::bPlatEndianSwap(&bounds.fHalfDimensions.y);
-                ::bPlatEndianSwap(&bounds.fHalfDimensions.z);
-                ::bPlatEndianSwap(&bounds.fOrientation.x);
-                ::bPlatEndianSwap(&bounds.fOrientation.y);
-                ::bPlatEndianSwap(&bounds.fOrientation.z);
-                ::bPlatEndianSwap(&bounds.fOrientation.w);
-                ::bPlatEndianSwap(&bounds.fPivot.x);
-                ::bPlatEndianSwap(&bounds.fPivot.y);
-                ::bPlatEndianSwap(&bounds.fPivot.z);
-                ::bPlatEndianSwap(&bounds.fChildIndex);
-                ::bPlatEndianSwap(&bounds.fRadius);
-                ::bPlatEndianSwap(&bounds.fFlags);
-                ::bPlatEndianSwap(&bounds.fNameHash);
-                ::bPlatEndianSwap(&bounds.fSurface);
-            }
-            ::bPlatEndianSwap(&this->GetPCHeader()->fNumPClouds);
-            pcloud = this->GetPCloud();
-            i = 0;
-            while (i < this->GetPCHeader()->fNumPClouds) {
-                ::bPlatEndianSwap(&pcloud->fNumVerts);
-                i = i + 1;
-                pcloud->fPList = reinterpret_cast<UMath::Vector4 *>(pcloud + 1);
-                for (int j = 0; j < pcloud->fNumVerts; j++) {
-                    ::bPlatEndianSwap(&pcloud->fPList[j]);
-                }
-                pcloud = reinterpret_cast<PCloud *>(pcloud->fPList + pcloud->fNumVerts);
-            }
-            this->fIsResolved = 1;
+    }
+    if (this->fIsResolved == 0) {
+        int i;
+        PCloud *pcloud;
+        for (i = 0; i < this->fNumBounds; i++) {
+            Bounds &bounds = this->GetBounds()[i];
+            bounds.fPosition.EndianSwap();
+            bounds.fHalfDimensions.EndianSwap();
+            bounds.fOrientation.EndianSwap();
+            bounds.fPivot.EndianSwap();
+            ::bPlatEndianSwap(&bounds.fNumChildren);
+            ::bPlatEndianSwap(&bounds.fChildIndex);
+            ::bPlatEndianSwap(&bounds.fRadius);
+            ::bPlatEndianSwap(&bounds.fPCloudIndex);
+            ::bPlatEndianSwap(&bounds.fFlags);
+            ::bPlatEndianSwap(&bounds.fNameHash);
+            ::bPlatEndianSwap(&bounds.fSurface);
         }
+        ::bPlatEndianSwap(&this->GetPCHeader()->fNumPClouds);
+        pcloud = this->GetPCloud();
+        i = 0;
+        while (i < this->GetPCHeader()->fNumPClouds) {
+            ::bPlatEndianSwap(&pcloud->fNumVerts);
+            i = i + 1;
+            pcloud->fPList = reinterpret_cast<UMath::Vector4 *>(pcloud + 1);
+            for (int j = 0; j < pcloud->fNumVerts; j++) {
+                ::bPlatEndianSwap(&pcloud->fPList[j]);
+            }
+            pcloud = reinterpret_cast<PCloud *>(pcloud->fPList + pcloud->fNumVerts);
+        }
+        this->fIsResolved = 1;
     } else {
         PCloud *pcloud = this->GetPCloud();
         for (int i = 0; i < this->GetPCHeader()->fNumPClouds; i++) {

--- a/src/Speed/Indep/Src/Physics/Common/Bounds.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Bounds.cpp
@@ -16,7 +16,7 @@ namespace CollisionGeometry {
 static Collections TheCollections;
 
 inline Collection *BoundsPack::Table::Find(UCrc32 name) {
-    Pair *iter = _STL::lower_bound(this->begin(), this->end(), Pair(name, nullptr));
+    Pair *iter = std::lower_bound(this->begin(), this->end(), Pair(name, nullptr));
     if (iter != this->end() && iter->Name == name) {
         return iter->Collection;
     }

--- a/src/Speed/Indep/Src/Physics/Common/Explosion.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Explosion.cpp
@@ -1,0 +1,161 @@
+#include "Speed/Indep/Src/Physics/Explosion.h"
+
+#include "Speed/Indep/Src/Interfaces/Simables/IExplodeable.h"
+#include "Speed/Indep/Src/Interfaces/Simables/IRenderable.h"
+#include "Speed/Indep/Src/Physics/Behaviors/SimpleRigidBody.h"
+#include "Speed/Indep/Src/Physics/Dynamics/Collision.h"
+
+namespace Sim {
+bool CanSpawnSimpleRigidBody(const UMath::Vector3 &position, bool highPriority);
+}
+
+static inline ISimpleBody *FindSimpleBody(ISimable *owner) {
+    return reinterpret_cast<ISimpleBody *>(
+        (*reinterpret_cast<UTL::COM::Object **>(owner))->_mInterfaces.Find((HINTERFACE)ISimpleBody::_IHandle)
+    );
+}
+
+UTL::COM::Factory<Sim::Param, ISimable, UCrc32>::Prototype _Explosion("Explosion", Explosion::Construct);
+
+ISimable *Explosion::Construct(Sim::Param params) {
+    const ExplosionParams ep(params.Fetch<ExplosionParams>(UCrc32(0xa6b47fac)));
+    if (Sim::CanSpawnSimpleRigidBody(ep.fPosition, true)) {
+        return new Explosion(ep, params);
+    }
+    return nullptr;
+}
+
+Explosion::Explosion(const ExplosionParams &params, Sim::Param sp)
+    : PhysicsObject("explosion", "default", SIMABLE_EXPLOSION, nullptr, 0) //
+    , IExplosion(this) //
+    , mExpansionSpeed(params.fExpansionSpeed) //
+    , mExpansionRadius(params.fRadius) //
+    , mSource(params.fSource) //
+    , mDamages(params.fDamage) //
+    , mTargets(params.fTargets)
+{
+    mIRBSimple = nullptr;
+    mCausality = nullptr;
+    mCauseTime = 0.0f;
+    mEffectSource = params.fEffectSource;
+
+    float start_radius = UMath::Max(0.0f, params.fStartRadius);
+    LoadBehavior(
+        UCrc32(BEHAVIOR_MECHANIC_RIGIDBODY), //
+        UCrc32("SimpleRigidBody"), //
+        RBSimpleParams(
+            params.fPosition, //
+            UMath::Vector3::kZero, //
+            UMath::Vector3::kZero, //
+            UMath::Matrix4::kIdentity, //
+            start_radius, //
+            1.0f
+        )
+    );
+
+    IModel *model = IModel::FindInstance(mSource);
+    if (model) {
+        mCausality = model->GetCausality();
+        mCauseTime = model->GetCausalityTime();
+    }
+}
+
+Explosion::~Explosion() {}
+
+void Explosion::OnBehaviorChange(const UCrc32 &mechanic) {
+    if (mechanic == UCrc32(BEHAVIOR_MECHANIC_RIGIDBODY)) {
+        bool hasbody;
+
+        mIRBSimple = FindSimpleBody(static_cast<ISimable *>(this));
+        hasbody = mIRBSimple != nullptr;
+
+        if (hasbody) {
+            mIRBSimple->ModifyFlags(0, 0xC100);
+        }
+    }
+    PhysicsObject::OnBehaviorChange(mechanic);
+}
+
+void Explosion::OnCollide(IRigidBody *other, float dT, float radius,
+                          const Dynamics::Collision::Geometry &explosion_sphere) {
+    IExplodeable *iexplodeable;
+    if (!other->QueryInterface(&iexplodeable)) {
+        return;
+    }
+
+    float total_radius = radius + other->GetRadius();
+    if (UMath::DistanceSquare(other->GetPosition(), explosion_sphere.GetPosition()) <
+        total_radius * total_radius) {
+        float targetspeed;
+        UMath::Vector3 dim;
+        UMath::Matrix4 matrix;
+        other->GetDimension(dim);
+        other->GetMatrix4(matrix);
+        Dynamics::Collision::Geometry box(matrix, other->GetPosition(), dim,
+                                          Dynamics::Collision::Geometry::BOX, UMath::Vector3::kZero);
+        if (Dynamics::Collision::Geometry::FindIntersection(&box, &explosion_sphere, &box)) {
+            iexplodeable->OnExplosion(box.GetCollisionNormal(), box.GetCollisionPoint(), dT,
+                                      static_cast<IExplosion *>(this));
+        }
+    }
+}
+
+float Explosion::GetRadius() const {
+    const IRigidBody *irb = GetRigidBody();
+    if (irb) {
+        return irb->GetRadius();
+    }
+    return 0.0f;
+}
+
+void Explosion::TestCollisions(float dT) {
+    if (!mIRBSimple) {
+        return;
+    }
+    {
+        SimCollisionMap *cmap = mIRBSimple->GetCollisionMap();
+        if (!cmap) {
+            return;
+        }
+        if (!cmap->CollisionWithAny()) {
+            return;
+        }
+
+        {
+            IRigidBody *mybody = GetRigidBody();
+            float radius = mybody->GetRadius();
+            UVector3 mydim(radius, radius, radius);
+            Dynamics::Collision::Geometry explosion_sphere(UMath::Matrix4::kIdentity, mybody->GetPosition(),
+                                                           mydim, Dynamics::Collision::Geometry::SPHERE,
+                                                           UMath::Vector3::kZero);
+
+            for (unsigned int i = 0; i < 0xA0; i++) {
+                if (!cmap->CollisionWithOrderedBody(i)) {
+                    continue;
+                }
+                IRigidBody *irb = cmap->GetOrderedBody(i);
+                if (!irb) {
+                    continue;
+                }
+                if (!mEffectSource) {
+                    IRenderable *irender;
+                    if (irb->QueryInterface(&irender) && irender->GetModelHandle() == mSource) {
+                        continue;
+                    }
+                }
+                OnCollide(irb, dT, radius, explosion_sphere);
+            }
+        }
+    }
+}
+
+void Explosion::OnTaskSimulate(float dT) {
+    IRigidBody *irb = GetRigidBody();
+    TestCollisions(dT);
+    float radius = irb->GetRadius();
+    if (mExpansionSpeed * dT + radius > mExpansionRadius) {
+        Kill();
+    } else {
+        irb->SetRadius(mExpansionSpeed * dT + radius);
+    }
+}

--- a/src/Speed/Indep/Src/Physics/Common/Explosion.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Explosion.cpp
@@ -31,15 +31,14 @@ Explosion::Explosion(const ExplosionParams &params, Sim::Param sp)
     , mExpansionSpeed(params.fExpansionSpeed) //
     , mExpansionRadius(params.fRadius) //
     , mSource(params.fSource) //
+    , mIRBSimple(nullptr) //
+    , mEffectSource(params.fEffectSource) //
+    , mCausality(nullptr) //
+    , mCauseTime(0.0f) //
     , mDamages(params.fDamage) //
     , mTargets(params.fTargets)
 {
-    mIRBSimple = nullptr;
-    mCausality = nullptr;
-    mCauseTime = 0.0f;
-    mEffectSource = params.fEffectSource;
-
-    float start_radius = UMath::Max(0.0f, params.fStartRadius);
+    float start_radius = UMath::Max(params.fStartRadius, 0.01f);
     LoadBehavior(
         UCrc32(BEHAVIOR_MECHANIC_RIGIDBODY), //
         UCrc32("SimpleRigidBody"), //

--- a/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
@@ -1555,38 +1555,37 @@ bool PVehicle::MakeRoom(IVehicleCache *whosasking, const UTL::Std::list<Resource
     return true;
 }
 
-#define IMPL_LISTABLE(TYPE, N)                                                                                                                       \
-    template <> UTL::Collections::Listable<TYPE, N>::List UTL::Collections::Listable<TYPE, N>::_mTable = UTL::Collections::Listable<TYPE, N>::List();
+namespace VehicleClass {
 
-#define IMPL_LISTABLESET(TYPE, N, ENUM, BUCKETS)                                                                                                     \
-    template <>                                                                                                                                      \
-    UTL::Collections::ListableSet<TYPE, N, ENUM, BUCKETS>::_ListSet UTL::Collections::ListableSet<TYPE, N, ENUM, BUCKETS>::_mLists =                 \
-        UTL::Collections::ListableSet<TYPE, N, ENUM, BUCKETS>::_ListSet();
+const UCrc32 CAR("CAR");
+const UCrc32 SUBMARINE("SUBMARINE");
+const UCrc32 CHOPPER("CHOPPER");
+const UCrc32 BIKE("BIKE");
+const UCrc32 BOAT("BOAT");
+const UCrc32 SNOWMOBILE("SNOWMOBILE");
+const UCrc32 HOVER("HOVER");
+const UCrc32 PLANE("PLANE");
+const UCrc32 TANK("TANK");
+const UCrc32 TRAILER("TRAILER");
+const UCrc32 TRAIN("TRAIN");
+const UCrc32 TRANSPORT("TRANSPORT");
+const UCrc32 RC("RC");
+const UCrc32 TRACTOR("TRACTOR");
 
-#define IMPL_INSTANCABLE(HANDLE, TYPE, N)                                                                                                            \
-    template <>                                                                                                                                      \
-    UTL::Collections::Instanceable<HANDLE, TYPE, N>::_List UTL::Collections::Instanceable<HANDLE, TYPE, N>::_mList =                                 \
-        UTL::Collections::Instanceable<HANDLE, TYPE, N>::_List();                                                                                     \
-    template <> unsigned int UTL::Collections::Instanceable<HANDLE, TYPE, N>::_mHNext = 0;
+}; // namespace VehicleClass
 
-IMPL_LISTABLE(IExplosion, 96)
-IMPL_LISTABLE(IDisposable, 160)
-IMPL_LISTABLESET(IVehicle, 10, eVehicleList, 10)
-IMPL_LISTABLE(IRigidBody, 160)
-IMPL_LISTABLE(ICollisionBody, 160)
-IMPL_LISTABLE(ISimpleBody, 96)
-IMPL_LISTABLESET(Sim::IEntity, 8, eEntityList, 4)
-IMPL_LISTABLESET(IPlayer, 8, ePlayerList, 3)
-IMPL_LISTABLE(IRecordablePlayer, 8)
-IMPL_LISTABLE(IInputPlayer, 8)
-IMPL_LISTABLE(IModel, 434)
-IMPL_LISTABLE(IPursuit, 8)
-IMPL_LISTABLE(IRoadBlock, 8)
-IMPL_LISTABLE(IHud, 2)
-IMPL_LISTABLE(IVehicleCache, 18)
-IMPL_LISTABLE(ITrafficCenter, 8)
-IMPL_LISTABLE(ISpikeable, 10)
-IMPL_INSTANCABLE(HSIMABLE, ISimable, 160)
-IMPL_INSTANCABLE(HACTIVITY, Sim::IActivity, 40)
-IMPL_INSTANCABLE(HMODEL, IModel, 434)
-IMPL_INSTANCABLE(HCAUSE, ICause, 10)
+AIBehaviors ai_behaviors[] = {
+    {DRIVER_NONE, UCrc32::kNull, UCrc32("AIVehicleEmpty")},
+    {DRIVER_NIS, UCrc32::kNull, UCrc32("AIVehicleEmpty")},
+    {DRIVER_RACER, UCrc32::kNull, UCrc32("AIVehicleRacecar")},
+    {DRIVER_TRAFFIC, UCrc32::kNull, UCrc32("AIVehicleTraffic")},
+    {DRIVER_COP, UCrc32("CHOPPER"), UCrc32("AIVehicleHelicopter")},
+    {DRIVER_COP, UCrc32::kNull, UCrc32("AIVehicleCopCar")},
+    {DRIVER_HUMAN, UCrc32::kNull, UCrc32("AIVehicleHuman")},
+    {DRIVER_REMOTE, UCrc32::kNull, UCrc32("AIVehicleHuman")},
+    {DRIVER_NONE, UCrc32::kNull, UCrc32::kNull},
+};
+
+UTL::COM::Factory<Sim::Param, ISimable, UCrc32>::Prototype _PVehicle("PVehicle", PVehicle::Construct);
+
+bTList<PVehicle> PVehicle::mInstances;

--- a/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
@@ -1247,12 +1247,11 @@ ISimable *PVehicle::Construct(Sim::Param params) {
     if (!attributes.IsValid()) {
         return nullptr;
     }
-    const char *vehicle_name;
+    const char *vehicle_name = attributes.CollectionName();
     const FECustomizationRecord *customizations = vp.customization;
     if (customizations == nullptr) {
-        vehicle_name = attributes.DefaultPresetRide();
-        if (vehicle_name != nullptr) {
-            PresetCar *preset = FindFEPresetCar(bStringHashUpper(vehicle_name));
+        if (attributes.DefaultPresetRide() != nullptr) {
+            PresetCar *preset = FindFEPresetCar(bStringHashUpper(attributes.DefaultPresetRide()));
             if (preset != nullptr) {
                 static FECustomizationRecord temp_record;
                 temp_record.Default();

--- a/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
@@ -761,15 +761,12 @@ bool PVehicle::SetDynamicData(const EventSequencer::System *system, EventDynamic
     data->fWorldID = static_cast<ISimable *>(this)->GetWorldID();
     IRigidBody *body = static_cast<ISimable *>(this)->GetRigidBody();
     if (body != nullptr) {
-        const UMath::Vector3 &pos = body->GetPosition();
-        data->fPosition = UMath::Vector4Make(pos, 0.0f);
         UMath::Vector3 dir;
+        data->fPosition = UMath::Vector4Make(body->GetPosition(), 0.0f);
         body->GetForwardVector(dir);
         data->fVector = UMath::Vector4Make(dir, 0.0f);
-        const UMath::Vector3 &vel = body->GetLinearVelocity();
-        data->fVelocity = UMath::Vector4Make(vel, 0.0f);
-        const UMath::Vector3 &angvel = body->GetAngularVelocity();
-        data->fAngularVelocity = UMath::Vector4Make(angvel, 0.0f);
+        data->fVelocity = UMath::Vector4Make(body->GetLinearVelocity(), 1.0f);
+        data->fAngularVelocity = UMath::Vector4Make(body->GetAngularVelocity(), 1.0f);
     }
     if (mRenderable != nullptr) {
         data->fhModel = reinterpret_cast<uintptr_t>(mRenderable->GetModelHandle());

--- a/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
@@ -68,7 +68,9 @@ unsigned int CarInfo_GetResourcePool(bool needs_compositing);
 bool IsSplitScreen();
 PresetCar *FindFEPresetCar(unsigned int hash);
 int GetMikeMannBuild();
+namespace Sim {
 bool CanSpawnRigidBody(const UMath::Vector3 &position, bool highPriority);
+} // namespace Sim
 
 namespace Physics { namespace Upgrades {
 void RemoveJunkman(Attrib::Gen::pvehicle &vehicle, Type type);
@@ -1258,11 +1260,8 @@ ISimable *PVehicle::Construct(Sim::Param params) {
                 customizations = &temp_record;
             }
         }
-        if (customizations == nullptr) {
-            return nullptr;
-        }
     }
-    if (!customizations->WriteRecordIntoPhysics(attributes)) {
+    if (customizations != nullptr && !customizations->WriteRecordIntoPhysics(attributes)) {
         return nullptr;
     }
     if (vp.matched != nullptr
@@ -1318,7 +1317,7 @@ ISimable *PVehicle::Construct(Sim::Param params) {
             performance = &perf;
         }
     }
-    if (CanSpawnRigidBody(vp.initialPos, true)) {
+    if (Sim::CanSpawnRigidBody(vp.initialPos, true)) {
         const char *cache_name;
         PVehicle *vehicle;
 #ifndef EA_BUILD_A124

--- a/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
@@ -1084,8 +1084,7 @@ void PVehicle::LoadBehaviors(const UMath::Vector3 &initialPos, const UMath::Matr
     if (mEngine != nullptr) {
         mStartingNOS = mEngine->GetNOSCapacity();
     }
-    UMath::Vector3 linearVel;
-    memset(&linearVel, 0, sizeof(UMath::Vector3));
+    UMath::Vector3 linearVel = UMath::Vector3();
     UMath::Vector3 Dimension;
     mBounds->GetHalfDimensions(Dimension);
     unsigned int collision_mask = 0;

--- a/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
@@ -1394,11 +1394,9 @@ bool PVehicle::MakeRoom(IVehicleCache *whosasking, const UTL::Std::list<Resource
     for (PVehicle *vehicle = mInstances.GetHead(); vehicle != mInstances.EndOfList();
          vehicle = vehicle->GetNext()) {
         ManageNode node;
-        node.result = VCR_DONTCARE;
-        node.resource.Flags = 0;
-        node.instancecount = 0;
         node.vehicle = vehicle;
         node.resource = vehicle->mResources;
+        node.result = VCR_DONTCARE;
         vehicle_list.push_back(node);
     }
 

--- a/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
@@ -509,10 +509,10 @@ void PVehicle::CheckOffWorld() {
     set_false:
         mOffWorld = false;
     } else {
-        float worldHeight = 0.0f;
         WCollisionMgr mgr(0, 3);
-        const UMath::Vector3 &pos = static_cast<ISimable *>(this)->GetPosition();
-        mOffWorld = !mgr.GetWorldHeightAtPointRigorous(pos, worldHeight, nullptr);
+        float worldHeight = 0.0f;
+        mOffWorld = !mgr.GetWorldHeightAtPointRigorous(
+            static_cast<ISimable *>(this)->GetPosition(), worldHeight, nullptr);
     }
 done:;
 }

--- a/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
@@ -5,6 +5,9 @@
 #include "Speed/Indep/Src/AI/AITarget.h"
 #include "Speed/Indep/Src/Camera/CameraAI.hpp"
 #include "Speed/Indep/Src/Frontend/Database/VehicleDB.hpp"
+#include "Speed/Indep/Src/Interfaces/SimActivities/IActivity.h"
+#include "Speed/Indep/Src/Interfaces/SimEntities/IEntity.h"
+#include "Speed/Indep/Src/Interfaces/Simables/IDisposable.h"
 #include "Speed/Indep/Src/Interfaces/Simables/IEffects.h"
 #include "Speed/Indep/Src/Generated/Events/EPerfectLaunch.hpp"
 #include "Speed/Indep/Src/Generated/Events/EPlayerAirborne.hpp"
@@ -18,6 +21,9 @@
 #include "Speed/Indep/Src/Interfaces/Simables/IArticulatedVehicle.h"
 #include "Speed/Indep/Src/Interfaces/Simables/ICollisionBody.h"
 #include "Speed/Indep/Src/Interfaces/Simables/IDamageable.h"
+#include "Speed/Indep/Src/Interfaces/SimActivities/IActivity.h"
+#include "Speed/Indep/Src/Interfaces/SimEntities/IEntity.h"
+#include "Speed/Indep/Src/Interfaces/Simables/IDisposable.h"
 #include "Speed/Indep/Src/Interfaces/Simables/IEffects.h"
 #include "Speed/Indep/Src/Interfaces/Simables/IEngine.h"
 #include "Speed/Indep/Src/Interfaces/Simables/IExplosion.h"
@@ -1551,10 +1557,38 @@ bool PVehicle::MakeRoom(IVehicleCache *whosasking, const UTL::Std::list<Resource
     return true;
 }
 
-template void UTL::Vector<ICollisionBody *, 16>::push_back(ICollisionBody *const &);
-template void UTL::Vector<IInputPlayer *, 16>::push_back(IInputPlayer *const &);
-template void UTL::Vector<IRecordablePlayer *, 16>::push_back(IRecordablePlayer *const &);
-template void UTL::Vector<ISpikeable *, 16>::push_back(ISpikeable *const &);
-template UTL::Collections::Listable<ITrafficCenter, 8>::List::~List();
-template UTL::Collections::Listable<ISpikeable, 10>::List::~List();
-template Behavior *UTL::COM::Factory<const BehaviorParams &, Behavior, UCrc32>::CreateInstance(UCrc32, const BehaviorParams &);
+#define IMPL_LISTABLE(TYPE, N)                                                                                                                       \
+    template <> UTL::Collections::Listable<TYPE, N>::List UTL::Collections::Listable<TYPE, N>::_mTable = UTL::Collections::Listable<TYPE, N>::List();
+
+#define IMPL_LISTABLESET(TYPE, N, ENUM, BUCKETS)                                                                                                     \
+    template <>                                                                                                                                      \
+    UTL::Collections::ListableSet<TYPE, N, ENUM, BUCKETS>::_ListSet UTL::Collections::ListableSet<TYPE, N, ENUM, BUCKETS>::_mLists =                 \
+        UTL::Collections::ListableSet<TYPE, N, ENUM, BUCKETS>::_ListSet();
+
+#define IMPL_INSTANCABLE(HANDLE, TYPE, N)                                                                                                            \
+    template <>                                                                                                                                      \
+    UTL::Collections::Instanceable<HANDLE, TYPE, N>::_List UTL::Collections::Instanceable<HANDLE, TYPE, N>::_mList =                                 \
+        UTL::Collections::Instanceable<HANDLE, TYPE, N>::_List();                                                                                     \
+    template <> unsigned int UTL::Collections::Instanceable<HANDLE, TYPE, N>::_mHNext = 0;
+
+IMPL_LISTABLE(IExplosion, 96)
+IMPL_LISTABLE(IDisposable, 160)
+IMPL_LISTABLESET(IVehicle, 10, eVehicleList, 10)
+IMPL_LISTABLE(IRigidBody, 160)
+IMPL_LISTABLE(ICollisionBody, 160)
+IMPL_LISTABLE(ISimpleBody, 96)
+IMPL_LISTABLESET(Sim::IEntity, 8, eEntityList, 4)
+IMPL_LISTABLESET(IPlayer, 8, ePlayerList, 3)
+IMPL_LISTABLE(IRecordablePlayer, 8)
+IMPL_LISTABLE(IInputPlayer, 8)
+IMPL_LISTABLE(IModel, 434)
+IMPL_LISTABLE(IPursuit, 8)
+IMPL_LISTABLE(IRoadBlock, 8)
+IMPL_LISTABLE(IHud, 2)
+IMPL_LISTABLE(IVehicleCache, 18)
+IMPL_LISTABLE(ITrafficCenter, 8)
+IMPL_LISTABLE(ISpikeable, 10)
+IMPL_INSTANCABLE(HSIMABLE, ISimable, 160)
+IMPL_INSTANCABLE(HACTIVITY, Sim::IActivity, 40)
+IMPL_INSTANCABLE(HMODEL, IModel, 434)
+IMPL_INSTANCABLE(HCAUSE, ICause, 10)

--- a/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
@@ -1,0 +1,1560 @@
+#include "Speed/Indep/Src/Physics/PVehicle.h"
+
+#include <algorithm>
+
+#include "Speed/Indep/Src/AI/AITarget.h"
+#include "Speed/Indep/Src/Camera/CameraAI.hpp"
+#include "Speed/Indep/Src/Frontend/Database/VehicleDB.hpp"
+#include "Speed/Indep/Src/Interfaces/Simables/IEffects.h"
+#include "Speed/Indep/Src/Generated/Events/EPerfectLaunch.hpp"
+#include "Speed/Indep/Src/Generated/Events/EPlayerAirborne.hpp"
+#include "Speed/Indep/Src/Generated/Messages/MJumpCut.h"
+#include "Speed/Indep/Src/Interfaces/ITaskable.h"
+#include "Speed/Indep/Src/Interfaces/SimActivities/INIS.h"
+#include "Speed/Indep/Src/Interfaces/SimActivities/ITrafficCenter.h"
+#include "Speed/Indep/Src/Interfaces/SimEntities/IPlayer.h"
+#include "Speed/Indep/Src/Interfaces/Simables/IAI.h"
+#include "Speed/Indep/Src/Interfaces/Simables/IAudible.h"
+#include "Speed/Indep/Src/Interfaces/Simables/IArticulatedVehicle.h"
+#include "Speed/Indep/Src/Interfaces/Simables/ICollisionBody.h"
+#include "Speed/Indep/Src/Interfaces/Simables/IDamageable.h"
+#include "Speed/Indep/Src/Interfaces/Simables/IEffects.h"
+#include "Speed/Indep/Src/Interfaces/Simables/IEngine.h"
+#include "Speed/Indep/Src/Interfaces/Simables/IExplosion.h"
+#include "Speed/Indep/Src/Interfaces/Simables/IINput.h"
+#include "Speed/Indep/Src/Interfaces/Simables/IRecordablePlayer.h"
+#include "Speed/Indep/Src/Interfaces/Simables/IRenderable.h"
+#include "Speed/Indep/Src/Interfaces/Simables/IRigidBody.h"
+#include "Speed/Indep/Src/Interfaces/Simables/ISpikeable.h"
+#include "Speed/Indep/Src/Interfaces/Simables/ISuspension.h"
+#include "Speed/Indep/Src/Interfaces/Simables/ITransmission.h"
+#include "Speed/Indep/Src/Misc/Config.h"
+#include "Speed/Indep/Src/Misc/Profiler.hpp"
+#include "Speed/Indep/Src/Physics/Behavior.h"
+#include "Speed/Indep/Src/Physics/Behaviors/DamageVehicle.h"
+#include "Speed/Indep/Src/Physics/Behaviors/RigidBody.h"
+#include "Speed/Indep/Src/Physics/Bounds.h"
+#include "Speed/Indep/Src/Physics/Common/VehicleSystem.h"
+#include "Speed/Indep/Src/Physics/PhysicsInfo.hpp"
+#include "Speed/Indep/Src/Sim/SimSurface.h"
+#include "Speed/Indep/Src/Sim/Simulation.h"
+#include "Speed/Indep/Src/Sim/Util.h"
+#include "Speed/Indep/Src/World/CarInfo.hpp"
+#include "Speed/Indep/Src/World/WCollisionMgr.h"
+#include "Speed/Indep/Src/World/WWorldPos.h"
+#include "Speed/Indep/bWare/Inc/Strings.hpp"
+
+class OnlineRacer;
+
+class IOnlinePlayer : public UTL::COM::IUnknown {
+  public:
+    static HINTERFACE _IHandle() { return (HINTERFACE)_IHandle; }
+    IOnlinePlayer(UTL::COM::Object *owner) : UTL::COM::IUnknown(owner, _IHandle()) {}
+    virtual ~IOnlinePlayer() {}
+    virtual void SetOnlineRacer();
+    virtual OnlineRacer *GetOnlineRacer();
+    virtual void SendSetVehicleOnGround();
+};
+
+bool CarInfo_IsSkinned(CarType type);
+unsigned int CarInfo_GetResourceCost(CarType type, bool is_player, bool split_screen);
+unsigned int CarInfo_GetResourcePool(bool needs_compositing);
+bool IsSplitScreen();
+PresetCar *FindFEPresetCar(unsigned int hash);
+int GetMikeMannBuild();
+bool CanSpawnRigidBody(const UMath::Vector3 &position, bool highPriority);
+
+namespace Physics { namespace Upgrades {
+void RemoveJunkman(Attrib::Gen::pvehicle &vehicle, Type type);
+void RemovePart(Attrib::Gen::pvehicle &vehicle, Type type);
+int GetLevel(const Attrib::Gen::pvehicle &vehicle, Type type);
+int GetMaxLevel(const Attrib::Gen::pvehicle &vehicle, Type type);
+bool SetLevel(Attrib::Gen::pvehicle &vehicle, Type type, int level);
+bool MatchPerformance(Attrib::Gen::pvehicle &vehicle, const Physics::Info::Performance &matched_performance);
+}; };
+
+extern Attrib::StringKey BEHAVIOR_MECHANIC_AI;
+extern Attrib::StringKey BEHAVIOR_MECHANIC_AUDIO;
+extern Attrib::StringKey BEHAVIOR_MECHANIC_DAMAGE;
+extern Attrib::StringKey BEHAVIOR_MECHANIC_DRAW;
+extern Attrib::StringKey BEHAVIOR_MECHANIC_EFFECTS;
+extern Attrib::StringKey BEHAVIOR_MECHANIC_ENGINE;
+extern Attrib::StringKey BEHAVIOR_MECHANIC_INPUT;
+extern Attrib::StringKey BEHAVIOR_MECHANIC_RESET;
+extern Attrib::StringKey BEHAVIOR_MECHANIC_RIGIDBODY;
+extern Attrib::StringKey BEHAVIOR_MECHANIC_SUSPENSION;
+
+extern bool Tweak_UseTweakerTunings;
+extern float Tweak_TuningAero;
+
+namespace CameraAI {
+void AddAvoidable(IBody *body);
+void RemoveAvoidable(IBody *body);
+} // namespace CameraAI
+
+bool CanInstancesShareResourceCost(CarType type);
+
+struct AIBehaviors {
+    DriverClass dclass;
+    UCrc32 vclass;
+    UCrc32 signature;
+};
+extern AIBehaviors ai_behaviors[];
+
+inline PVehicle::LaunchState::LaunchState()
+    : Time(0.0f), //
+      Amount(0.0f) {}
+
+inline void PVehicle::LaunchState::Clear() {
+    Time = 0.0f;
+    Amount = 0.0f;
+}
+
+inline bool PVehicle::LaunchState::IsSet() const {
+    return Time > 0.0f;
+}
+
+inline void PVehicle::LaunchState::Set(float time) {
+    Time = time;
+}
+
+inline void PVehicle::LaunchState::Tick(float dT) {
+    Time -= dT;
+}
+
+const ISimable *PVehicle::GetSimable() const { return static_cast<const ISimable *>(this); }
+
+ISimable *PVehicle::GetSimable() { return static_cast<ISimable *>(this); }
+
+float PVehicle::GetSpeed() const { return mSpeed; }
+
+void PVehicle::GlareOn(VehicleFX::ID glare) { mGlareState |= glare; }
+
+void PVehicle::GlareOff(VehicleFX::ID glare) { mGlareState &= ~glare; }
+
+void PVehicle::DebugObject() { PhysicsObject::DebugObject(); }
+
+void PVehicle::OnAttributeChange(const Attrib::Collection *collection, unsigned int attribkey) {}
+
+void PVehicle::OnEnableModeling() {}
+
+void PVehicle::DoDebug(float dT) {}
+
+void PVehicle::OnDebugDraw() {}
+
+void PVehicle::CommitBehaviorOverrides() {
+    if (mOverrideDirty) {
+        mOverrideDirty = false;
+        ReloadBehaviors();
+    }
+}
+
+void PVehicle::Reset() {
+    mBehaviors.Reset();
+    mTimeInAir = 0.0f;
+    mWheelsOnGround = 0;
+    mBrakeTime = 0.0f;
+}
+
+void PVehicle::SetDriverClass(DriverClass cclass) {
+    if (mDriverClass != cclass) {
+        mDriverClass = cclass;
+        UpdateListing();
+        ReloadBehaviors();
+    }
+}
+
+void PVehicle::Activate() {
+    if (mPhysicsMode == PHYSICS_MODE_INACTIVE) {
+        SetPhysicsMode(PHYSICS_MODE_SIMULATED);
+    }
+}
+
+void PVehicle::Deactivate() { SetPhysicsMode(PHYSICS_MODE_INACTIVE); }
+
+void PVehicle::Kill() {
+    PhysicsObject::Kill();
+    ReleaseBehavior(UCrc32(BEHAVIOR_MECHANIC_DRAW));
+    ReleaseBehavior(UCrc32(BEHAVIOR_MECHANIC_AUDIO));
+    mResources.Invalidate();
+}
+
+void PVehicle::ForceStopOn(char forceStopBits) {
+    mForceStop |= forceStopBits;
+    if (mInput != nullptr) {
+        mInput->ClearInput();
+    }
+}
+
+void PVehicle::ForceStopOff(char forceStopBits) {
+    mForceStop &= ~forceStopBits;
+    if (mInput != nullptr) {
+        mInput->ClearInput();
+    }
+}
+
+void PVehicle::OnDisableModeling() {
+    IEffects *ieff;
+    if (static_cast<ISimable *>(this)->QueryInterface(&ieff)) {
+        ieff->Purge();
+    }
+}
+
+IModel *PVehicle::GetModel() {
+    if (mRenderable != nullptr) {
+        return mRenderable->GetModel();
+    } else {
+        return nullptr;
+    }
+}
+
+const IModel *PVehicle::GetModel() const {
+    if (mRenderable == nullptr) {
+        return nullptr;
+    }
+    return mRenderable->GetModel();
+}
+
+void PVehicle::SetPhysicsMode(PhysicsMode mode) {
+    if (mode != mPhysicsMode) {
+        OnEndMode(mPhysicsMode);
+        mPhysicsMode = mode;
+        OnBeginMode(mode);
+    }
+    if (mArticulation != nullptr) {
+        IVehicle *itrailer = mArticulation->GetTrailer();
+        if (itrailer != nullptr) {
+            itrailer->SetPhysicsMode(mode);
+        }
+    }
+}
+
+void PVehicle::SetTunings(const Physics::Tunings &tunings) {
+    if (mCustomization == nullptr) {
+        return;
+    }
+    for (unsigned int i = 0; i < Physics::Tunings::MAX_TUNINGS; i++) {
+        Physics::Tunings::Path path = static_cast<Physics::Tunings::Path>(i);
+        mCustomization->SetTuning(path, tunings.Value[i]);
+    }
+}
+
+bool PVehicle::OnTask(HSIMTASK htask, float dT) {
+    ProfileNode profile_node("OnTask", 0);
+    if (mTaskFX == htask) {
+        OnTaskFX(dT);
+        return true;
+    }
+    return PhysicsObject::OnTask(htask, dT);
+}
+
+void PVehicle::SetStaging(bool staging) {
+    if (static_cast<unsigned int>(staging) != static_cast<unsigned int>(mStaging)) {
+        mStaging = staging;
+        if (staging) {
+            SetSpeed(0.0f);
+        }
+    }
+}
+
+void PVehicle::SetDriverStyle(DriverStyle style) {
+    if (mDriverStyle != style) {
+        mDriverStyle = style;
+        ReloadBehaviors();
+        if (mDriverStyle == STYLE_RACING && mEngine != nullptr) {
+            mEngine->MatchSpeed(mLocalVel.z);
+        }
+    }
+}
+
+void PVehicle::Launch() {
+    if (mEngine == nullptr) {
+        return;
+    }
+    if (mPerfectLaunch.IsSet()) {
+        return;
+    }
+    if (mDriverClass == DRIVER_HUMAN) {
+        if (mPerfectLaunch.Amount > 0.0f) {
+            mPerfectLaunch.Set(10.0f);
+            new EPerfectLaunch(ISimable::GetInstanceHandle(), mPerfectLaunch.Amount);
+        }
+    } else {
+        mPerfectLaunch.Clear();
+    }
+}
+
+float PVehicle::GetPerfectLaunch() const {
+    if (mPerfectLaunch.IsSet()) {}
+    if (!IsStaging() && 0.5f < mPerfectLaunch.Time) {
+        return mPerfectLaunch.Amount;
+    }
+    return 0.5f;
+}
+
+bool PVehicle::IsLoading() const {
+    if (mRenderable != nullptr && !mRenderable->IsRenderable()) {
+        return true;
+    }
+    if (mAudible != nullptr && !mAudible->IsAudible()) {
+        return true;
+    }
+    if (mArticulation != nullptr) {
+        IVehicle *trailer = mArticulation->GetTrailer();
+        if (trailer != nullptr) {
+            return trailer->IsLoading();
+        }
+    }
+    return false;
+}
+
+void PVehicle::ReloadBehaviors() {
+    UMath::Vector3 pos;
+    UMath::Matrix4 mat;
+    pos = static_cast<ISimable *>(this)->GetRigidBody()->GetPosition();
+    static_cast<ISimable *>(this)->GetRigidBody()->GetMatrix4(mat);
+    LoadBehaviors(pos, mat);
+}
+
+void PVehicle::SetAnimating(bool animate) {
+    if (static_cast<unsigned int>(animate) != static_cast<unsigned int>(mAnimating)) {
+        mBehaviorOverrides.clear();
+        mAnimating = animate;
+        ReloadBehaviors();
+        PauseBehavior(UCrc32(BEHAVIOR_MECHANIC_AI), animate);
+        if (mCollisionBody != nullptr) {
+            mCollisionBody->SetAnimating(mAnimating);
+        }
+    }
+}
+
+void PVehicle::SetBehaviorOverride(UCrc32 mechanic, UCrc32 behavior) {
+    Behavior *beh = FindBehavior(mechanic);
+    if (beh == nullptr || beh->GetSignature() != behavior) {
+        mBehaviorOverrides[mechanic] = behavior;
+        mOverrideDirty = true;
+    }
+}
+
+void PVehicle::RemoveBehaviorOverride(UCrc32 mechanic) {
+    UTL::Std::map<UCrc32, UCrc32, _type_ID_PVehicleChangeReq>::iterator iter = mBehaviorOverrides.find(mechanic);
+    if (iter != mBehaviorOverrides.end()) {
+        mBehaviorOverrides.erase(iter);
+        mOverrideDirty = true;
+    }
+}
+
+void PVehicle::OnBehaviorChange(const UCrc32 &mechanic) {
+    PhysicsObject::OnBehaviorChange(mechanic);
+    if (mechanic == UCrc32(BEHAVIOR_MECHANIC_AI)) {
+        static_cast<ISimable *>(this)->QueryInterface(&mAI);
+    } else if (mechanic == UCrc32(BEHAVIOR_MECHANIC_INPUT)) {
+        static_cast<ISimable *>(this)->QueryInterface(&mInput);
+    } else if (mechanic == UCrc32(BEHAVIOR_MECHANIC_RIGIDBODY)) {
+        if (static_cast<ISimable *>(this)->QueryInterface(&mCollisionBody)) {
+            mCollisionBody->SetAnimating(mAnimating);
+        }
+        static_cast<ISimable *>(this)->QueryInterface(&mArticulation);
+    } else if (mechanic == UCrc32(BEHAVIOR_MECHANIC_DRAW)) {
+        static_cast<ISimable *>(this)->QueryInterface(&mRenderable);
+    } else if (mechanic == UCrc32(BEHAVIOR_MECHANIC_AUDIO)) {
+        static_cast<ISimable *>(this)->QueryInterface(&mAudible);
+    } else if (mechanic == UCrc32(BEHAVIOR_MECHANIC_SUSPENSION)) {
+        if (!static_cast<ISimable *>(this)->QueryInterface(&mSuspension)) {
+            return;
+        }
+        if (mCollisionBody == nullptr) {
+            return;
+        }
+        {
+            float speed = UMath::Dot(mCollisionBody->GetForwardVector(),
+                                     static_cast<ISimable *>(this)->GetRigidBody()->GetLinearVelocity());
+            mSuspension->MatchSpeed(speed);
+        }
+    } else if (mechanic == UCrc32(BEHAVIOR_MECHANIC_ENGINE)) {
+        static_cast<ISimable *>(this)->QueryInterface(&mTranny);
+        if (!static_cast<ISimable *>(this)->QueryInterface(&mEngine)) {
+            return;
+        }
+        mEngine->ChargeNOS(mStartingNOS - mEngine->GetNOSCapacity());
+        if (mCollisionBody == nullptr) {
+            return;
+        }
+        {
+            float speed = UMath::Dot(mCollisionBody->GetForwardVector(),
+                                     static_cast<ISimable *>(this)->GetRigidBody()->GetLinearVelocity());
+            mEngine->MatchSpeed(speed);
+        }
+    } else if (mechanic == UCrc32(BEHAVIOR_MECHANIC_DAMAGE)) {
+        static_cast<ISimable *>(this)->QueryInterface(&mDamage);
+    }
+}
+
+void PVehicle::SetSpeed(float speed) {
+    mSpeed = speed;
+    mPerfectLaunch.Clear();
+    if (mCollisionBody != nullptr) {
+        UMath::Vector3 vel;
+        UMath::Scale(mCollisionBody->GetForwardVector(), speed, vel);
+        static_cast<ISimable *>(this)->GetRigidBody()->SetLinearVelocity(vel);
+        if (mSuspension != nullptr) {
+            mSuspension->MatchSpeed(speed);
+        }
+        if (mEngine != nullptr) {
+            mEngine->MatchSpeed(speed);
+        }
+        UpdateLocalVelocities();
+        if (mArticulation != nullptr && mArticulation->GetTrailer() != nullptr) {
+            mArticulation->GetTrailer()->SetSpeed(speed);
+        }
+    }
+}
+
+void PVehicle::UpdateLocalVelocities() {
+    IRigidBody *rigidbody = static_cast<ISimable *>(this)->GetRigidBody();
+    if (rigidbody == nullptr || mCollisionBody == nullptr) {
+        UMath::Clear(mLocalVel);
+        mSlipAngle = 0.0f;
+        mSpeed = 0.0f;
+        mAbsSpeed = 0.0f;
+    } else {
+        mLocalVel = rigidbody->GetLinearVelocity();
+        rigidbody->ConvertWorldToLocal(mLocalVel, false);
+        mSlipAngle = UMath::Atan2a(mLocalVel.x, UMath::Abs(mLocalVel.z));
+        mSpeed = rigidbody->GetSpeed();
+        if (UMath::Dot(mCollisionBody->GetForwardVector(), rigidbody->GetLinearVelocity()) < 0.0f) {
+            mSpeed = -mSpeed;
+        }
+        mAbsSpeed = UMath::Abs(mSpeed);
+    }
+}
+
+void PVehicle::DoStaging(float dT) {
+    if (!mPerfectLaunch.IsSet()) {
+        mPerfectLaunch.Amount = 0.0f;
+        if (mEngine != nullptr) {
+            IRaceEngine *raceEngine = reinterpret_cast<IRaceEngine *>(
+                (*reinterpret_cast<UTL::COM::Object **>(mEngine))->_mInterfaces.Find((HINTERFACE)IRaceEngine::_IHandle)
+            );
+            bool hasRaceEngine = raceEngine != nullptr;
+            if (hasRaceEngine) {
+                float range = 0.0f;
+                float peak_rpm = raceEngine->GetPerfectLaunchRange(range);
+                if (range > 0.0f && peak_rpm > 0.0f) {
+                    float rpm = mEngine->GetRPM();
+                    float dist = rpm - peak_rpm;
+                    if (dist < range && dist > 0.0f) {
+                        mPerfectLaunch.Amount = (dist / range) * 0.5f + 0.5f;
+                    }
+                }
+            }
+        }
+    }
+}
+
+void PVehicle::ComputeHeading(UMath::Vector3 *v) {
+    UMath::Vector3 forward;
+    UMath::Vector3 velocity;
+    IRigidBody *rigid_body = static_cast<ISimable *>(this)->GetRigidBody();
+    float speed = rigid_body->GetSpeed();
+    rigid_body->GetForwardVector(forward);
+    velocity = rigid_body->GetLinearVelocity();
+    if (speed > 0.01f) {
+        UMath::Unit(velocity, velocity);
+    }
+    float velocity_blend = UMath::Clamp(speed, 0.0f, 1.0f);
+    float forward_blend = 1.0f - velocity_blend;
+    UMath::Scale(forward, forward_blend, forward);
+    UMath::ScaleAdd(velocity, velocity_blend, forward, forward);
+    UMath::Unit(forward, *v);
+}
+
+void PVehicle::CheckOffWorld() {
+    UCrc32 susp(BEHAVIOR_MECHANIC_SUSPENSION);
+    if (IsBehaviorActive(susp)) {
+        if (static_cast<ISimable *>(this)->GetWPos().GetSurface() !=
+            SimSurface::kNull.GetConstCollection()) {
+            goto set_false;
+        }
+        if (mSuspension == nullptr) {
+            goto set_true;
+        }
+        {
+            unsigned int invalid_tires = 0;
+            for (unsigned int i = 0; i < mSuspension->GetNumWheels(); i++) {
+                if (mSuspension->GetWheelRoadSurface(i).GetConstCollection() ==
+                    SimSurface::kNull.GetConstCollection()) {
+                    invalid_tires++;
+                }
+            }
+            mOffWorld = !(invalid_tires < 2);
+        }
+        goto done;
+    set_true:
+        mOffWorld = true;
+        goto done;
+    set_false:
+        mOffWorld = false;
+    } else {
+        float worldHeight = 0.0f;
+        WCollisionMgr mgr(0, 3);
+        const UMath::Vector3 &pos = static_cast<ISimable *>(this)->GetPosition();
+        mOffWorld = !mgr.GetWorldHeightAtPointRigorous(pos, worldHeight, nullptr);
+    }
+done:;
+}
+
+void PVehicle::OnTaskSimulate(float dT) {
+    if (IsBehaviorActive(UCrc32(BEHAVIOR_MECHANIC_DRAW)) && mRenderable != nullptr && mRenderable->IsRenderable()) {
+        if (!mRenderable->InView()) {
+            mOffScreenTime = mOffScreenTime + dT;
+            mOnScreenTime = 0.0f;
+        } else {
+            mOffScreenTime = 0.0f;
+            mOnScreenTime = mOnScreenTime + dT;
+        }
+    } else {
+        mOffScreenTime = 0.0f;
+        mOnScreenTime = 0.0f;
+    }
+    CommitBehaviorOverrides();
+    DoDebug(dT);
+    if (mCollisionBody != nullptr) {
+        if (mCollisionBody->IsModeling() != mIsModeling) {
+            mIsModeling = mCollisionBody->IsModeling();
+            if (mIsModeling) {
+                OnEnableModeling();
+            } else {
+                OnDisableModeling();
+            }
+        } else {
+            mIsModeling = mCollisionBody->IsModeling();
+        }
+    }
+    if (mPhysicsMode != PHYSICS_MODE_INACTIVE) {
+        UpdateLocalVelocities();
+        CheckOffWorld();
+    }
+    if (mPhysicsMode == PHYSICS_MODE_SIMULATED) {
+        PauseBehavior(UCrc32(BEHAVIOR_MECHANIC_SUSPENSION),
+            mCollisionBody->IsSleeping() && IsDestroyed());
+        if (mTranny != nullptr) {
+            if (!mTranny->IsGearChanging()) {
+                mSpeedometer = mTranny->GetSpeedometer();
+            }
+        } else {
+            mSpeedometer = mAbsSpeed;
+        }
+        unsigned int num_onground = 0;
+        if (mSuspension != nullptr) {
+            num_onground = mSuspension->GetNumWheelsOnGround();
+            if (num_onground == 0 && mWheelsOnGround != 0 && mDriverClass == DRIVER_HUMAN) {
+                new EPlayerAirborne(ISimable::GetInstanceHandle());
+            }
+            mWheelsOnGround = num_onground;
+        }
+        if (mSuspension == nullptr || num_onground == 0) {
+            mTimeInAir = mTimeInAir + dT;
+        } else {
+            mTimeInAir = 0.0f;
+        }
+        if (IsStaging()) {
+            DoStaging(dT);
+        } else {
+            if (mPerfectLaunch.IsSet()) {
+                if (mTranny != nullptr) {
+                    if (!mTranny->IsGearChanging()) {
+                        mPerfectLaunch.Time -= dT;
+                        if (mPerfectLaunch.Time <= 0.0f) {
+                            mPerfectLaunch.Amount = 0.0f;
+                            mPerfectLaunch.Time = 0.0f;
+                        }
+                    } else {
+                        if (mDriverStyle == STYLE_DRAG) {
+                            mPerfectLaunch.Time = 0.0f;
+                            mPerfectLaunch.Amount = 0.0f;
+                        }
+                    }
+                    if (GetSpeed() > MPH2MPS(60.0f)) {
+                        mPerfectLaunch.Clear();
+                    }
+                }
+            }
+        }
+    } else if (mPhysicsMode == PHYSICS_MODE_EMULATED) {
+        mTimeInAir = 0.0f;
+        if (mSuspension != nullptr) {
+            mWheelsOnGround = mSuspension->GetNumWheels();
+        } else {
+            mWheelsOnGround = 0;
+        }
+        mSpeedometer = mAbsSpeed;
+    } else {
+        mWheelsOnGround = 0;
+        mTimeInAir = 0.0f;
+        mSpeedometer = 0.0f;
+    }
+}
+
+bool CanInstancesShareResourceCost(CarType type) {
+    CarUsageType usage_type = GetCarTypeInfo(type)->GetCarUsageType();
+    if (usage_type == CAR_USAGE_TYPE_COP) {
+        return true;
+    }
+    return usage_type == CAR_USAGE_TYPE_TRAFFIC;
+}
+
+void PVehicle::CleanResources() {
+    for (PVehicle *dirty = mInstances.GetHead(); dirty != mInstances.EndOfList();) {
+        PVehicle *next = dirty->GetNext();
+        if (dirty != nullptr && dirty->IsDirty()) {
+            delete dirty;
+        }
+        dirty = next;
+    }
+}
+
+const Physics::Tunings *PVehicle::GetTunings() const {
+    if (GetDriverClass()) {
+        return nullptr;
+    }
+    if (Tweak_UseTweakerTunings) {
+        static Physics::Tunings tunings;
+        tunings.Value[Physics::Tunings::STEERING] = 0.0f;
+        tunings.Value[Physics::Tunings::HANDLING] = 0.0f;
+        tunings.Value[Physics::Tunings::BRAKES] = 0.0f;
+        tunings.Value[Physics::Tunings::RIDEHEIGHT] = 0.0f;
+        tunings.Value[Physics::Tunings::AERODYNAMICS] = Tweak_TuningAero;
+        tunings.Value[Physics::Tunings::NOS] = 0.0f;
+        tunings.Value[Physics::Tunings::INDUCTION] = 0.0f;
+        return &tunings;
+    }
+    if (mCustomization != nullptr) {
+        return static_cast<const FECustomizationRecord *>(mCustomization)->GetTunings();
+    }
+    return nullptr;
+}
+
+unsigned int PVehicle::CountResources() {
+    unsigned int total_resources = 0;
+    UTL::Std::list<Resource, _type_list> resource_list;
+    for (PVehicle *vehicle = mInstances.GetHead(); vehicle != mInstances.EndOfList();
+         vehicle = vehicle->GetNext()) {
+        bool found = false;
+        for (UTL::Std::list<Resource, _type_list>::const_iterator iter = resource_list.begin();
+             iter != resource_list.end(); iter++) {
+            const Resource &resource = *iter;
+            if (resource.Type == vehicle->mResources.Type) {
+                found = true;
+                break;
+            }
+        }
+        int cost = 0;
+        if (!(found && CanInstancesShareResourceCost(vehicle->mResources.Type))) {
+            resource_list.push_back(vehicle->mResources);
+            cost = vehicle->mResources.Cost;
+        }
+        total_resources += static_cast<unsigned int>(cost);
+    }
+    return total_resources;
+}
+
+void PVehicle::OnTaskFX(float dT) {
+    IRigidBody &rigidBody = *static_cast<ISimable *>(this)->GetRigidBody();
+    if (&rigidBody) {}
+    {
+        if (INIS::Get() == nullptr) {
+            GlareOn(static_cast<VehicleFX::ID>(7));
+        }
+        bool do_brake = false;
+        if (mInput != nullptr) {
+            do_brake = mInput->GetControls().fBrake > 0.0f;
+        }
+        if (!static_cast<ISimable *>(this)->IsPlayer()) {
+            if (do_brake) {
+                mBrakeTime = mBrakeTime + dT;
+            } else {
+                mBrakeTime = 0.0f;
+            }
+            do_brake = mBrakeTime > 0.5f;
+        }
+        if (do_brake) {
+            GlareOn(static_cast<VehicleFX::ID>(0x38));
+        } else {
+            GlareOff(static_cast<VehicleFX::ID>(0x38));
+        }
+    }
+    if (mTranny != nullptr && mTranny->IsReversing()) {
+        GlareOn(static_cast<VehicleFX::ID>(0xc0));
+    } else {
+        GlareOff(static_cast<VehicleFX::ID>(0xc0));
+    }
+}
+
+void PVehicle::OnBeginMode(const PhysicsMode mode) {
+    if (mode == PHYSICS_MODE_INACTIVE) {
+        IVehicle::AddToList(VEHICLE_INACTIVE);
+        if (mCollisionBody != nullptr) {
+            mCollisionBody->DisableTriggering();
+        }
+        Reset();
+    } else if (mode == PHYSICS_MODE_EMULATED) {
+    } else if (mode == PHYSICS_MODE_SIMULATED) {
+        if (mCollisionBody != nullptr) {
+            mCollisionBody->EnableModeling();
+        }
+        CameraAI::AddAvoidable(static_cast<IBody *>(this));
+        PauseBehavior(UCrc32(BEHAVIOR_MECHANIC_DRAW), false);
+        PauseBehavior(UCrc32(BEHAVIOR_MECHANIC_SUSPENSION), false);
+        PauseBehavior(UCrc32(BEHAVIOR_MECHANIC_ENGINE), false);
+        PauseBehavior(UCrc32(BEHAVIOR_MECHANIC_RIGIDBODY), false);
+        PauseBehavior(UCrc32(BEHAVIOR_MECHANIC_EFFECTS), false);
+        PauseBehavior(UCrc32(BEHAVIOR_MECHANIC_RESET), false);
+        PauseBehavior(UCrc32(BEHAVIOR_MECHANIC_AUDIO), false);
+        PauseBehavior(UCrc32(BEHAVIOR_MECHANIC_DAMAGE), false);
+    }
+}
+
+void PVehicle::OnEndMode(const PhysicsMode mode) {
+    if (mode == PHYSICS_MODE_INACTIVE) {
+        if (mCollisionBody != nullptr) {
+            mCollisionBody->EnableTriggering();
+        }
+        Reset();
+        IVehicle::UnList(VEHICLE_INACTIVE);
+    } else if (mode == PHYSICS_MODE_EMULATED) {
+    } else if (mode == PHYSICS_MODE_SIMULATED) {
+        if (mCollisionBody != nullptr) {
+            mCollisionBody->DisableModeling();
+        }
+        CameraAI::RemoveAvoidable(static_cast<IBody *>(this));
+        PauseBehavior(UCrc32(BEHAVIOR_MECHANIC_DRAW), true);
+        PauseBehavior(UCrc32(BEHAVIOR_MECHANIC_SUSPENSION), true);
+        PauseBehavior(UCrc32(BEHAVIOR_MECHANIC_ENGINE), true);
+        PauseBehavior(UCrc32(BEHAVIOR_MECHANIC_RIGIDBODY), true);
+        PauseBehavior(UCrc32(BEHAVIOR_MECHANIC_EFFECTS), true);
+        PauseBehavior(UCrc32(BEHAVIOR_MECHANIC_RESET), true);
+        PauseBehavior(UCrc32(BEHAVIOR_MECHANIC_AUDIO), true);
+        PauseBehavior(UCrc32(BEHAVIOR_MECHANIC_DAMAGE), true);
+    }
+}
+
+
+bool PVehicle::SetDynamicData(const EventSequencer::System *system, EventDynamicData *data) {
+    if (IsDirty()) {
+        return false;
+    }
+    data->fhSimable = reinterpret_cast<uintptr_t>(ISimable::GetInstanceHandle());
+    data->fWorldID = static_cast<ISimable *>(this)->GetWorldID();
+    IRigidBody *body = static_cast<ISimable *>(this)->GetRigidBody();
+    if (body != nullptr) {
+        const UMath::Vector3 &pos = body->GetPosition();
+        data->fPosition = UMath::Vector4Make(pos, 0.0f);
+        UMath::Vector3 dir;
+        body->GetForwardVector(dir);
+        data->fVector = UMath::Vector4Make(dir, 0.0f);
+        const UMath::Vector3 &vel = body->GetLinearVelocity();
+        data->fVelocity = UMath::Vector4Make(vel, 0.0f);
+        const UMath::Vector3 &angvel = body->GetAngularVelocity();
+        data->fAngularVelocity = UMath::Vector4Make(angvel, 0.0f);
+    }
+    if (mRenderable != nullptr) {
+        data->fhModel = reinterpret_cast<uintptr_t>(mRenderable->GetModelHandle());
+    }
+    return true;
+}
+
+bool PVehicle::OnExplosion(const UMath::Vector3 &normal, const UMath::Vector3 &position, float dT, IExplosion *explosion) {
+    unsigned int targets = explosion->GetTargets();
+    if ((targets & 2) == 0) {
+        return false;
+    }
+    if (static_cast<ISimable *>(this)->IsPlayer()) {
+        if ((targets & 4) == 0) {
+            return false;
+        }
+    }
+    if (static_cast<ISimable *>(this)->GetCausality() == nullptr && explosion->GetCausality() != nullptr) {
+        ICause *cause = ICause::FindInstance(explosion->GetCausality());
+        if (cause != nullptr) {
+            cause->OnCausedExplosion(explosion, static_cast<ISimable *>(this));
+        }
+    }
+    IRigidBody *irb = static_cast<ISimable *>(this)->GetRigidBody();
+    float factor;
+    float targetspeed = 1.0f / irb->GetMass();
+    factor = explosion->GetExpansionSpeed() * targetspeed;
+    targetspeed = factor;
+    UMath::Vector3 point_velocity;
+    irb->GetPointVelocity(position, point_velocity);
+    float speed = UMath::Dot(point_velocity, normal);
+    if (speed < targetspeed) {
+        float deltaspeed = targetspeed - speed;
+        UMath::Vector3 impactvel;
+        UMath::Scale(normal, deltaspeed, impactvel);
+        UMath::Vector3 force;
+        UMath::Scale(impactvel, irb->GetMass() / dT, force);
+        irb->ResolveForce(force, position);
+    }
+    if (mSequencer != nullptr) {
+        mSequencer->ProcessStimulus(0xab556d39, Sim::GetTime(), nullptr, EventSequencer::QUEUE_ALLOW);
+        if (explosion->HasDamage()) {
+            mSequencer->ProcessStimulus(0xffcd8a63, Sim::GetTime(), nullptr, EventSequencer::QUEUE_ALLOW);
+        }
+    }
+    return true;
+}
+
+void PVehicle::UpdateListing() {
+    for (unsigned int i = 1; i < VEHICLE_MAX; i++) {
+        IVehicle::UnList(static_cast<eVehicleList>(i));
+    }
+    switch (mDriverClass) {
+    case DRIVER_HUMAN:
+        IVehicle::AddToList(VEHICLE_PLAYERS);
+        IVehicle::AddToList(VEHICLE_RACERS);
+        break;
+    case DRIVER_REMOTE:
+        IVehicle::AddToList(VEHICLE_PLAYERS);
+        IVehicle::AddToList(VEHICLE_RACERS);
+        IVehicle::AddToList(VEHICLE_REMOTE);
+        break;
+    case DRIVER_COP:
+        IVehicle::AddToList(VEHICLE_AI);
+        IVehicle::AddToList(VEHICLE_AICOPS);
+        break;
+    case DRIVER_RACER:
+        IVehicle::AddToList(VEHICLE_AI);
+        IVehicle::AddToList(VEHICLE_AIRACERS);
+        IVehicle::AddToList(VEHICLE_RACERS);
+        break;
+    case DRIVER_TRAFFIC:
+        IVehicle::AddToList(VEHICLE_AI);
+        IVehicle::AddToList(VEHICLE_AITRAFFIC);
+        break;
+    default:
+        break;
+    }
+    if (!IsActive()) {
+        IVehicle::AddToList(VEHICLE_INACTIVE);
+    }
+    if (mClass == VehicleClass::TRAILER) {
+        IVehicle::AddToList(VEHICLE_TRAILERS);
+    }
+}
+
+PVehicle::Resource::Resource(const Attrib::Gen::pvehicle &pvehicle, bool spool, bool is_player) {
+    Flags = 0;
+    CarPartDatabase &db = CarPartDB;
+    const char *text = pvehicle.MODEL().GetString();
+    if (text == nullptr) {
+        text = "";
+    }
+    CarType type = db.GetCarType(bStringHash(text));
+    Type = type;
+    if (type != CARTYPE_NONE && type < NUM_CARTYPES) {
+        if (CarInfo_IsSkinned(type)) {
+            Flags |= 4;
+        }
+        bool split_screen = Sim::GetUserMode() == Sim::USER_SPLIT_SCREEN;
+        Cost = CarInfo_GetResourceCost(Type, is_player, split_screen);
+        if (spool) {
+            Flags |= 2;
+        }
+        if (Cost != 0) {
+            Flags |= 1;
+        }
+    }
+}
+
+PVehicle::PVehicle(DriverClass dc, const Attrib::Gen::pvehicle &attribs, const UMath::Vector3 &initialVec,
+                   const UMath::Vector3 &initialPos, const CollisionGeometry::Bounds *bounds,
+                   const FECustomizationRecord *customization, const Resource &resource,
+                   const Physics::Info::Performance *performance, const char *cache_name)
+    : PhysicsObject(attribs.GetBase(), SIMABLE_VEHICLE, 0, 0x18) //
+    , bTNode<PVehicle>() //
+    , IVehicle(this) //
+    , Debugable() //
+    , EventSequencer::IContext(this) //
+    , IExplodeable(this) //
+    , IAttributeable() //
+    , mAttributes(attribs) //
+    , mCustomization(nullptr) //
+    , mInput(nullptr) //
+    , mCollisionBody(nullptr) //
+    , mSuspension(nullptr) //
+    , mEngine(nullptr) //
+    , mDamage(nullptr) //
+    , mTranny(nullptr) //
+    , mAI(nullptr) //
+    , mArticulation(nullptr) //
+    , mRenderable(nullptr) //
+    , mAudible(nullptr) //
+    , mSequencer(nullptr) //
+    , mTaskFX(nullptr) //
+    , mClass() //
+    , mSpeed(0.0f) //
+    , mAbsSpeed(0.0f) //
+    , mSpeedometer(0.0f) //
+    , mTimeInAir(0.0f) //
+    , mSlipAngle(0.0f) //
+    , mWheelsOnGround(0) //
+    , mLocalVel(UMath::Vector3::kZero) //
+    , mDriverClass(dc) //
+    , mDriverStyle(STYLE_RACING) //
+    , mGlareState(0) //
+    , mStartingNOS(0.0f) //
+    , mBrakeTime(0.0f) //
+    , mForceStop(0) //
+    , mPhysicsMode(PHYSICS_MODE_SIMULATED) //
+    , mAnimating(false) //
+    , mStaging(false) //
+    , mPerfectLaunch() //
+    , mBehaviorOverrides() //
+    , mResources() //
+{
+    mBounds = bounds;
+    mOnScreenTime = 0.0f;
+    mOverrideDirty = false;
+    mIsModeling = true;
+    mOffScreenTime = 0.0f;
+    mOffWorld = false;
+    mHasDyno = false;
+    mResources = resource;
+    mPerformance.Default();
+    mPerformanceValid = false;
+    mCacheName = cache_name;
+    if (performance != nullptr) {
+        mPerformance = *performance;
+        mPerformanceValid = true;
+    }
+    mInstances.AddTail(this);
+    AITarget::Register(static_cast<ISimable *>(this));
+    if (customization != nullptr) {
+        FECustomizationRecord *pFVar = static_cast<FECustomizationRecord *>(operator new(0x198));
+        memcpy(pFVar, customization, 0x198);
+        mCustomization = pFVar;
+    }
+    mClass = mAttributes.CLASS();
+    IVehicle::AddToList(VEHICLE_ALL);
+    UpdateListing();
+    switch (mDriverClass) {
+    case DRIVER_HUMAN:
+        mTaskFX = AddTask("FX", 0.0f, 0.0f, Sim::TASK_FRAME_FIXED);
+        break;
+    case DRIVER_TRAFFIC:
+        mTaskFX = AddTask("FX", 0.05f, 0.0f, Sim::TASK_FRAME_FIXED);
+        break;
+    default:
+        mTaskFX = AddTask("FX", 0.02f, 0.0f, Sim::TASK_FRAME_FIXED);
+        break;
+    }
+    Debugable::MakeDebugable(DBG_PHYSICS_RACERS);
+    Reset();
+    if (mDamage != nullptr) {
+        mDamage->ResetDamage();
+    }
+    mGlareState = 0;
+    UMath::Matrix4 initMat;
+    initMat = Util_GenerateMatrix(initialVec, nullptr);
+    LoadBehaviors(initialPos, initMat);
+    SetOwnerObject(this);
+    const Attrib::StringKey seq(mAttributes.EventSequencer());
+    if (seq.IsNotEmpty()) {
+        mSequencer = EventSequencer::Create(this, static_cast<EventSequencer::IContext *>(this),
+                                            UCrc32(seq.GetString()), Sim::GetTime(), 0.0f);
+    }
+    OnBeginMode(PHYSICS_MODE_SIMULATED);
+}
+
+PVehicle::~PVehicle() {
+    PhysicsObject::DetachAll();
+    AITarget::UnRegister(static_cast<ISimable *>(this));
+    IAttributeable::UnRegister(this);
+    if (mCustomization != nullptr) {
+        delete static_cast<FECustomizationRecord *>(mCustomization);
+        mCustomization = nullptr;
+    }
+    ReleaseBehaviors();
+    if (mTaskFX != nullptr) {
+        RemoveTask(mTaskFX);
+        mTaskFX = nullptr;
+    }
+    if (mSequencer != nullptr) {
+        mSequencer->Release();
+        mSequencer = nullptr;
+    }
+    mInstances.Remove(this);
+    CameraAI::RemoveAvoidable(static_cast<IBody *>(this));
+}
+
+UCrc32 PVehicle::LookupBehaviorSignature(const Attrib::StringKey &mechanic) const {
+    if (mechanic == BEHAVIOR_MECHANIC_AUDIO) {
+        if (!IsSoundEnabled) {
+            return UCrc32::kNull;
+        }
+    }
+    UTL::Std::map<UCrc32, UCrc32, _type_ID_PVehicleChangeReq>::const_iterator iter =
+        mBehaviorOverrides.find(UCrc32(mechanic));
+    if (iter != mBehaviorOverrides.end()) {
+        return (*iter).second;
+    }
+    if (mAnimating) {
+        if (mClass != VehicleClass::CHOPPER) {
+            if (mechanic == BEHAVIOR_MECHANIC_SUSPENSION) {
+                return UCrc32("SuspensionSpline");
+            }
+            if (mechanic == BEHAVIOR_MECHANIC_ENGINE) {
+                return UCrc32("EngineSpline");
+            }
+        }
+        if (mechanic == BEHAVIOR_MECHANIC_RESET) {
+            return UCrc32::kNull;
+        }
+        if (mechanic == BEHAVIOR_MECHANIC_INPUT) {
+            return UCrc32("InputNIS");
+        }
+    }
+    if (mechanic == BEHAVIOR_MECHANIC_RIGIDBODY && mDriverClass == DRIVER_REMOTE) {
+        return UCrc32("RBRemote");
+    }
+    if (mechanic == BEHAVIOR_MECHANIC_INPUT && mDriverClass == DRIVER_HUMAN) {
+        if (mDriverStyle == STYLE_DRAG) {
+            return UCrc32("InputPlayerDrag");
+        }
+        return UCrc32("InputPlayer");
+    }
+    if (mechanic == BEHAVIOR_MECHANIC_DAMAGE && mDriverStyle == STYLE_DRAG) {
+        return UCrc32("DamageDragster");
+    }
+    if (mechanic == BEHAVIOR_MECHANIC_ENGINE && mClass == VehicleClass::CAR &&
+        mDriverStyle == STYLE_DRAG) {
+        return UCrc32("EngineDragster");
+    }
+    if (mechanic == BEHAVIOR_MECHANIC_SUSPENSION && mClass == VehicleClass::CAR) {
+        switch (mDriverClass) {
+        case DRIVER_RACER:
+        case DRIVER_NONE:
+        case DRIVER_REMOTE:
+            return UCrc32("SuspensionSimple");
+        default:
+            break;
+        }
+    }
+    if (mechanic == BEHAVIOR_MECHANIC_AI) {
+        const AIBehaviors *aibehavior = ai_behaviors;
+        UCrc32 signature = aibehavior->signature;
+        while (aibehavior->signature != UCrc32::kNull) {
+            if (mDriverClass == aibehavior->dclass) {
+                if (mClass == aibehavior->vclass || aibehavior->vclass == UCrc32::kNull) {
+                    signature = aibehavior->signature;
+                    break;
+                }
+            }
+            aibehavior++;
+        }
+        return signature;
+    }
+    if (mechanic == BEHAVIOR_MECHANIC_EFFECTS) {
+        if (mDriverClass == DRIVER_HUMAN ||
+            static_cast<const ISimable *>(this)->IsPlayer()) {
+            return UCrc32("EffectsPlayer");
+        }
+    }
+    Attrib::Instance instance(nullptr, 0, nullptr);
+    Attrib::StringKey behaviourKey;
+    Attrib::Attribute atr = mAttributes.Get(static_cast<unsigned int>(mechanic));
+    if (atr.Get(0, behaviourKey)) {
+    } else {
+        return UCrc32::kNull;
+    }
+    return UCrc32(behaviourKey);
+}
+
+void PVehicle::LoadBehaviors(const UMath::Vector3 &initialPos, const UMath::Matrix4 &initMat) {
+    if (IsDirty()) {
+        return;
+    }
+    ProfileNode profile_node("LoadBehaviors", 0);
+    if (mEngine != nullptr) {
+        mStartingNOS = mEngine->GetNOSCapacity();
+    }
+    UMath::Vector3 linearVel;
+    memset(&linearVel, 0, sizeof(UMath::Vector3));
+    UMath::Vector3 Dimension;
+    mBounds->GetHalfDimensions(Dimension);
+    unsigned int collision_mask = 0;
+    switch (mDriverClass) {
+    case DRIVER_HUMAN:
+    case DRIVER_RACER:
+    case DRIVER_REMOTE:
+        break;
+    case DRIVER_COP:
+        collision_mask = 0x80;
+        break;
+    default:
+        collision_mask |= 0x40;
+        break;
+    }
+    float mass = mAttributes.MASS();
+    const UMath::Vector3 &tensorScale = UMath::Vector4To3(mAttributes.TENSOR_SCALE());
+    UMath::Vector3 initMoment = Util_GenerateCarTensor(mass, Dimension.x, Dimension.y, Dimension.z, tensorScale);
+
+    UCrc32 rbclass = LookupBehaviorSignature(BEHAVIOR_MECHANIC_RIGIDBODY);
+    LoadBehavior(UCrc32(BEHAVIOR_MECHANIC_RIGIDBODY), rbclass,
+                 RBComplexParams(initialPos, linearVel, UMath::Vector3::kZero, initMat, mass, initMoment, Dimension, mBounds, true, collision_mask));
+
+    UCrc32 iclass = LookupBehaviorSignature(BEHAVIOR_MECHANIC_INPUT);
+    LoadBehavior(UCrc32(BEHAVIOR_MECHANIC_INPUT), iclass, Sim::Param());
+
+    UCrc32 engine = LookupBehaviorSignature(BEHAVIOR_MECHANIC_ENGINE);
+    LoadBehavior(UCrc32(BEHAVIOR_MECHANIC_ENGINE), engine, EngineParams());
+
+    UCrc32 suspclass = LookupBehaviorSignature(BEHAVIOR_MECHANIC_SUSPENSION);
+    LoadBehavior(UCrc32(BEHAVIOR_MECHANIC_SUSPENSION), suspclass, SuspensionParams());
+
+    UCrc32 damageclass = LookupBehaviorSignature(BEHAVIOR_MECHANIC_DAMAGE);
+    LoadBehavior(UCrc32(BEHAVIOR_MECHANIC_DAMAGE), damageclass, DamageParams());
+
+    UCrc32 drawclass = LookupBehaviorSignature(BEHAVIOR_MECHANIC_DRAW);
+    LoadBehavior(UCrc32(BEHAVIOR_MECHANIC_DRAW), drawclass, Sim::Param());
+
+    UCrc32 audioclass = LookupBehaviorSignature(BEHAVIOR_MECHANIC_AUDIO);
+    LoadBehavior(UCrc32(BEHAVIOR_MECHANIC_AUDIO), audioclass, Sim::Param());
+
+    UCrc32 aiclass = LookupBehaviorSignature(BEHAVIOR_MECHANIC_AI);
+    LoadBehavior(UCrc32(BEHAVIOR_MECHANIC_AI), aiclass, AIParams());
+
+    UCrc32 effectsclass = LookupBehaviorSignature(BEHAVIOR_MECHANIC_EFFECTS);
+    LoadBehavior(UCrc32(BEHAVIOR_MECHANIC_EFFECTS), effectsclass, Sim::Param());
+
+    UCrc32 resetclass = LookupBehaviorSignature(BEHAVIOR_MECHANIC_RESET);
+    LoadBehavior(UCrc32(BEHAVIOR_MECHANIC_RESET), resetclass, Sim::Param());
+
+    ResetBehavior(UCrc32(BEHAVIOR_MECHANIC_RIGIDBODY));
+    ResetBehavior(UCrc32(BEHAVIOR_MECHANIC_INPUT));
+    ResetBehavior(UCrc32(BEHAVIOR_MECHANIC_SUSPENSION));
+    ResetBehavior(UCrc32(BEHAVIOR_MECHANIC_ENGINE));
+    ResetBehavior(UCrc32(BEHAVIOR_MECHANIC_DAMAGE));
+    ResetBehavior(UCrc32(BEHAVIOR_MECHANIC_EFFECTS));
+}
+
+bool PVehicle::SetVehicleOnGround(const UMath::Vector3 &resetPos, const UMath::Vector3 &initialVec) {
+    IRigidBody *rigid_body = static_cast<ISimable *>(this)->GetRigidBody();
+    if (rigid_body == nullptr || mCollisionBody == nullptr) {
+        return false;
+    }
+    bool success = true;
+    MJumpCut msg(static_cast<ISimable *>(this)->GetWorldID());
+    msg.Send(UCrc32("CameraMessagePort"));
+    const UMath::Vector3 dim = rigid_body->GetDimension();
+    UMath::Vector3 position = resetPos;
+    position.y += dim.y;
+    UMath::Matrix4 orientMat = Util_GenerateMatrix(initialVec, nullptr);
+    rigid_body->SetLinearVelocity(UMath::Vector3::kZero);
+    rigid_body->SetAngularVelocity(UMath::Vector3::kZero);
+    float load = mCollisionBody->GetGravity() * rigid_body->GetMass();
+    float worldHeight;
+    if (!WCollisionMgr(0, 3).GetWorldHeightAtPointRigorous(position, worldHeight, nullptr)) {
+        position = resetPos;
+        success = false;
+    } else if (mSuspension == nullptr) {
+        position = resetPos;
+        position.y = worldHeight + dim.y;
+    } else {
+        WWorldPos wpos(dim.y);
+        wpos.SetTolerance(1.0f);
+        UMath::Vector4 plane[4];
+        UMath::Vector4 axle_center = UMath::Vector4::kZero;
+        position.y = worldHeight;
+        UMath::Vector4 p4 = UMath::Vector4Make(position, 1.0f);
+        for (unsigned int i = 0; i < 4; i++) {
+            UMath::Vector4 &this_corner = plane[i];
+            const UMath::Vector3 &wheelPos = mSuspension->GetWheelLocalPos(i);
+            this_corner = UMath::Vector4Make(wheelPos, 0.0f);
+            this_corner.y = 0.0f;
+            UMath::ScaleAdd(this_corner, 0.25f, axle_center, axle_center);
+            UMath::Rotate(this_corner, orientMat, this_corner);
+            UMath::Add(this_corner, p4, this_corner);
+            wpos.FindClosestFace(UMath::Vector4To3(this_corner), true);
+            if (wpos.OnValidFace()) {
+                float compression = mSuspension->GuessCompression(i, load);
+                float ride = mSuspension->GetRideHeight(i);
+                this_corner.y = dim.y + wpos.HeightAtPoint(UMath::Vector4To3(this_corner)) + (ride - compression);
+            } else {
+                success = false;
+            }
+        }
+        if (!success) {
+            position = resetPos;
+        } else {
+            UMath::Vector4 front;
+            UMath::Vector4 rear;
+            UMath::Vector4 right;
+            UMath::Vector4 left;
+            UMath::Vector4 world_axle;
+            UMath::Vector4 p0;
+            UMath::Vector4 p1;
+            UMath::AddScale(plane[0], plane[1], 0.5f, front);
+            UMath::AddScale(plane[2], plane[3], 0.5f, rear);
+            UMath::AddScale(plane[0], plane[2], 0.5f, left);
+            UMath::AddScale(plane[1], plane[3], 0.5f, right);
+            UMath::Subxyz(front, rear, orientMat.v2);
+            UMath::Unitxyz(orientMat.v2);
+            UMath::Subxyz(right, left, orientMat.v0);
+            UMath::Unitxyz(orientMat.v0);
+            UMath::UnitCrossxyz(orientMat.v2, orientMat.v0, orientMat.v1);
+            UMath::UnitCrossxyz(orientMat.v1, orientMat.v2, orientMat.v0);
+            UMath::Rotate(axle_center, orientMat, world_axle);
+            UMath::AddScalexyz(front, rear, 0.5f, p0);
+            UMath::AddScalexyz(right, left, 0.5f, p1);
+            UMath::AddScalexyz(p0, p1, 0.5f, p4);
+            UMath::Subxyz(p4, world_axle, p4);
+            position = UMath::Vector4To3(p4);
+        }
+    }
+    rigid_body->PlaceObject(orientMat, position);
+    IPlayer *player = static_cast<ISimable *>(this)->GetPlayer();
+    if (player != nullptr) {
+        IOnlinePlayer *online = nullptr;
+        if (player->QueryInterface(&online)) {
+            online->SendSetVehicleOnGround();
+        }
+    }
+    if (mArticulation != nullptr && !mArticulation->Pose()) {
+        success = false;
+    }
+    ResetBehavior(UCrc32(BEHAVIOR_MECHANIC_SUSPENSION));
+    ResetBehavior(UCrc32(BEHAVIOR_MECHANIC_ENGINE));
+    ResetBehavior(UCrc32(BEHAVIOR_MECHANIC_AI));
+    ResetBehavior(UCrc32(BEHAVIOR_MECHANIC_RESET));
+    static_cast<IVehicle *>(this)->SetSpeed(0.0f);
+    mOffWorld = !success;
+    AITarget::Track(static_cast<const ISimable *>(this));
+    return success;
+}
+
+ISimable *PVehicle::Construct(Sim::Param params) {
+    const VehicleParams vp = params.Fetch< VehicleParams >(UCrc32(0xa6b47fac));
+    Attrib::Gen::pvehicle attributes(vp.carType, 0, nullptr);
+    if (!attributes.IsValid()) {
+        return nullptr;
+    }
+    const char *vehicle_name;
+    const FECustomizationRecord *customizations = vp.customization;
+    if (customizations == nullptr) {
+        vehicle_name = attributes.DefaultPresetRide();
+        if (vehicle_name != nullptr) {
+            PresetCar *preset = FindFEPresetCar(bStringHash(vehicle_name));
+            if (preset != nullptr) {
+                static FECustomizationRecord temp_record;
+                temp_record.Default();
+                temp_record.BecomePreset(preset);
+                customizations = &temp_record;
+            }
+        }
+        if (customizations == nullptr) {
+            return nullptr;
+        }
+    }
+    if (!customizations->WriteRecordIntoPhysics(attributes)) {
+        return nullptr;
+    }
+    if (vp.matched != nullptr
+        && !Physics::Upgrades::MatchPerformance(attributes, *vp.matched)) {
+        return nullptr;
+    }
+    if ((vp.Flags & 4) != 0) {
+        Physics::Upgrades::RemoveJunkman(attributes, Physics::Upgrades::PUT_NOS);
+        Physics::Upgrades::RemovePart(attributes, Physics::Upgrades::PUT_NOS);
+    }
+    if (GetMikeMannBuild() != 0) {
+        int new_nos = Physics::Upgrades::GetMaxLevel(attributes, Physics::Upgrades::PUT_NOS);
+        Physics::Upgrades::SetLevel(attributes, Physics::Upgrades::PUT_NOS, new_nos);
+    }
+    if ((vp.Flags & 0x10) != 0) {
+        if (Physics::Upgrades::GetLevel(attributes, Physics::Upgrades::PUT_NOS) == 0) {
+            if (Physics::Upgrades::GetMaxLevel(attributes, Physics::Upgrades::PUT_NOS) > 0) {
+                Physics::Upgrades::SetLevel(attributes, Physics::Upgrades::PUT_NOS, 1);
+            }
+        }
+    }
+        const CollisionGeometry::Collection *geoms =
+        CollisionGeometry::Lookup(UCrc32(attributes.MODEL()));
+    if (geoms == nullptr) {
+        return nullptr;
+    }
+    if (geoms->GetRoot() == nullptr) {
+        return nullptr;
+    }
+    bool spooling_resources = (vp.Flags & 1) != 0;
+    bool is_player = vp.carClass == DRIVER_HUMAN;
+    Resource resource(attributes, spooling_resources, is_player);
+    if (!resource.IsValid()) {
+        return nullptr;
+    }
+    UTL::Std::list< Resource, _type_list > resources;
+    resources.push_back(resource);
+    Attrib::RefSpec trailer_ref = attributes.Trailer();
+    Physics::Info::Performance perf;
+    if (trailer_ref.GetCollectionKey() != 0) {
+        Attrib::Gen::pvehicle trailerAttribs(trailer_ref, 0, nullptr);
+        resources.push_back(Resource(trailerAttribs, spooling_resources, false));
+    }
+    if (!MakeRoom(vp.VehicleCache, resources)) {
+        return nullptr;
+    }
+    resources.clear();
+    perf.Default();
+    const Physics::Info::Performance *performance = nullptr;
+    if (vp.matched != nullptr) {
+        performance = vp.matched;
+    } else if ((vp.Flags & 8) != 0) {
+        if (Physics::Info::ComputePerformance(attributes, perf)) {
+            performance = &perf;
+        }
+    }
+    if (CanSpawnRigidBody(vp.initialPos, true)) {
+        const char *cache_name;
+        PVehicle *vehicle;
+#ifndef EA_BUILD_A124
+        if (vp.VehicleCache != nullptr) {
+            cache_name = vp.VehicleCache->GetCacheName();
+        } else {
+            cache_name = nullptr;
+        }
+#else
+        cache_name = nullptr;
+#endif
+        vehicle = new PVehicle(vp.carClass, attributes, vp.initialVec, vp.initialPos,
+                               geoms->GetRoot(),
+                               customizations, resource, performance, cache_name);
+        if ((vp.Flags & 2) != 0) {
+            vehicle->SetVehicleOnGround(vp.initialPos, vp.initialVec);
+        }
+        if (vehicle != nullptr) {
+            return static_cast<ISimable *>(vehicle);
+        }
+    }
+    return nullptr;
+}
+
+bool PVehicle::MakeRoom(IVehicleCache *whosasking, const UTL::Std::list<Resource, _type_list> &resources) {
+    CleanResources();
+
+    unsigned int newinstances = resources.size();
+
+    unsigned int newresources = 0;
+    bool needs_compositing = false;
+    for (UTL::Std::list<Resource, _type_list>::const_iterator res_iter = resources.begin();
+         res_iter != resources.end(); res_iter++) {
+        const Resource &resource = *res_iter;
+        if (resource.NeedsCompositing()) {
+            needs_compositing = true;
+        }
+        unsigned int cost = resource.Cost;
+        for (PVehicle *vehicle = mInstances.GetHead(); vehicle != mInstances.EndOfList();
+             vehicle = vehicle->GetNext()) {
+            if (vehicle->mResources.Type == resource.Type) {
+                if (CanInstancesShareResourceCost(resource.Type)) {
+                    cost = 0;
+                }
+                break;
+            }
+        }
+        newresources += cost;
+    }
+
+    unsigned int resource_limit = CarInfo_GetResourcePool(needs_compositing);
+    unsigned int current_resources = CountResources();
+    unsigned int current_instances = IVehicle::Count(VEHICLE_ALL);
+    unsigned int needed_resources = 0;
+    unsigned int needed_instances = 0;
+    if (current_resources + newresources > resource_limit) {
+        needed_resources = (current_resources + newresources) - resource_limit;
+    }
+    if (current_instances + newinstances > 10) {
+        needed_instances = (current_instances + newinstances) - 10;
+    }
+
+    if (needed_resources == 0 && needed_instances == 0) {
+        return true;
+    }
+    if (whosasking == nullptr) {
+        return false;
+    }
+
+    ManagementList vehicle_list;
+    vehicle_list.reserve(10);
+
+    for (PVehicle *vehicle = mInstances.GetHead(); vehicle != mInstances.EndOfList();
+         vehicle = vehicle->GetNext()) {
+        ManageNode node;
+        node.result = VCR_DONTCARE;
+        node.resource.Flags = 0;
+        node.instancecount = 0;
+        node.vehicle = vehicle;
+        node.resource = vehicle->mResources;
+        vehicle_list.push_back(node);
+    }
+
+    for (ManageNode *node_iter = vehicle_list.begin();
+         node_iter != vehicle_list.end(); ++node_iter) {
+        ManageNode &node = *node_iter;
+        if (node.result != VCR_WANT) {
+            node.result = whosasking->OnQueryVehicleCache(node.vehicle, whosasking);
+        }
+    }
+
+    for (ManageNode *node_iter = vehicle_list.begin();
+         node_iter != vehicle_list.end(); ++node_iter) {
+        ManageNode &node = *node_iter;
+        if (node.result != VCR_WANT) {
+            for (IVehicleCache *const *cache_iter =
+                     UTL::Collections::Listable<IVehicleCache, 18>::GetList().begin();
+                 cache_iter !=
+                     UTL::Collections::Listable<IVehicleCache, 18>::GetList().end();
+                 ++cache_iter) {
+                IVehicleCache *cache = *cache_iter;
+                if (!UTL::COM::ComparePtr(cache, whosasking)) {
+                    if (cache->OnQueryVehicleCache(node.vehicle, whosasking) == VCR_WANT) {
+                        node.result = VCR_WANT;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    std::sort(vehicle_list.begin(), vehicle_list.end(), ManageNode::sort_by_keep);
+    vehicle_list.print();
+
+    for (UTL::Std::list<Resource, _type_list>::const_iterator res_iter = resources.begin();
+         res_iter != resources.end(); res_iter++) {
+        const Resource &resource = *res_iter;
+        for (ManageNode *node_iter = vehicle_list.begin();
+             node_iter != vehicle_list.end(); ++node_iter) {
+            ManageNode &node = *node_iter;
+            if (resource.Type == node.resource.Type) {
+                node.result = VCR_WANT;
+                break;
+            }
+        }
+    }
+
+    vehicle_list.print();
+
+    if (needed_resources != 0) {
+        CarType type = CARTYPE_NONE;
+        eVehicleCacheResult pushresult = VCR_DONTCARE;
+        for (ManageNode *node_iter = vehicle_list.begin();
+             node_iter != vehicle_list.end(); ++node_iter) {
+            ManageNode &node = *node_iter;
+            CarType t = node.resource.Type;
+            if (t != type) {
+                pushresult = node.result;
+                type = t;
+            }
+            if (pushresult == VCR_WANT) {
+                node.result = VCR_WANT;
+            }
+        }
+    }
+
+    ManageNode *end_iter = std::remove_if(vehicle_list.begin(), vehicle_list.end(),
+                                           ManageNode::is_kept);
+    vehicle_list.erase(end_iter, vehicle_list.end());
+
+    if (vehicle_list.size() == 0) {
+        return false;
+    }
+
+    UTL::Std::map<CarType, unsigned int, _type_map> type_map;
+    for (ManageNode *node_iter = vehicle_list.begin();
+         node_iter != vehicle_list.end(); ++node_iter) {
+        type_map[node_iter->resource.Type]++;
+    }
+
+    for (ManageNode *node_iter = vehicle_list.begin();
+         node_iter != vehicle_list.end(); ++node_iter) {
+        node_iter->instancecount = type_map[node_iter->resource.Type];
+    }
+
+    unsigned int found_instances = 0;
+    ManageNode *node_iter = vehicle_list.begin();
+    if (needed_resources != 0) {
+        std::sort(vehicle_list.begin(), vehicle_list.end(),
+                  ManageNode::sort_remove_resources);
+        vehicle_list.print();
+
+        unsigned int found_resources = 0;
+        CarType type = CARTYPE_NONE;
+        unsigned int type_cost = 0;
+        for (node_iter = vehicle_list.begin(); node_iter != vehicle_list.end();
+             ++node_iter) {
+            CarType t = node_iter->resource.Type;
+            if (t != type) {
+                found_resources += type_cost;
+                type = t;
+            }
+            if (found_resources >= needed_resources) {
+                type_cost = 0;
+                break;
+            }
+            type_cost = node_iter->resource.Cost;
+            found_instances++;
+        }
+
+        if (found_resources + type_cost < needed_resources) {
+            return false;
+        }
+    }
+
+    if (found_instances < needed_instances) {
+        std::sort(node_iter, vehicle_list.end(),
+                  ManageNode::sort_remove_instances);
+        vehicle_list.print();
+
+        for (; node_iter != vehicle_list.end(); ++node_iter) {
+            if (found_instances >= needed_instances) {
+                break;
+            }
+            found_instances++;
+        }
+
+        if (found_instances < needed_instances) {
+            return false;
+        }
+    }
+
+    vehicle_list.erase(node_iter, vehicle_list.end());
+
+    vehicle_list.print();
+
+    for (ManageNode *node_iter = vehicle_list.begin();
+         node_iter != vehicle_list.end(); ++node_iter) {
+        ManageNode &node = *node_iter;
+        PVehicle *killit = node.vehicle;
+        for (IVehicleCache *const *citer =
+                 UTL::Collections::Listable<IVehicleCache, 18>::GetList().begin();
+             citer !=
+                 UTL::Collections::Listable<IVehicleCache, 18>::GetList().end();
+             ++citer) {
+            IVehicleCache *cache = *citer;
+            cache->OnRemovedVehicleCache(killit);
+        }
+        if (killit != nullptr) {
+            delete killit;
+        }
+    }
+
+    return true;
+}
+
+template void UTL::Vector<ICollisionBody *, 16>::push_back(ICollisionBody *const &);
+template void UTL::Vector<IInputPlayer *, 16>::push_back(IInputPlayer *const &);
+template void UTL::Vector<IRecordablePlayer *, 16>::push_back(IRecordablePlayer *const &);
+template void UTL::Vector<ISpikeable *, 16>::push_back(ISpikeable *const &);
+template UTL::Collections::Listable<ITrafficCenter, 8>::List::~List();
+template UTL::Collections::Listable<ISpikeable, 10>::List::~List();
+template Behavior *UTL::COM::Factory<const BehaviorParams &, Behavior, UCrc32>::CreateInstance(UCrc32, const BehaviorParams &);

--- a/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
@@ -1335,9 +1335,11 @@ ISimable *PVehicle::Construct(Sim::Param params) {
         if ((vp.Flags & 2) != 0) {
             vehicle->SetVehicleOnGround(vp.initialPos, vp.initialVec);
         }
+        ISimable *result = nullptr;
         if (vehicle != nullptr) {
-            return static_cast<ISimable *>(vehicle);
+            result = static_cast<ISimable *>(vehicle);
         }
+        return result;
     }
     return nullptr;
 }

--- a/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
@@ -1452,10 +1452,9 @@ bool PVehicle::MakeRoom(IVehicleCache *whosasking, const UTL::Std::list<Resource
         for (ManageNode *node_iter = vehicle_list.begin();
              node_iter != vehicle_list.end(); ++node_iter) {
             ManageNode &node = *node_iter;
-            CarType t = node.resource.Type;
-            if (t != type) {
+            if (node.resource.Type != type) {
                 pushresult = node.result;
-                type = t;
+                type = node.resource.Type;
             }
             if (pushresult == VCR_WANT) {
                 node.result = VCR_WANT;
@@ -1463,27 +1462,28 @@ bool PVehicle::MakeRoom(IVehicleCache *whosasking, const UTL::Std::list<Resource
         }
     }
 
-    ManageNode *end_iter = std::remove_if(vehicle_list.begin(), vehicle_list.end(),
-                                           ManageNode::is_kept);
-    vehicle_list.erase(end_iter, vehicle_list.end());
-
+    vehicle_list.erase(std::remove_if(vehicle_list.begin(), vehicle_list.end(), ManageNode::is_kept),
+                       vehicle_list.end());
     if (vehicle_list.size() == 0) {
         return false;
     }
+    vehicle_list.print();
 
     UTL::Std::map<CarType, unsigned int, _type_map> type_map;
     for (ManageNode *node_iter = vehicle_list.begin();
          node_iter != vehicle_list.end(); ++node_iter) {
-        type_map[node_iter->resource.Type]++;
+        ManageNode &node = *node_iter;
+        type_map[node.resource.Type]++;
     }
 
     for (ManageNode *node_iter = vehicle_list.begin();
          node_iter != vehicle_list.end(); ++node_iter) {
-        node_iter->instancecount = type_map[node_iter->resource.Type];
+        ManageNode &node = *node_iter;
+        node.instancecount = type_map[node.resource.Type];
     }
 
     unsigned int found_instances = 0;
-    ManageNode *node_iter = vehicle_list.begin();
+    ManageNode *end_iter = vehicle_list.begin();
     if (needed_resources != 0) {
         std::sort(vehicle_list.begin(), vehicle_list.end(),
                   ManageNode::sort_remove_resources);
@@ -1492,18 +1492,17 @@ bool PVehicle::MakeRoom(IVehicleCache *whosasking, const UTL::Std::list<Resource
         unsigned int found_resources = 0;
         CarType type = CARTYPE_NONE;
         unsigned int type_cost = 0;
-        for (node_iter = vehicle_list.begin(); node_iter != vehicle_list.end();
-             ++node_iter) {
-            CarType t = node_iter->resource.Type;
-            if (t != type) {
+        for (; end_iter != vehicle_list.end(); ++end_iter) {
+            ManageNode &node = *end_iter;
+            if (node.resource.Type != type) {
                 found_resources += type_cost;
-                type = t;
+                type = node.resource.Type;
             }
             if (found_resources >= needed_resources) {
                 type_cost = 0;
                 break;
             }
-            type_cost = node_iter->resource.Cost;
+            type_cost = node.resource.Cost;
             found_instances++;
         }
 
@@ -1513,11 +1512,11 @@ bool PVehicle::MakeRoom(IVehicleCache *whosasking, const UTL::Std::list<Resource
     }
 
     if (found_instances < needed_instances) {
-        std::sort(node_iter, vehicle_list.end(),
+        std::sort(end_iter, vehicle_list.end(),
                   ManageNode::sort_remove_instances);
         vehicle_list.print();
 
-        for (; node_iter != vehicle_list.end(); ++node_iter) {
+        for (; end_iter != vehicle_list.end(); ++end_iter) {
             if (found_instances >= needed_instances) {
                 break;
             }
@@ -1529,7 +1528,7 @@ bool PVehicle::MakeRoom(IVehicleCache *whosasking, const UTL::Std::list<Resource
         }
     }
 
-    vehicle_list.erase(node_iter, vehicle_list.end());
+    vehicle_list.erase(end_iter, vehicle_list.end());
 
     vehicle_list.print();
 

--- a/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
@@ -250,7 +250,8 @@ void PVehicle::SetTunings(const Physics::Tunings &tunings) {
     }
     for (unsigned int i = 0; i < Physics::Tunings::MAX_TUNINGS; i++) {
         Physics::Tunings::Path path = static_cast<Physics::Tunings::Path>(i);
-        mCustomization->SetTuning(path, tunings.Value[i]);
+        // TODO: Uncomment + add from PR 135
+        // mCustomization->SetTuning(path, tunings.Value[i]);
     }
 }
 
@@ -644,7 +645,8 @@ const Physics::Tunings *PVehicle::GetTunings() const {
         return &tunings;
     }
     if (mCustomization != nullptr) {
-        return static_cast<const FECustomizationRecord *>(mCustomization)->GetTunings();
+        // TODO: Uncomment + add from PR 135
+        // return static_cast<const FECustomizationRecord *>(mCustomization)->GetTunings();
     }
     return nullptr;
 }
@@ -1254,15 +1256,20 @@ ISimable *PVehicle::Construct(Sim::Param params) {
             PresetCar *preset = FindFEPresetCar(bStringHashUpper(attributes.DefaultPresetRide()));
             if (preset != nullptr) {
                 static FECustomizationRecord temp_record;
-                temp_record.Default();
-                temp_record.BecomePreset(preset);
+                // TODO: Uncomment + add from PR 135
+                // temp_record.Default();
+                // TODO: Uncomment + add from PR 135
+                // temp_record.BecomePreset(preset);
                 customizations = &temp_record;
             }
         }
     }
-    if (customizations != nullptr && !customizations->WriteRecordIntoPhysics(attributes)) {
-        return nullptr;
-    }
+    // TODO: Uncomment + add from PR 135
+    // if (customizations != nullptr && !customizations->WriteRecordIntoPhysics(attributes)) {
+    // TODO: Uncomment + add from PR 135
+    //     return nullptr;
+    // TODO: Uncomment + add from PR 135
+    // }
     if (vp.matched != nullptr
         && !Physics::Upgrades::MatchPerformance(attributes, *vp.matched)) {
         return nullptr;

--- a/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
@@ -1302,8 +1302,7 @@ ISimable *PVehicle::Construct(Sim::Param params) {
     resources.push_back(resource);
     Attrib::RefSpec trailer_ref = attributes.Trailer();
     if (trailer_ref.GetCollectionKey() != 0) {
-        Attrib::Gen::pvehicle trailerAttribs(trailer_ref, 0, nullptr);
-        resources.push_back(Resource(trailerAttribs, spooling_resources, false));
+        resources.push_back(Resource(Attrib::Gen::pvehicle(trailer_ref, 0, nullptr), spooling_resources, false));
     }
     if (!MakeRoom(vp.VehicleCache, resources)) {
         return nullptr;

--- a/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
@@ -1574,6 +1574,11 @@ const UCrc32 TRACTOR("TRACTOR");
 
 }; // namespace VehicleClass
 
+
+UTL::COM::Factory<Sim::Param, ISimable, UCrc32>::Prototype _PVehicle("PVehicle", PVehicle::Construct);
+
+bTList<PVehicle> PVehicle::mInstances;
+
 AIBehaviors ai_behaviors[] = {
     {DRIVER_NONE, UCrc32::kNull, UCrc32("AIVehicleEmpty")},
     {DRIVER_NIS, UCrc32::kNull, UCrc32("AIVehicleEmpty")},
@@ -1585,7 +1590,3 @@ AIBehaviors ai_behaviors[] = {
     {DRIVER_REMOTE, UCrc32::kNull, UCrc32("AIVehicleHuman")},
     {DRIVER_NONE, UCrc32::kNull, UCrc32::kNull},
 };
-
-UTL::COM::Factory<Sim::Param, ISimable, UCrc32>::Prototype _PVehicle("PVehicle", PVehicle::Construct);
-
-bTList<PVehicle> PVehicle::mInstances;

--- a/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
@@ -917,18 +917,17 @@ PVehicle::PVehicle(DriverClass dc, const Attrib::Gen::pvehicle &attribs, const U
     , mStaging(false) //
     , mPerfectLaunch() //
     , mBehaviorOverrides() //
-    , mResources() //
+    , mOverrideDirty(false) //
+    , mBounds(bounds) //
+    , mIsModeling(true) //
+    , mOffScreenTime(0.0f) //
+    , mOnScreenTime(0.0f) //
+    , mOffWorld(false) //
+    , mHasDyno(false) //
+    , mResources(resource) //
+    , mPerformanceValid(false) //
+    , mCacheName(cache_name) //
 {
-    mBounds = bounds;
-    mOnScreenTime = 0.0f;
-    mOverrideDirty = false;
-    mIsModeling = true;
-    mOffScreenTime = 0.0f;
-    mOffWorld = false;
-    mHasDyno = false;
-    mResources = resource;
-    mPerformanceValid = false;
-    mCacheName = cache_name;
     if (performance != nullptr) {
         mPerformance = *performance;
         mPerformanceValid = true;

--- a/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
@@ -138,6 +138,13 @@ void PVehicle::GlareOn(VehicleFX::ID glare) { mGlareState |= glare; }
 
 void PVehicle::GlareOff(VehicleFX::ID glare) { mGlareState &= ~glare; }
 
+inline bool PVehicle::IsGlareOn(VehicleFX::ID glare) {
+    if ((mGlareState & glare) != 0) {
+        return true;
+    }
+    return false;
+}
+
 void PVehicle::DebugObject() { PhysicsObject::DebugObject(); }
 
 void PVehicle::OnAttributeChange(const Attrib::Collection *collection, unsigned int attribkey) {}

--- a/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
@@ -1250,7 +1250,7 @@ ISimable *PVehicle::Construct(Sim::Param params) {
     if (customizations == nullptr) {
         vehicle_name = attributes.DefaultPresetRide();
         if (vehicle_name != nullptr) {
-            PresetCar *preset = FindFEPresetCar(bStringHash(vehicle_name));
+            PresetCar *preset = FindFEPresetCar(bStringHashUpper(vehicle_name));
             if (preset != nullptr) {
                 static FECustomizationRecord temp_record;
                 temp_record.Default();
@@ -1301,7 +1301,6 @@ ISimable *PVehicle::Construct(Sim::Param params) {
     UTL::Std::list< Resource, _type_list > resources;
     resources.push_back(resource);
     Attrib::RefSpec trailer_ref = attributes.Trailer();
-    Physics::Info::Performance perf;
     if (trailer_ref.GetCollectionKey() != 0) {
         Attrib::Gen::pvehicle trailerAttribs(trailer_ref, 0, nullptr);
         resources.push_back(Resource(trailerAttribs, spooling_resources, false));
@@ -1310,7 +1309,7 @@ ISimable *PVehicle::Construct(Sim::Param params) {
         return nullptr;
     }
     resources.clear();
-    perf.Default();
+    Physics::Info::Performance perf;
     const Physics::Info::Performance *performance = nullptr;
     if (vp.matched != nullptr) {
         performance = vp.matched;

--- a/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
@@ -937,9 +937,10 @@ PVehicle::PVehicle(DriverClass dc, const Attrib::Gen::pvehicle &attribs, const U
     mInstances.AddTail(this);
     AITarget::Register(static_cast<ISimable *>(this));
     if (customization != nullptr) {
-        FECustomizationRecord *pFVar = static_cast<FECustomizationRecord *>(operator new(0x198));
-        memcpy(pFVar, customization, 0x198);
-        mCustomization = pFVar;
+        FECustomizationRecord *&record = mCustomization;
+        FECustomizationRecord *copy = static_cast<FECustomizationRecord *>(operator new(0x198));
+        memcpy(copy, customization, 0x198);
+        record = copy;
     }
     mClass = mAttributes.CLASS();
     IVehicle::AddToList(VEHICLE_ALL);

--- a/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
@@ -1167,9 +1167,10 @@ bool PVehicle::SetVehicleOnGround(const UMath::Vector3 &resetPos, const UMath::V
     } else {
         WWorldPos wpos(dim.y);
         wpos.SetTolerance(1.0f);
+        position.y = worldHeight;
+
         UMath::Vector4 plane[4];
         UMath::Vector4 axle_center = UMath::Vector4::kZero;
-        position.y = worldHeight;
         UMath::Vector4 p4 = UMath::Vector4Make(position, 1.0f);
         for (unsigned int i = 0; i < 4; i++) {
             UMath::Vector4 &this_corner = plane[i];
@@ -1183,7 +1184,8 @@ bool PVehicle::SetVehicleOnGround(const UMath::Vector3 &resetPos, const UMath::V
             if (wpos.OnValidFace()) {
                 float compression = mSuspension->GuessCompression(i, load);
                 float ride = mSuspension->GetRideHeight(i);
-                this_corner.y = dim.y + wpos.HeightAtPoint(UMath::Vector4To3(this_corner)) + (ride - compression);
+                float delta = ride - compression;
+                this_corner.y = dim.y + wpos.HeightAtPoint(UMath::Vector4To3(this_corner)) + delta;
             } else {
                 success = false;
             }

--- a/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
@@ -511,9 +511,8 @@ void PVehicle::CheckOffWorld() {
     set_false:
         mOffWorld = false;
     } else {
-        WCollisionMgr mgr(0, 3);
         float worldHeight = 0.0f;
-        mOffWorld = !mgr.GetWorldHeightAtPointRigorous(
+        mOffWorld = !WCollisionMgr(0, 3).GetWorldHeightAtPointRigorous(
             static_cast<ISimable *>(this)->GetPosition(), worldHeight, nullptr);
     }
 done:;

--- a/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
@@ -909,7 +909,7 @@ PVehicle::PVehicle(DriverClass dc, const Attrib::Gen::pvehicle &attribs, const U
     , mDriverClass(dc) //
     , mDriverStyle(STYLE_RACING) //
     , mGlareState(0) //
-    , mStartingNOS(0.0f) //
+    , mStartingNOS(1.0f) //
     , mBrakeTime(0.0f) //
     , mForceStop(0) //
     , mPhysicsMode(PHYSICS_MODE_SIMULATED) //
@@ -927,7 +927,6 @@ PVehicle::PVehicle(DriverClass dc, const Attrib::Gen::pvehicle &attribs, const U
     mOffWorld = false;
     mHasDyno = false;
     mResources = resource;
-    mPerformance.Default();
     mPerformanceValid = false;
     mCacheName = cache_name;
     if (performance != nullptr) {
@@ -946,13 +945,13 @@ PVehicle::PVehicle(DriverClass dc, const Attrib::Gen::pvehicle &attribs, const U
     UpdateListing();
     switch (mDriverClass) {
     case DRIVER_HUMAN:
-        mTaskFX = AddTask("FX", 0.0f, 0.0f, Sim::TASK_FRAME_FIXED);
+        mTaskFX = AddTask("FX", 1.0f, 0.0f, Sim::TASK_FRAME_FIXED);
         break;
     case DRIVER_TRAFFIC:
-        mTaskFX = AddTask("FX", 0.05f, 0.0f, Sim::TASK_FRAME_FIXED);
+        mTaskFX = AddTask("FX", 0.25f, 0.0f, Sim::TASK_FRAME_FIXED);
         break;
     default:
-        mTaskFX = AddTask("FX", 0.02f, 0.0f, Sim::TASK_FRAME_FIXED);
+        mTaskFX = AddTask("FX", 0.5f, 0.0f, Sim::TASK_FRAME_FIXED);
         break;
     }
     Debugable::MakeDebugable(DBG_PHYSICS_RACERS);

--- a/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
@@ -856,11 +856,7 @@ void PVehicle::UpdateListing() {
 PVehicle::Resource::Resource(const Attrib::Gen::pvehicle &pvehicle, bool spool, bool is_player) {
     Flags = 0;
     CarPartDatabase &db = CarPartDB;
-    const char *text = pvehicle.MODEL().GetString();
-    if (text == nullptr) {
-        text = "";
-    }
-    CarType type = db.GetCarType(bStringHash(text));
+    CarType type = db.GetCarType(bStringHash(pvehicle.MODEL().GetString()));
     Type = type;
     if (type != CARTYPE_NONE && type < NUM_CARTYPES) {
         if (CarInfo_IsSkinned(type)) {

--- a/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/PVehicle.cpp
@@ -1166,7 +1166,7 @@ bool PVehicle::SetVehicleOnGround(const UMath::Vector3 &resetPos, const UMath::V
         position.y = worldHeight + dim.y;
     } else {
         WWorldPos wpos(dim.y);
-        wpos.SetTolerance(1.0f);
+        wpos.SetTolerance(dim.y);
         position.y = worldHeight;
 
         UMath::Vector4 plane[4];

--- a/src/Speed/Indep/Src/Physics/Common/PhysicsObject.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/PhysicsObject.cpp
@@ -12,6 +12,12 @@
 
 #include <algorithm>
 
+const UCrc32 UCrc32::kNull;
+
+template <>
+UTL::Collections::GarbageNode<PhysicsObject, 160>::Collector UTL::Collections::GarbageNode<PhysicsObject, 160>::_mCollector =
+    UTL::Collections::GarbageNode<PhysicsObject, 160>::Collector();
+
 void PhysicsObject::Behaviors::Add(Behavior *beh) {
     int pri = beh->GetPriority();
     iterator iter;

--- a/src/Speed/Indep/Src/Physics/Common/PhysicsObject.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/PhysicsObject.cpp
@@ -1,0 +1,466 @@
+#define ZPHYSICS_OUTLINE_IENTITY_HANDLE
+#include "Speed/Indep/Src/Physics/PhysicsObject.h"
+
+#include "Speed/Indep/Src/Interfaces/SimEntities/IEntity.h"
+#include "Speed/Indep/Src/Interfaces/SimEntities/IPlayer.h"
+#include "Speed/Indep/Src/Interfaces/SimModels/IModel.h"
+#include "Speed/Indep/Src/Interfaces/Simables/IRigidBody.h"
+#include "Speed/Indep/Src/Main/AttribSupport.h"
+#include "Speed/Indep/Src/Sim/Collision.h"
+#include "Speed/Indep/Src/Sim/Simulation.h"
+#include "Speed/Indep/Src/World/WorldConn.h"
+
+#include <algorithm>
+
+void PhysicsObject::Behaviors::Add(Behavior *beh) {
+    int pri = beh->GetPriority();
+    iterator iter;
+    for (iter = begin(); iter != end(); ++iter) {
+        if ((*iter)->GetPriority() > pri) {
+            break;
+        }
+    }
+    insert(iter, beh);
+}
+
+void PhysicsObject::Behaviors::Remove(Behavior *beh) {
+    erase(std::remove(this->begin(), this->end(), beh));
+}
+
+PhysicsObject::PhysicsObject(const Attrib::Instance &attribs, SimableType objType, WUID wuid,
+                             unsigned int num_interfaces)
+    : Sim::Object(num_interfaces + 3) //
+    , ISimable(this) //
+    , IBody(this) //
+    , IAttachable(this) //
+    , mAttributes(attribs.GetConstCollection(), 0, nullptr) //
+{
+    mWPos = new WWorldPos(0.025f);
+    mObjType = objType;
+    mOwner = nullptr;
+    mRigidBody = nullptr;
+    mEntity = nullptr;
+    mPlayer = nullptr;
+    mBodyService = nullptr;
+    mWorldID = reinterpret_cast<unsigned int>(GetInstanceHandle()) | 0x1000000;
+    if (wuid != 0) {
+        mWorldID = wuid;
+    }
+    mAttachments = new Sim::Attachments(static_cast<IAttachable *>(this));
+    mSimulateTask = AddTask(UCrc32(stringhash32("Physics")), 1.0f, 0.0f, Sim::TASK_FRAME_FIXED);
+    Sim::ProfileTask(mSimulateTask, "Physics");
+    Sim::Collision::AddParticipant(GetInstanceHandle());
+}
+
+PhysicsObject::PhysicsObject(const char *attributeClass, const char *attribName, SimableType objType,
+                             HSIMABLE owner, WUID wuid)
+    : Sim::Object(13) //
+    , ISimable(this) //
+    , IBody(this) //
+    , IAttachable(this) //
+    , mAttributes(Attrib::FindCollectionWithDefault(Attrib::StringToKey(attributeClass),
+                                                    Attrib::StringToKey(attribName)),
+                  0, nullptr) //
+{
+    mWPos = new WWorldPos(0.025f);
+    mObjType = objType;
+    mOwner = owner;
+    mRigidBody = nullptr;
+    mEntity = nullptr;
+    mPlayer = nullptr;
+    mBodyService = nullptr;
+    mWorldID = reinterpret_cast<unsigned int>(GetInstanceHandle()) | 0x1000000;
+    if (wuid != 0) {
+        mWorldID = wuid;
+    }
+    mAttachments = new Sim::Attachments(static_cast<IAttachable *>(this));
+    mSimulateTask = AddTask(UCrc32(stringhash32("Physics")), 1.0f, 0.0f, Sim::TASK_FRAME_FIXED);
+    Sim::ProfileTask(mSimulateTask, "Physics");
+    Sim::Collision::AddParticipant(GetInstanceHandle());
+}
+
+PhysicsObject::~PhysicsObject() {
+    ReleaseBehaviors();
+    RemoveTask(mSimulateTask);
+    DetachEntity();
+    if (mAttachments) {
+        delete mAttachments;
+        mAttachments = nullptr;
+    }
+    if (mBodyService) {
+        CloseService(mBodyService);
+        mBodyService = nullptr;
+    }
+    if (mWPos) {
+        delete mWPos;
+    }
+    Sim::Collision::RemoveParticipant(GetInstanceHandle());
+}
+
+void PhysicsObject::GetTransform(UMath::Matrix4 &matrix) const {
+    if (mRigidBody != nullptr) {
+        mRigidBody->GetMatrix4(matrix);
+        matrix.v3 = UMath::Vector4Make(mRigidBody->GetPosition(), 1.0f);
+    } else {
+        UMath::Copy(UMath::Matrix4::kIdentity, matrix);
+    }
+}
+
+void PhysicsObject::GetLinearVelocity(UMath::Vector3 &velocity) const {
+    if (mRigidBody != nullptr) {
+        UMath::Copy(mRigidBody->GetLinearVelocity(), velocity);
+    } else {
+        UMath::Copy(UMath::Vector3::kZero, velocity);
+    }
+}
+
+void PhysicsObject::GetAngularVelocity(UMath::Vector3 &velocity) const {
+    if (mRigidBody != nullptr) {
+        UMath::Copy(mRigidBody->GetAngularVelocity(), velocity);
+    } else {
+        UMath::Copy(UMath::Vector3::kZero, velocity);
+    }
+}
+
+void PhysicsObject::GetDimension(UMath::Vector3 &dim) const {
+    if (mRigidBody != nullptr) {
+        mRigidBody->GetDimension(dim);
+    } else {
+        UMath::Copy(UMath::Vector3::kZero, dim);
+    }
+}
+
+float PhysicsObject::GetCausalityTime() const {
+    const IModel *model = GetModel();
+    if (model != nullptr) {
+        return model->GetCausalityTime();
+    }
+    return 0.0f;
+}
+
+void PhysicsObject::SetCausality(HCAUSE from, float time) {
+    IModel *model = GetModel();
+    if (model != nullptr) {
+        model->SetCausality(from, time);
+    }
+}
+
+HCAUSE PhysicsObject::GetCausality() const {
+    const IModel *model = GetModel();
+    if (model != nullptr) {
+        return model->GetCausality();
+    }
+    return nullptr;
+}
+
+void PhysicsObject::OnAttached(IAttachable *pOther) {
+    mBehaviors.OnAttach(pOther);
+}
+
+void PhysicsObject::OnDetached(IAttachable *pOther) {
+    mBehaviors.OnDetach(pOther);
+}
+
+bool PhysicsObject::OnService(HSIMSERVICE hConn, Sim::Packet *pkt) {
+    if (hConn == mBodyService) {
+        WorldConn::Pkt_Body_Service *pbs = static_cast<WorldConn::Pkt_Body_Service *>(pkt);
+        UMath::Matrix4 mat;
+        mRigidBody->GetMatrix4(mat);
+        UMath::Copy(mRigidBody->GetPosition(), UMath::ExtractAxis(mat, 3));
+        pbs->SetMatrix(mat);
+        pbs->SetVelocity(mRigidBody->GetLinearVelocity());
+        return true;
+    }
+    return Sim::Object::OnService(hConn, pkt);
+}
+
+bool PhysicsObject::OnTask(HSIMTASK htask, float dT) {
+    if (htask == mSimulateTask) {
+        if (!IsDirty()) {
+            OnTaskSimulate(dT);
+            mBehaviors.Simulate(dT);
+        }
+        return true;
+    }
+    return Sim::Object::OnTask(htask, dT);
+}
+
+void PhysicsObject::Kill() {
+    ReleaseGC();
+    if (mBodyService) {
+        CloseService(mBodyService);
+        mBodyService = nullptr;
+    }
+}
+
+void PhysicsObject::SetOwnerObject(ISimable *pOwner) {
+    if (pOwner != nullptr) {
+        mOwner = pOwner->GetInstanceHandle();
+    } else {
+        mOwner = nullptr;
+    }
+}
+
+bool PhysicsObject::IsOwnedByPlayer() const {
+    ISimable *owner = ISimable::FindInstance(mOwner);
+    if (owner != nullptr) {
+        do {
+            if (owner->IsPlayer()) {
+                return true;
+            }
+            if (owner->GetOwnerHandle() == nullptr) {
+                return false;
+            }
+            if (owner->GetOwnerHandle() == owner->GetInstanceHandle()) {
+                return false;
+            }
+            ISimable *next = ISimable::FindInstance(owner->GetOwnerHandle());
+            if (owner == next) {
+                return false;
+            }
+            owner = next;
+        } while (owner != nullptr);
+    }
+    return false;
+}
+
+bool PhysicsObject::IsOwnedBy(ISimable *queriedOwner) const {
+    if (queriedOwner != nullptr) {
+        HSIMABLE qSig = queriedOwner->GetInstanceHandle();
+        ISimable *potentialOwner = ISimable::FindInstance(mOwner);
+        if (potentialOwner != nullptr) {
+            do {
+                if (potentialOwner->GetInstanceHandle() == qSig) {
+                    return true;
+                }
+                HSIMABLE ownerHandle = potentialOwner->GetOwnerHandle();
+                if (ownerHandle == nullptr) {
+                    return false;
+                }
+                ISimable *newOwner = ISimable::FindInstance(ownerHandle);
+                if (potentialOwner == newOwner) {
+                    return false;
+                }
+                potentialOwner = newOwner;
+            } while (potentialOwner != nullptr);
+        }
+    }
+    return false;
+}
+
+void PhysicsObject::DebugObject() {
+    GetRigidBody()->Debug();
+}
+
+void PhysicsObject::OnBehaviorChange(const UCrc32 &mechanic) {
+    if (mechanic == UCrc32(BEHAVIOR_MECHANIC_RIGIDBODY)) {
+        IRigidBody *irb = nullptr;
+        static_cast<ISimable *>(this)->QueryInterface(&irb);
+        mRigidBody = irb;
+        if (mBodyService == nullptr && irb != nullptr) {
+            UMath::Matrix4 mat;
+            mRigidBody->GetMatrix4(mat);
+            UMath::Copy(mRigidBody->GetPosition(), UMath::ExtractAxis(mat, 3));
+            WorldConn::Pkt_Body_Open pkt(mWorldID, mat);
+            mBodyService = OpenService(UCrc32(0x998c21c0), &pkt);
+        }
+    }
+    mBehaviors.Changed(mechanic);
+}
+
+bool PhysicsObject::IsBehaviorActive(const UCrc32 &mechanic) const {
+    unsigned int key = mechanic.GetValue();
+    Mechanics::const_iterator iter = mMechanics.find(key);
+    if (iter == mMechanics.end()) {
+        return false;
+    }
+    Behavior *beh = (*iter).second;
+    if (beh == nullptr) {
+        return false;
+    }
+    return !beh->IsPaused();
+}
+
+void PhysicsObject::PauseBehavior(const UCrc32 &mechanic, bool pause) {
+    unsigned int key = mechanic.GetValue();
+    if (mMechanics.find(key) == mMechanics.end()) {
+        return;
+    }
+    Behavior *beh = mMechanics[key];
+    if (beh != nullptr) {
+        beh->Pause(pause);
+    }
+}
+
+bool PhysicsObject::ResetBehavior(const UCrc32 &mechanic) {
+    unsigned int key = mechanic.GetValue();
+    Behavior *beh;
+    if (mMechanics.find(key) == mMechanics.end()) {
+    } else {
+        beh = mMechanics[key];
+        if (beh != nullptr) {
+            beh->Reset();
+            return true;
+        }
+    }
+    return false;
+}
+
+void PhysicsObject::ReleaseBehaviors() {
+    for (Mechanics::iterator iter = mMechanics.begin(); iter != mMechanics.end(); iter++) {
+        Behavior *beh = (*iter).second;
+        if (beh != nullptr) {
+            UCrc32 mechanic((*iter).first);
+            mBehaviors.Remove(beh);
+            DestroyElement(*beh);
+            (*iter).second = nullptr;
+            OnBehaviorChange(mechanic);
+        }
+    }
+}
+
+void PhysicsObject::ReleaseBehavior(const UCrc32 &mechanic) {
+    unsigned int key = mechanic.GetValue();
+    if (mMechanics.find(key) == mMechanics.end()) {
+        return;
+    }
+    Behavior *beh = mMechanics[key];
+    if (beh != nullptr) {
+        mBehaviors.Remove(beh);
+        DestroyElement(*beh);
+        mMechanics[key] = nullptr;
+        OnBehaviorChange(mechanic);
+    }
+}
+
+Behavior *PhysicsObject::FindBehavior(const UCrc32 &mechanic) {
+    unsigned int key = mechanic.GetValue();
+    if (mMechanics.find(key) != mMechanics.end()) {
+        Behavior *beh = mMechanics[key];
+        if (beh != nullptr) {
+            return beh;
+        }
+    }
+    return nullptr;
+}
+
+Behavior *PhysicsObject::LoadBehavior(const UCrc32 &mechanic, const UCrc32 &behavior,
+                                      Sim::Param params) {
+    if (IsDirty()) {
+        return nullptr;
+    }
+    Behavior *beh = FindBehavior(mechanic);
+    if (beh != nullptr && beh->GetSignature() == behavior) {
+        return beh;
+    }
+    ReleaseBehavior(mechanic);
+
+    if (behavior == UCrc32::kNull) {
+        return nullptr;
+    }
+
+    unsigned int key = mechanic.GetValue();
+    beh = BuildElement(behavior, BehaviorParams(params, this, mechanic, behavior));
+    if (beh != nullptr) {
+        mMechanics[key] = beh;
+        mBehaviors.Add(beh);
+        OnBehaviorChange(mechanic);
+        return beh;
+    }
+    return nullptr;
+}
+
+bool PhysicsObject::Attach(UTL::COM::IUnknown *object) {
+    if (mAttachments == nullptr) {
+        return false;
+    }
+    UTL::COM::ValidatePtr(object);
+    if (UTL::COM::ComparePtr(mEntity, object)) {
+        return false;
+    }
+    Sim::IEntity *ientity = reinterpret_cast<Sim::IEntity *>(
+        (*reinterpret_cast<UTL::COM::Object **>(object))->_mInterfaces.Find((HINTERFACE)Sim::IEntity::_IHandle)
+    );
+    bool hasIEntity = ientity != nullptr;
+    if (hasIEntity) {
+        if (mEntity != nullptr) {
+            Detach(mEntity);
+            mEntity = nullptr;
+            mPlayer = nullptr;
+        }
+        mEntity = ientity;
+        ientity->QueryInterface(&mPlayer);
+    }
+    return mAttachments->Attach(object);
+}
+
+void PhysicsObject::DetachAll() {
+    DetachEntity();
+    if (mAttachments) {
+        delete mAttachments;
+        mAttachments = nullptr;
+    }
+}
+
+bool PhysicsObject::Detach(UTL::COM::IUnknown *object) {
+    if (!mAttachments) {
+        return false;
+    }
+    UTL::COM::ValidatePtr(object);
+    if (UTL::COM::ComparePtr(mEntity, object)) {
+        mEntity = nullptr;
+        mPlayer = nullptr;
+    }
+    return mAttachments->Detach(object);
+}
+
+void PhysicsObject::DetachEntity() {
+    if (mEntity != nullptr) {
+        Detach(mEntity);
+        mPlayer = nullptr;
+        mEntity = nullptr;
+    }
+}
+
+void PhysicsObject::AttachEntity(Sim::IEntity *e) {
+    if (e == nullptr) {
+        DetachEntity();
+    } else {
+        Attach(e);
+    }
+}
+
+void PhysicsObject::ProcessStimulus(unsigned int stimulus) {
+    if (GetEventSequencer() != nullptr) {
+        GetEventSequencer()->ProcessStimulus(stimulus, Sim::GetTime(), nullptr, EventSequencer::QUEUE_ALLOW);
+    }
+}
+
+void PhysicsObject::Reset() {
+    mBehaviors.Reset();
+}
+
+WWorldPos &PhysicsObject::GetWPos() {
+    return *mWPos;
+}
+
+const WWorldPos &PhysicsObject::GetWPos() const {
+    return *mWPos;
+}
+
+IRigidBody *PhysicsObject::GetRigidBody() {
+    return mRigidBody;
+}
+
+
+void PhysicsObject::Behaviors::Reset() {
+    for (const_iterator iter = begin(); iter != end(); ++iter) {
+        (*iter)->Reset();
+    }
+}
+
+template void UTL::Vector<Sim::IEntity *, 16>::reserve(UTL::Vector<Sim::IEntity *, 16>::size_type);
+template void UTL::Vector<IPlayer *, 16>::reserve(UTL::Vector<IPlayer *, 16>::size_type);
+template void UTL::Vector<IModel *, 16>::push_back(IModel *const &);
+template void UTL::Vector<IRigidBody *, 16>::push_back(IRigidBody *const &);
+template const Attrib::RefSpec &Attrib::Attribute::Get<Attrib::RefSpec>(unsigned int) const;

--- a/src/Speed/Indep/Src/Physics/Common/PhysicsObject.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/PhysicsObject.cpp
@@ -20,13 +20,15 @@ UTL::Collections::GarbageNode<PhysicsObject, 160>::Collector UTL::Collections::G
 
 void PhysicsObject::Behaviors::Add(Behavior *beh) {
     int pri = beh->GetPriority();
-    iterator iter;
-    for (iter = begin(); iter != end(); ++iter) {
+    iterator iter = begin();
+    while (iter != end()) {
         if ((*iter)->GetPriority() > pri) {
-            break;
+            insert(iter, beh);
+            return;
         }
+        iter++;
     }
-    insert(iter, beh);
+    insert(end(), beh);
 }
 
 void PhysicsObject::Behaviors::Remove(Behavior *beh) {
@@ -234,21 +236,15 @@ bool PhysicsObject::IsOwnedBy(ISimable *queriedOwner) const {
     if (queriedOwner != nullptr) {
         HSIMABLE qSig = queriedOwner->GetInstanceHandle();
         ISimable *potentialOwner = ISimable::FindInstance(mOwner);
-        if (potentialOwner != nullptr) {
-            do {
-                if (potentialOwner->GetInstanceHandle() == qSig) {
-                    return true;
-                }
-                HSIMABLE ownerHandle = potentialOwner->GetOwnerHandle();
-                if (ownerHandle == nullptr) {
-                    return false;
-                }
-                ISimable *newOwner = ISimable::FindInstance(ownerHandle);
-                if (potentialOwner == newOwner) {
-                    return false;
-                }
-                potentialOwner = newOwner;
-            } while (potentialOwner != nullptr);
+        while (potentialOwner != nullptr) {
+            if (potentialOwner->GetInstanceHandle() == qSig) {
+                return true;
+            }
+            ISimable *newOwner = ISimable::FindInstance(potentialOwner->GetOwnerHandle());
+            if (potentialOwner == newOwner) {
+                return false;
+            }
+            potentialOwner = newOwner;
         }
     }
     return false;
@@ -260,10 +256,8 @@ void PhysicsObject::DebugObject() {
 
 void PhysicsObject::OnBehaviorChange(const UCrc32 &mechanic) {
     if (mechanic == UCrc32(BEHAVIOR_MECHANIC_RIGIDBODY)) {
-        IRigidBody *irb = nullptr;
-        static_cast<ISimable *>(this)->QueryInterface(&irb);
-        mRigidBody = irb;
-        if (mBodyService == nullptr && irb != nullptr) {
+        static_cast<ISimable *>(this)->QueryInterface(&mRigidBody);
+        if (mBodyService == nullptr && mRigidBody != nullptr) {
             UMath::Matrix4 mat;
             mRigidBody->GetMatrix4(mat);
             UMath::Copy(mRigidBody->GetPosition(), UMath::ExtractAxis(mat, 3));
@@ -284,7 +278,7 @@ bool PhysicsObject::IsBehaviorActive(const UCrc32 &mechanic) const {
     if (beh == nullptr) {
         return false;
     }
-    return !beh->IsPaused();
+    return beh->IsPaused() == false;
 }
 
 void PhysicsObject::PauseBehavior(const UCrc32 &mechanic, bool pause) {

--- a/src/Speed/Indep/Src/Physics/Common/PhysicsObject.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/PhysicsObject.cpp
@@ -458,8 +458,6 @@ void PhysicsObject::Behaviors::Reset() {
     }
 }
 
-template void UTL::Vector<Sim::IEntity *, 16>::reserve(UTL::Vector<Sim::IEntity *, 16>::size_type);
-template void UTL::Vector<IPlayer *, 16>::reserve(UTL::Vector<IPlayer *, 16>::size_type);
 template void UTL::Vector<IModel *, 16>::push_back(IModel *const &);
 template void UTL::Vector<IRigidBody *, 16>::push_back(IRigidBody *const &);
 template const Attrib::RefSpec &Attrib::Attribute::Get<Attrib::RefSpec>(unsigned int) const;

--- a/src/Speed/Indep/Src/Physics/Common/PhysicsObject.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/PhysicsObject.cpp
@@ -235,21 +235,19 @@ bool PhysicsObject::IsOwnedBy(ISimable *queriedOwner) const {
     if (queriedOwner == nullptr) {
         return false;
     }
-    HSIMABLE qSig = queriedOwner->GetInstanceHandle();
-    ISimable *potentialOwner = ISimable::FindInstance(mOwner);
-    if (potentialOwner == nullptr) {
-        return false;
+    {
+        HSIMABLE qSig = queriedOwner->GetInstanceHandle();
+        for (ISimable *potentialOwner = ISimable::FindInstance(mOwner); potentialOwner != nullptr;) {
+            if (potentialOwner->GetInstanceHandle() == qSig) {
+                return true;
+            }
+            ISimable *nextInChain = ISimable::FindInstance(potentialOwner->GetOwnerHandle());
+            if (potentialOwner == nextInChain) {
+                return false;
+            }
+            potentialOwner = nextInChain;
+        }
     }
-    do {
-        if (potentialOwner->GetInstanceHandle() == qSig) {
-            return true;
-        }
-        ISimable *newOwner = ISimable::FindInstance(potentialOwner->GetOwnerHandle());
-        if (potentialOwner == newOwner) {
-            return false;
-        }
-        potentialOwner = newOwner;
-    } while (potentialOwner != nullptr);
     return false;
 }
 

--- a/src/Speed/Indep/Src/Physics/Common/PhysicsObject.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/PhysicsObject.cpp
@@ -232,20 +232,24 @@ bool PhysicsObject::IsOwnedByPlayer() const {
 }
 
 bool PhysicsObject::IsOwnedBy(ISimable *queriedOwner) const {
-    if (queriedOwner != nullptr) {
-        HSIMABLE qSig = queriedOwner->GetInstanceHandle();
-        ISimable *potentialOwner = ISimable::FindInstance(mOwner);
-        while (potentialOwner != nullptr) {
-            if (potentialOwner->GetInstanceHandle() == qSig) {
-                return true;
-            }
-            ISimable *newOwner = ISimable::FindInstance(potentialOwner->GetOwnerHandle());
-            if (potentialOwner == newOwner) {
-                return false;
-            }
-            potentialOwner = newOwner;
-        }
+    if (queriedOwner == nullptr) {
+        return false;
     }
+    HSIMABLE qSig = queriedOwner->GetInstanceHandle();
+    ISimable *potentialOwner = ISimable::FindInstance(mOwner);
+    if (potentialOwner == nullptr) {
+        return false;
+    }
+    do {
+        if (potentialOwner->GetInstanceHandle() == qSig) {
+            return true;
+        }
+        ISimable *newOwner = ISimable::FindInstance(potentialOwner->GetOwnerHandle());
+        if (potentialOwner == newOwner) {
+            return false;
+        }
+        potentialOwner = newOwner;
+    } while (potentialOwner != nullptr);
     return false;
 }
 

--- a/src/Speed/Indep/Src/Physics/Common/PhysicsObject.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/PhysicsObject.cpp
@@ -41,20 +41,20 @@ PhysicsObject::PhysicsObject(const Attrib::Instance &attribs, SimableType objTyp
     , ISimable(this) //
     , IBody(this) //
     , IAttachable(this) //
+    , mWPos(new WWorldPos(0.025f)) //
+    , mObjType(objType) //
+    , mOwner(nullptr) //
     , mAttributes(attribs.GetConstCollection(), 0, nullptr) //
+    , mRigidBody(nullptr) //
+    , mEntity(nullptr) //
+    , mPlayer(nullptr) //
+    , mBodyService(nullptr) //
+    , mWorldID(reinterpret_cast<unsigned int>(GetInstanceHandle()) | 0x1000000) //
+    , mAttachments(new Sim::Attachments(static_cast<IAttachable *>(this))) //
 {
-    mWPos = new WWorldPos(0.025f);
-    mObjType = objType;
-    mOwner = nullptr;
-    mRigidBody = nullptr;
-    mEntity = nullptr;
-    mPlayer = nullptr;
-    mBodyService = nullptr;
-    mWorldID = reinterpret_cast<unsigned int>(GetInstanceHandle()) | 0x1000000;
     if (wuid != 0) {
         mWorldID = wuid;
     }
-    mAttachments = new Sim::Attachments(static_cast<IAttachable *>(this));
     mSimulateTask = AddTask(UCrc32(stringhash32("Physics")), 1.0f, 0.0f, Sim::TASK_FRAME_FIXED);
     Sim::ProfileTask(mSimulateTask, "Physics");
     Sim::Collision::AddParticipant(GetInstanceHandle());
@@ -66,24 +66,23 @@ PhysicsObject::PhysicsObject(const char *attributeClass, const char *attribName,
     , ISimable(this) //
     , IBody(this) //
     , IAttachable(this) //
+    , mWPos(new WWorldPos(0.025f)) //
+    , mObjType(objType) //
+    , mOwner(owner) //
     , mAttributes(Attrib::FindCollectionWithDefault(Attrib::StringToKey(attributeClass),
                                                     Attrib::StringToKey(attribName)),
                   0, nullptr) //
+    , mRigidBody(nullptr) //
+    , mEntity(nullptr) //
+    , mPlayer(nullptr) //
+    , mBodyService(nullptr) //
+    , mWorldID(reinterpret_cast<unsigned int>(GetInstanceHandle()) | 0x1000000) //
+    , mAttachments(new Sim::Attachments(static_cast<IAttachable *>(this))) //
 {
-    mWPos = new WWorldPos(0.025f);
-    mObjType = objType;
-    mOwner = owner;
-    mRigidBody = nullptr;
-    mEntity = nullptr;
-    mPlayer = nullptr;
-    mBodyService = nullptr;
-    mWorldID = reinterpret_cast<unsigned int>(GetInstanceHandle()) | 0x1000000;
     if (wuid != 0) {
         mWorldID = wuid;
     }
-    mAttachments = new Sim::Attachments(static_cast<IAttachable *>(this));
     mSimulateTask = AddTask(UCrc32(stringhash32("Physics")), 1.0f, 0.0f, Sim::TASK_FRAME_FIXED);
-    Sim::ProfileTask(mSimulateTask, "Physics");
     Sim::Collision::AddParticipant(GetInstanceHandle());
 }
 

--- a/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
@@ -712,16 +712,16 @@ HeirarchyModel::HeirarchyModel(bHash32 rendermesh, const CollisionGeometry::Boun
     , IBody(this) //
     , ITriggerableModel(this) //
     , Attrib::Gen::smackable(attribs, 0, nullptr) //
+    , mTriggerAvoid(UMath::Vector4::kZero) //
+    , mHeirarchy(const_cast<ModelHeirarchy *>(heirarchy)) //
+    , mRenderMesh(rendermesh) //
+    , mTrigger(nullptr) //
+    , mOffScreenTimer(10.0f) //
+    , mHeirarchyNode(static_cast<unsigned short>(child_index)) //
+    , mFlags(0) //
+    , mChildVisibility(0xFFFFFFFF) //
+    , mAvoidable(nullptr) //
 {
-    mTriggerAvoid = UMath::Vector4::kZero;
-    mHeirarchy = const_cast<ModelHeirarchy *>(heirarchy);
-    mHeirarchyNode = static_cast<unsigned short>(child_index);
-    mRenderMesh = rendermesh;
-    mOffScreenTimer = 10.0f;
-    mChildVisibility = 0xFFFFFFFF;
-    mAvoidable = nullptr;
-    mTrigger = nullptr;
-    mFlags = 0;
     Attrib::Gen::smackable smackable(attribs, 0, nullptr);
     if (visible) {
         RenderConn::Pkt_Smackable_Open pkt(mRenderMesh, GetWorldID(), GetCollisionGeometry(),
@@ -729,7 +729,7 @@ HeirarchyModel::HeirarchyModel(bHash32 rendermesh, const CollisionGeometry::Boun
         BeginDraw(UCrc32(0x804c146e), &pkt);
     }
     if (smackable.AI_AVOIDABLE()) {
-        if (mAvoidable == nullptr) {
+        if (HasAvoidable() != true) {
             mAvoidable = new SmackableAvoidable(this);
         }
     }

--- a/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
@@ -985,7 +985,7 @@ PlaceableScenery *PlaceableScenery::Construct(const char *name, unsigned int att
     if (static_cast<unsigned int>(UTL::Collections::Countable< IPlaceableScenery >::Count()) > 12u) {
         return nullptr;
     }
-    bHash32 render_name(bStringHash(name));
+    bHash32 render_name(name);
     UCrc32 collision_name(name);
     bHash32 heirarchy_name(render_name);
     const ModelHeirarchy *heirarchy = FindSceneryHeirarchyByName(render_name.GetValue());
@@ -994,23 +994,16 @@ PlaceableScenery *PlaceableScenery::Construct(const char *name, unsigned int att
         return nullptr;
     }
     const CollisionGeometry::Bounds *bounds = collection->GetRoot();
-    if (bounds != nullptr) {
-        eModel model;
-        model.Init(render_name.GetValue());
-        if (model.GetSolid() == nullptr) {
-            bHash32 fallback(0xc7395a8);
-            render_name = fallback;
-            heirarchy_name = fallback;
-        }
-        const Attrib::Collection *attribs =
-            Attrib::FindCollection(Attrib::Gen::smackable::ClassKey(), attributes);
-        Attrib::Gen::smackable smk_attribs(attribs, 0, nullptr);
-        PlaceableScenery *result = new PlaceableScenery(heirarchy_name, bounds,
-                                                        smk_attribs.GetConstCollection(),
-                                                        heirarchy);
-        return result;
+    if (bounds == nullptr) {
+        return nullptr;
     }
-    return nullptr;
+    eModel model;
+    model.Init(render_name.GetValue());
+    if (model.GetSolid() == nullptr) {
+        render_name = bHash32(0xc7395a8);
+    }
+    Attrib::Gen::smackable smk_attribs(attributes, 0, nullptr);
+    return new PlaceableScenery(render_name, bounds, smk_attribs.GetConstCollection(), heirarchy);
 }
 
 void PlaceableScenery::PickUp() {

--- a/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
@@ -992,8 +992,7 @@ PlaceableScenery *PlaceableScenery::Construct(const char *name, unsigned int att
     if (bounds == nullptr) {
         return nullptr;
     }
-    eModel model;
-    model.Init(render_name.GetValue());
+    eModel model(render_name.GetValue());
     if (model.GetSolid() == nullptr) {
         render_name = bHash32(0xc7395a8);
     }

--- a/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
@@ -292,7 +292,7 @@ void Smackable::OnBehaviorChange(const UCrc32 &mechanic) {
         if (static_cast<ISimable *>(this)->QueryInterface(&mCollisionBody)) {
             float detach = mAttributes.DETACH_FORCE();
             if (mVirgin && detach != 0.0f) {
-                mCollisionBody->AttachedToWorld(true, UMath::Max(0.0f, detach));
+                mCollisionBody->AttachedToWorld(true, UMath::Max(detach, 0.0f));
             }
             const CollisionGeometry::Bounds *cog =
                 mGeometry->GetChild(UCrc32(0x28b0bb8d));

--- a/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
@@ -61,13 +61,10 @@ static float Smackable_ManagementRate = 0.125f;
 static float GetDropTimer(const Attrib::Gen::smackable &attributes) {
     float result;
     result = attributes.DROPOUT(0);
-    if (!(result > 0.0f)) {
+    if (!(result > 0.0f) || !(attributes.DROPOUT(1) > 0.0f)) {
         return 0.0f;
     }
-    if (attributes.DROPOUT(1) > 0.0f) {
-        return result;
-    }
-    return 0.0f;
+    return result;
 }
 
 bool Smackable::Simplify() {

--- a/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
@@ -709,11 +709,11 @@ bool RBSmackable::CanCollideWithWorld() const {
 }
 
 HeirarchyModel::HeirarchyModel(bHash32 rendermesh, const CollisionGeometry::Bounds *geometry,
-                               UCrc32 nodename, HeirarchyModel *parent,
+                               UCrc32 rendernode, HeirarchyModel *parent,
                                const Attrib::Collection *attribs, const ModelHeirarchy *heirarchy,
-                               unsigned int child_index, bool visible)
+                               unsigned int heirarchynode, bool visible)
     : Sim::Model(parent != nullptr ? static_cast<IModel *>(parent) : nullptr, geometry,
-                 nodename, 6) //
+                 rendernode, 6) //
     , IBody(this) //
     , ITriggerableModel(this) //
     , Attrib::Gen::smackable(attribs, 0, nullptr) //
@@ -722,7 +722,7 @@ HeirarchyModel::HeirarchyModel(bHash32 rendermesh, const CollisionGeometry::Boun
     , mRenderMesh(rendermesh) //
     , mTrigger(nullptr) //
     , mOffScreenTimer(10.0f) //
-    , mHeirarchyNode(static_cast<unsigned short>(child_index)) //
+    , mHeirarchyNode(static_cast<unsigned short>(heirarchynode)) //
     , mFlags(0) //
     , mChildVisibility(0xFFFFFFFF) //
     , mAvoidable(nullptr) //
@@ -734,9 +734,7 @@ HeirarchyModel::HeirarchyModel(bHash32 rendermesh, const CollisionGeometry::Boun
         BeginDraw(UCrc32(0x804c146e), &pkt);
     }
     if (smackable.AI_AVOIDABLE()) {
-        if (HasAvoidable() != true) {
-            mAvoidable = new SmackableAvoidable(this);
-        }
+        SetAvoidable(true);
     }
     if (smackable.CAMERA_AVOIDABLE()) {
         SetCameraAvoidable(true);

--- a/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
@@ -847,8 +847,7 @@ IModel *HeirarchyModel::SpawnModel(UCrc32 rendernode, UCrc32 collisionnode, UCrc
     if (emodel == nullptr) {
         return nullptr;
     }
-    bHash32 meshname(emodel->GetNameHash());
-    HeirarchyModel *child = new HeirarchyModel(meshname, bounds, rendernode, this, attribs,
+    HeirarchyModel *child = new HeirarchyModel(bHash32(emodel->GetNameHash()), bounds, rendernode, this, attribs,
                                                mHeirarchy, childindex, true);
     IModel *result = nullptr;
     if (child != nullptr) {

--- a/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
@@ -183,8 +183,9 @@ Smackable::Smackable(const UMath::Matrix4 &matrix, const Attrib::Gen::smackable 
     float radius = UMath::Length(dimension);
     float mass = mAttributes.MASS();
     Dynamics::Inertia::Box inertia(mass, dimension.x * 2.0f, dimension.y * 2.0f, dimension.z * 2.0f);
-    UMath::Scale(inertia, 2.0f, inertia);
     UMath::Vector3 moment;
+    UCrc32 smack_class;
+    UMath::Scale(inertia, 2.0f, inertia);
     if (mAttributes.MOMENT(moment)) {
         if (moment.x > 0.0f) {
             inertia.x *= moment.x;
@@ -197,7 +198,6 @@ Smackable::Smackable(const UMath::Matrix4 &matrix, const Attrib::Gen::smackable 
         }
     }
     bool active = !virginspawn || mPersistant;
-    UCrc32 smack_class;
     if (simple_physics) {
         RBSimpleParams rbp(UMath::Vector4To3(matrix.v3), UMath::Vector3::kZero,
                            UMath::Vector3::kZero, matrix, radius, mass);
@@ -225,8 +225,7 @@ Smackable::Smackable(const UMath::Matrix4 &matrix, const Attrib::Gen::smackable 
     if (mAttributes.EventSequencer().IsNotEmpty()) {
         Sim::Collision::AddListener(static_cast<Sim::Collision::IListener *>(this),
                                     GetInstanceHandle(), "Smackable");
-    }
-}
+    }}
 
 Smackable::~Smackable() {
     DetachAll();

--- a/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
@@ -822,38 +822,38 @@ int HeirarchyModel::FindHeirarchyChild(const UCrc32 &nodename) const {
 }
 
 IModel *HeirarchyModel::SpawnModel(UCrc32 rendernode, UCrc32 collisionnode, UCrc32 attributes) {
-    if (mHeirarchy != nullptr && !IsDirty()) {
-        if (UTL::Collections::Listable< IModel, 434 >::Count() > 434u) {
-            return nullptr;
-        }
-        int childindex = FindHeirarchyChild(rendernode);
-        if (childindex > -1) {
-            const CollisionGeometry::Bounds *geom = GetCollisionGeometry();
-            const CollisionGeometry::Bounds *bounds =
-                geom->GetChild(collisionnode);
-            if (bounds != nullptr) {
-                const Attrib::Collection *attribs =
-                    SmokeableSpawner::FindAttributes(attributes);
-                if (attribs != nullptr) {
-                    const ModelHeirarchy::Node *nodes = mHeirarchy->GetNodes();
-                    eModel *emodel =
-                        reinterpret_cast<eModel *>(nodes[childindex].mModel);
-                    if (emodel != nullptr) {
-                        bHash32 meshname(emodel->GetNameHash());
-                        HeirarchyModel *child = new HeirarchyModel(
-                            meshname, bounds, rendernode, this, attribs, mHeirarchy,
-                            childindex, true);
-                        IModel *result = nullptr;
-                        if (child != nullptr) {
-                            result = static_cast<IModel *>(child);
-                        }
-                        return result;
-                    }
-                }
-            }
-        }
+    if (mHeirarchy == nullptr || IsDirty()) {
+        return nullptr;
     }
-    return nullptr;
+    if (UTL::Collections::Listable< IModel, 434 >::Count() > 434u) {
+        return nullptr;
+    }
+    int childindex = FindHeirarchyChild(rendernode);
+    if (childindex <= -1) {
+        return nullptr;
+    }
+    const CollisionGeometry::Bounds *geom = GetCollisionGeometry();
+    const CollisionGeometry::Bounds *bounds = geom->GetChild(collisionnode);
+    if (bounds == nullptr) {
+        return nullptr;
+    }
+    const Attrib::Collection *attribs = SmokeableSpawner::FindAttributes(attributes);
+    if (attribs == nullptr) {
+        return nullptr;
+    }
+    const ModelHeirarchy::Node *nodes = mHeirarchy->GetNodes();
+    eModel *emodel = reinterpret_cast<eModel *>(nodes[childindex].mModel);
+    if (emodel == nullptr) {
+        return nullptr;
+    }
+    bHash32 meshname(emodel->GetNameHash());
+    HeirarchyModel *child = new HeirarchyModel(meshname, bounds, rendernode, this, attribs,
+                                               mHeirarchy, childindex, true);
+    IModel *result = nullptr;
+    if (child != nullptr) {
+        result = static_cast<IModel *>(child);
+    }
+    return result;
 }
 
 HeirarchyModel::~HeirarchyModel() {

--- a/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
@@ -199,9 +199,9 @@ Smackable::Smackable(const UMath::Matrix4 &matrix, const Attrib::Gen::smackable 
     }
     bool active = !virginspawn || mPersistant;
     if (simple_physics) {
-        RBSimpleParams rbp(UMath::Vector4To3(matrix.v3), UMath::Vector3::kZero,
-                           UMath::Vector3::kZero, matrix, radius, mass);
-        LoadBehavior(UCrc32(BEHAVIOR_MECHANIC_RIGIDBODY), UCrc32("SimpleRigidBody"), rbp);
+        LoadBehavior(UCrc32(BEHAVIOR_MECHANIC_RIGIDBODY), UCrc32("SimpleRigidBody"),
+                     RBSimpleParams(UMath::Vector4To3(matrix.v3), UMath::Vector3::kZero,
+                                    UMath::Vector3::kZero, matrix, radius, mass));
     } else {
         RBComplexParams rbparams(UMath::Vector4To3(matrix.v3), UMath::Vector3::kZero,
                                  UMath::Vector3::kZero, matrix, mass, inertia, dimension, geoms,

--- a/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
@@ -57,7 +57,7 @@ UTL::COM::Factory<Sim::Param, ISimable, UCrc32>::Prototype _Smackable("Smackable
 UTL::COM::Factory<const BehaviorParams &, Behavior, UCrc32>::Prototype __RBSmackable(
     "RBSmackable", RBSmackable::Construct);
 
-static float Smackable_ManagementRate = 0.125f;
+static const float Smackable_ManagementRate = 0.125f;
 
 static float GetDropTimer(const Attrib::Gen::smackable &attributes) {
     float result;
@@ -181,11 +181,11 @@ Smackable::Smackable(const UMath::Matrix4 &matrix, const Attrib::Gen::smackable 
     dimension.y = UMath::Max(dimension.y, 0.025f);
     dimension.z = UMath::Max(dimension.z, 0.025f);
     float radius = UMath::Length(dimension);
-    float mass = attributes.MASS();
+    float mass = mAttributes.MASS();
     Dynamics::Inertia::Box inertia(mass, dimension.x * 2.0f, dimension.y * 2.0f, dimension.z * 2.0f);
     UMath::Scale(inertia, 2.0f, inertia);
     UMath::Vector3 moment;
-    if (attributes.MOMENT(moment)) {
+    if (mAttributes.MOMENT(moment)) {
         if (moment.x > 0.0f) {
             inertia.x *= moment.x;
         }

--- a/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
@@ -297,7 +297,8 @@ void Smackable::OnBehaviorChange(const UCrc32 &mechanic) {
         if (static_cast<ISimable *>(this)->QueryInterface(&mCollisionBody)) {
             float detach = mAttributes.DETACH_FORCE();
             if (mVirgin && detach != 0.0f) {
-                mCollisionBody->AttachedToWorld(true, UMath::Max(detach, 0.0f));
+                float force = UMath::Max(detach, 0.0f);
+                mCollisionBody->AttachedToWorld(true, force);
             }
             const CollisionGeometry::Bounds *cog =
                 mGeometry->GetChild(UCrc32(0x28b0bb8d));

--- a/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
@@ -211,8 +211,8 @@ Smackable::Smackable(const UMath::Matrix4 &matrix, const Attrib::Gen::smackable 
         } else {
             LoadBehavior(UCrc32(BEHAVIOR_MECHANIC_RIGIDBODY), UCrc32("RBSmackable"), rbparams);
         }
+        LoadBehavior(UCrc32(BEHAVIOR_MECHANIC_EFFECTS), UCrc32("EffectsSmackable"), Sim::Param());
     }
-    LoadBehavior(UCrc32(BEHAVIOR_MECHANIC_EFFECTS), UCrc32("EffectsSmackable"), Sim::Param());
     for (unsigned int i = 0; i < mAttributes.Num_BEHAVIORS(); ++i) {
         const Attrib::StringKey &key = mAttributes.BEHAVIORS(i);
         if (key.IsNotEmpty()) {

--- a/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
@@ -44,18 +44,19 @@ namespace DamageZone {
 UCrc32 GetImpactStimulus(unsigned int level);
 } // namespace DamageZone
 
-Attrib::StringKey BEHAVIOR_MECHANIC_EFFECTS;
+unsigned int Smackable_RigidCount;
+Attrib::StringKey Smackable::CYLINDER("CYLINDER");
+Attrib::StringKey Smackable::TUBE("TUBE");
+Attrib::StringKey Smackable::CONE("CONE");
+Attrib::StringKey Smackable::SPHERE("SPHERE");
+
+template <> UTL::Collections::Listable<Smackable, 160>::List UTL::Collections::Listable<Smackable, 160>::_mTable = UTL::Collections::Listable<Smackable, 160>::List();
 
 UTL::COM::Factory<Sim::Param, ISimable, UCrc32>::Prototype _Smackable("Smackable",
                                                                        Smackable::Construct);
 UTL::COM::Factory<const BehaviorParams &, Behavior, UCrc32>::Prototype __RBSmackable(
     "RBSmackable", RBSmackable::Construct);
 
-unsigned int Smackable_RigidCount;
-Attrib::StringKey Smackable::CYLINDER;
-Attrib::StringKey Smackable::TUBE;
-Attrib::StringKey Smackable::CONE;
-Attrib::StringKey Smackable::SPHERE;
 static float Smackable_ManagementRate = 0.125f;
 
 static float GetDropTimer(const Attrib::Gen::smackable &attributes) {
@@ -1063,4 +1064,3 @@ IPlaceableScenery *IPlaceableScenery::CreateInstance(const char *name, unsigned 
 
 PlaceableScenery::~PlaceableScenery() {}
 
-template <> UTL::Collections::Listable<Smackable, 160>::List UTL::Collections::Listable<Smackable, 160>::_mTable = UTL::Collections::Listable<Smackable, 160>::List();

--- a/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
@@ -1078,3 +1078,5 @@ IPlaceableScenery *IPlaceableScenery::CreateInstance(const char *name, unsigned 
 }
 
 PlaceableScenery::~PlaceableScenery() {}
+
+template <> UTL::Collections::Listable<Smackable, 160>::List UTL::Collections::Listable<Smackable, 160>::_mTable = UTL::Collections::Listable<Smackable, 160>::List();

--- a/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
@@ -809,13 +809,11 @@ int HeirarchyModel::FindHeirarchyChild(const UCrc32 &nodename) const {
     if (mHeirarchy == nullptr) {
         return -1;
     }
-    const ModelHeirarchy::Node *nodes = mHeirarchy->GetNodes();
-    const ModelHeirarchy::Node &node = nodes[mHeirarchyNode];
-    unsigned int numChildren = node.mNumChildren;
+    const ModelHeirarchy::Node &node = mHeirarchy->GetNodes()[mHeirarchyNode];
     int childindex = -1;
-    for (unsigned int i = 0; i < numChildren; ++i) {
+    for (unsigned int i = 0; i < node.mNumChildren; ++i) {
         int idx = node.mChildIndex + i;
-        if (nodes[idx].mNodeName == nodename) {
+        if (mHeirarchy->GetNodes()[idx].mNodeName == nodename) {
             childindex = idx;
             break;
         }

--- a/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
@@ -921,12 +921,8 @@ void HeirarchyModel::SetTrigger(const UMath::Matrix4 &matrix, bool virgin) {
         mTrigger->Enable();
     }
     mTriggerAvoid = matrix.v3;
-    float zz = dim.y * matrix.v1.z;
-    float zx = dim.y * matrix.v1.x;
-    zz += dim.x * matrix.v0.z;
-    zx += dim.x * matrix.v0.x;
-    zz += dim.z * matrix.v2.z;
-    zx += dim.z * matrix.v2.x;
+    float zx = dim.x * matrix.v0.x + dim.y * matrix.v1.x + dim.z * matrix.v2.x;
+    float zz = dim.x * matrix.v0.z + dim.y * matrix.v1.z + dim.z * matrix.v2.z;
     mTriggerAvoid.w = UMath::Sqrt(zx * zx + zz * zz);
 }
 

--- a/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
@@ -975,7 +975,7 @@ PlaceableScenery::PlaceableScenery(bHash32 rendermesh,
 }
 
 void PlaceableScenery::ReleaseModel() {
-    static_cast<IPlaceableScenery *>(this)->Destroy();
+    static_cast<IPlaceableScenery *>(this)->PickUp();
 }
 
 PlaceableScenery *PlaceableScenery::Construct(const char *name, unsigned int attributes) {
@@ -1016,7 +1016,7 @@ void PlaceableScenery::PickUp() {
 }
 
 bool PlaceableScenery::Place(const UMath::Matrix4 &transform, bool snap_to_ground) {
-    static_cast<IPlaceableScenery *>(this)->Destroy();
+    static_cast<IPlaceableScenery *>(this)->PickUp();
     UMath::Matrix4 mat;
     UMath::Copy(transform, mat);
     if (snap_to_ground) {

--- a/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
@@ -69,22 +69,26 @@ static float GetDropTimer(const Attrib::Gen::smackable &attributes) {
 }
 
 bool Smackable::Simplify() {
-    if (mCollisionBody != nullptr && !mPersistant) {
-        const UMath::Vector3 &pos = static_cast<ISimable *>(this)->GetPosition();
-        if (Sim::CanSpawnSimpleRigidBody(pos, true)) {
-            IRigidBody *irb = GetRigidBody();
-            UMath::Vector3 position = irb->GetPosition();
-            UMath::Vector3 velocity = irb->GetLinearVelocity();
-            UMath::Vector3 angular = irb->GetAngularVelocity();
-            float radius = irb->GetRadius();
-            float mass = irb->GetMass();
-            UMath::Matrix4 matrix = mCollisionBody->GetMatrix4();
-            RBSimpleParams rbp(position, velocity, angular, matrix, radius, mass);
-            LoadBehavior(UCrc32(BEHAVIOR_MECHANIC_RIGIDBODY), UCrc32("SimpleRigidBody"), rbp);
-            return true;
-        }
+    if (mCollisionBody == nullptr) {
+        return false;
     }
-    return false;
+    if (mPersistant) {
+        return false;
+    }
+    const UMath::Vector3 &pos = static_cast<ISimable *>(this)->GetPosition();
+    if (!Sim::CanSpawnSimpleRigidBody(pos, true)) {
+        return false;
+    }
+    IRigidBody *irb = GetRigidBody();
+    UMath::Vector3 position = irb->GetPosition();
+    UMath::Vector3 velocity = irb->GetLinearVelocity();
+    UMath::Vector3 angular = irb->GetAngularVelocity();
+    float radius = irb->GetRadius();
+    float mass = irb->GetMass();
+    UMath::Matrix4 matrix = mCollisionBody->GetMatrix4();
+    LoadBehavior(UCrc32(BEHAVIOR_MECHANIC_RIGIDBODY), UCrc32("SimpleRigidBody"),
+                 RBSimpleParams(position, velocity, angular, matrix, radius, mass));
+    return true;
 }
 
 bool Smackable::TrySimplify() {

--- a/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
@@ -184,7 +184,6 @@ Smackable::Smackable(const UMath::Matrix4 &matrix, const Attrib::Gen::smackable 
     float mass = mAttributes.MASS();
     Dynamics::Inertia::Box inertia(mass, dimension.x * 2.0f, dimension.y * 2.0f, dimension.z * 2.0f);
     UMath::Vector3 moment;
-    UCrc32 smack_class;
     UMath::Scale(inertia, 2.0f, inertia);
     if (mAttributes.MOMENT(moment)) {
         if (moment.x > 0.0f) {
@@ -198,6 +197,7 @@ Smackable::Smackable(const UMath::Matrix4 &matrix, const Attrib::Gen::smackable 
         }
     }
     bool active = !virginspawn || mPersistant;
+    UCrc32 smack_class;
     if (simple_physics) {
         LoadBehavior(UCrc32(BEHAVIOR_MECHANIC_RIGIDBODY), UCrc32("SimpleRigidBody"),
                      RBSimpleParams(UMath::Vector4To3(matrix.v3), UMath::Vector3::kZero,

--- a/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
@@ -1013,21 +1013,19 @@ bool PlaceableScenery::Place(const UMath::Matrix4 &transform, bool snap_to_groun
     UMath::Matrix4 mat;
     UMath::Copy(transform, mat);
     if (snap_to_ground) {
-        WCollisionMgr wcm(0, 3);
+        UMath::Vector3 dim;
         float worldHeight = 1000.0f;
-        if (!wcm.GetWorldHeightAtPointRigorous(UMath::Vector4To3(mat.v3), worldHeight, nullptr)) {
+        if (WCollisionMgr(0, 3).GetWorldHeightAtPointRigorous(UMath::Vector4To3(mat.v3), worldHeight, nullptr) == false) {
             return false;
         }
-        UMath::Vector3 dim;
         GetDimension(dim);
         mat.v3.y = worldHeight + dim.y;
     }
     PlaceTrigger(mat, false);
-    SmackableParams sp(mat, true, static_cast<IModel *>(this), false);
     ISimable *physics = UTL::COM::Factory< Sim::Param, ISimable, UCrc32 >::CreateInstance(
-        UCrc32("Smackable"), sp);
+        UCrc32("Smackable"), SmackableParams(mat, true, static_cast<IModel *>(this), false));
     if (physics == nullptr) {
-        static_cast<IPlaceableScenery *>(this)->Destroy();
+        static_cast<IPlaceableScenery *>(this)->PickUp();
         return false;
     }
     return true;

--- a/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
@@ -1,0 +1,1080 @@
+#include "Speed/Indep/Src/Physics/Smackable.h"
+
+#include "Speed/Indep/Libs/Support/Utility/UMath.h"
+#include "Speed/Indep/Libs/Support/Utility/UStandard.h"
+#include "Speed/Indep/Src/Camera/CameraAI.hpp"
+#include "Speed/Indep/Src/Ecstasy/Ecstasy.hpp"
+#include "Speed/Indep/Src/Interfaces/SimModels/IModel.h"
+#include "Speed/Indep/Src/Interfaces/SimModels/IPlaceableScenery.h"
+#include "Speed/Indep/Src/Interfaces/SimModels/ISceneryModel.h"
+#include "Speed/Indep/Src/Interfaces/SimModels/ITriggerableModel.h"
+#include "Speed/Indep/Src/Interfaces/Simables/ICause.h"
+#include "Speed/Indep/Src/Interfaces/Simables/IExplosion.h"
+#include "Speed/Indep/Src/Interfaces/Simables/IRigidBody.h"
+#include "Speed/Indep/Src/Interfaces/Simables/ISimpleBody.h"
+#include "Speed/Indep/Src/Main/AttribSupport.h"
+#include "Speed/Indep/Src/Physics/Behaviors/SimpleRigidBody.h"
+#include "Speed/Indep/Src/Physics/Behaviors/RigidBody.h"
+#include "Speed/Indep/Src/Physics/Bounds.h"
+#include "Speed/Indep/Src/Physics/Dynamics/Inertia.h"
+#include "Speed/Indep/Src/Physics/HeirarchyModel.h"
+#include "Speed/Indep/Src/Physics/PlaceableScenery.h"
+#include "Speed/Indep/Src/Physics/SmackableTrigger.h"
+#include "Speed/Indep/Src/Physics/SmokeableInfo.hpp"
+#include "Speed/Indep/Src/Render/RenderConn.h"
+#include "Speed/Indep/Src/Sim/Simulation.h"
+#include "Speed/Indep/Src/World/DamageZones.h"
+#include "Speed/Indep/Src/World/WCollisionMgr.h"
+#include "Speed/Indep/Src/World/WWorldPos.h"
+#include "Speed/Indep/Tools/Inc/ConversionUtil.hpp"
+
+namespace CameraAI {
+void AddAvoidable(IBody *body);
+void RemoveAvoidable(IBody *body);
+} // namespace CameraAI
+
+const ModelHeirarchy *FindSceneryHeirarchyByName(unsigned int name);
+
+namespace Sim {
+bool CanSpawnRigidBody(const UMath::Vector3 &position, bool highPriority);
+bool CanSpawnSimpleRigidBody(const UMath::Vector3 &position, bool highPriority);
+} // namespace Sim
+
+namespace DamageZone {
+UCrc32 GetImpactStimulus(unsigned int level);
+} // namespace DamageZone
+
+Attrib::StringKey BEHAVIOR_MECHANIC_EFFECTS;
+
+UTL::COM::Factory<Sim::Param, ISimable, UCrc32>::Prototype _Smackable("Smackable",
+                                                                       Smackable::Construct);
+UTL::COM::Factory<const BehaviorParams &, Behavior, UCrc32>::Prototype __RBSmackable(
+    "RBSmackable", RBSmackable::Construct);
+
+unsigned int Smackable_RigidCount;
+Attrib::StringKey Smackable::CYLINDER;
+Attrib::StringKey Smackable::TUBE;
+Attrib::StringKey Smackable::CONE;
+Attrib::StringKey Smackable::SPHERE;
+static float Smackable_ManagementRate = 0.125f;
+
+static float GetDropTimer(const Attrib::Gen::smackable &attributes) {
+    float result;
+    result = attributes.DROPOUT(0);
+    if (!(result > 0.0f)) {
+        return 0.0f;
+    }
+    if (attributes.DROPOUT(1) > 0.0f) {
+        return result;
+    }
+    return 0.0f;
+}
+
+bool Smackable::Simplify() {
+    if (mCollisionBody != nullptr && !mPersistant) {
+        const UMath::Vector3 &pos = static_cast<ISimable *>(this)->GetPosition();
+        if (Sim::CanSpawnSimpleRigidBody(pos, true)) {
+            IRigidBody *irb = GetRigidBody();
+            UMath::Vector3 position = irb->GetPosition();
+            UMath::Vector3 velocity = irb->GetLinearVelocity();
+            UMath::Vector3 angular = irb->GetAngularVelocity();
+            float radius = irb->GetRadius();
+            float mass = irb->GetMass();
+            UMath::Matrix4 matrix = mCollisionBody->GetMatrix4();
+            RBSimpleParams rbp(position, velocity, angular, matrix, radius, mass);
+            LoadBehavior(UCrc32(BEHAVIOR_MECHANIC_RIGIDBODY), UCrc32("SimpleRigidBody"), rbp);
+            return true;
+        }
+    }
+    return false;
+}
+
+bool Smackable::TrySimplify() {
+    for (Smackable *const *iter = UTL::Collections::Listable< Smackable, 160 >::GetList().begin();
+         iter != UTL::Collections::Listable< Smackable, 160 >::GetList().end(); ++iter) {
+        Smackable *smack = *iter;
+        if (smack->Simplify()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+ISimable *Smackable::Construct(Sim::Param params) {
+    const SmackableParams sp = params.Fetch< SmackableParams >(UCrc32(0xa6b47fac));
+    if (sp.fScenery == nullptr) {
+        return nullptr;
+    }
+    Attrib::Gen::smackable attributes(sp.fScenery->GetAttributes());
+    if (!attributes.IsValid()) {
+        return nullptr;
+    }
+    IPlaceableScenery *placeable = nullptr;
+    bool is_persistant = false;
+    if (sp.fScenery->QueryInterface(&placeable)) {
+        is_persistant = true;
+    }
+    bool simple_physics = attributes.SimplePhysics() || sp.fSimplePhysics;
+    if (!simple_physics && !is_persistant && Smackable_RigidCount >= 0x14 && !TrySimplify()) {
+        return nullptr;
+    }
+    sp.fScenery->GetWorldID();
+    const CollisionGeometry::Bounds *geoms = sp.fScenery->GetCollisionGeometry();
+    if (geoms == nullptr) {
+        return nullptr;
+    }
+    if (!(attributes.MASS() > 0.0f)) {
+        return nullptr;
+    }
+    UMath::Matrix4 matrix = sp.fMatrix;
+    if (simple_physics) {
+        if (!Sim::CanSpawnSimpleRigidBody(UMath::Vector4To3(matrix.v3), false)) {
+            return nullptr;
+        }
+    } else {
+        if (!Sim::CanSpawnRigidBody(UMath::Vector4To3(matrix.v3), false)) {
+            return nullptr;
+        }
+    }
+    if (Manager::Get() == nullptr) {
+        if (new Manager(Smackable_ManagementRate) == nullptr) {
+            return nullptr;
+        }
+    }
+    return new Smackable(matrix, attributes, geoms, sp.fVirginSpawn, sp.fScenery, simple_physics,
+                         is_persistant);
+}
+
+Smackable::Smackable(const UMath::Matrix4 &matrix, const Attrib::Gen::smackable &attributes,
+                     const CollisionGeometry::Bounds *geoms, bool virginspawn, IModel *scenery,
+                     bool simple_physics, bool is_persistant)
+    : PhysicsObject(attributes, SIMABLE_SMACKABLE, scenery->GetWorldID(), 10) //
+    , IDisposable(this) //
+    , IRenderable(this) //
+    , IExplodeable(this) //
+    , EventSequencer::IContext(this) //
+    , mAttributes(attributes) //
+    , mSimplifyWeight(0.0f) //
+    , mAge(0.0f) //
+    , mLife(Smackable_ManagementRate) //
+    , mDropTimer(0.0f) //
+    , mDropOutTimerMax(GetDropTimer(attributes)) //
+    , mOffWorldTimer(0.0f) //
+    , mAutoSimplify(attributes.AUTO_SIMPLIFY()) //
+    , mVirgin(virginspawn) //
+    , mModel(scenery) //
+    , mGeometry(geoms) //
+    , mManageTask(nullptr) //
+    , mDroppingOut(false) //
+    , mPersistant(is_persistant) //
+    , mCollisionBody(nullptr) //
+    , mSimpleBody(nullptr) //
+    , mLastImpactSpeed(UMath::Vector3::kZero) //
+    , mRBSpecs(static_cast<ISimable *>(this), 0) //
+    , mLastCollisionPosition(UMath::Vector4::kZero) //
+{
+    UMath::Vector3 dimension;
+    geoms->GetHalfDimensions(dimension);
+    dimension.x = UMath::Max(dimension.x, 0.025f);
+    dimension.y = UMath::Max(dimension.y, 0.025f);
+    dimension.z = UMath::Max(dimension.z, 0.025f);
+    float radius = UMath::Length(dimension);
+    float mass = attributes.MASS();
+    Dynamics::Inertia::Box inertia(mass, dimension.x, dimension.y, dimension.z);
+    UMath::Scale(inertia, 2.0f, inertia);
+    UMath::Vector3 moment;
+    if (attributes.MOMENT(moment)) {
+        if (moment.x > 0.0f) {
+            inertia.x *= moment.x;
+        }
+        if (moment.y > 0.0f) {
+            inertia.y *= moment.y;
+        }
+        if (moment.z > 0.0f) {
+            inertia.z *= moment.z;
+        }
+    }
+    bool active = !virginspawn || mPersistant;
+    UCrc32 smack_class;
+    if (simple_physics) {
+        RBSimpleParams rbp(UMath::Vector4To3(matrix.v3), UMath::Vector3::kZero,
+                           UMath::Vector3::kZero, matrix, radius, mass);
+        LoadBehavior(UCrc32(BEHAVIOR_MECHANIC_RIGIDBODY), UCrc32("SimpleRigidBody"), rbp);
+    } else {
+        RBComplexParams rbparams(UMath::Vector4To3(matrix.v3), UMath::Vector3::kZero,
+                                 UMath::Vector3::kZero, matrix, mass, inertia, dimension, geoms,
+                                 active, 0);
+        if (mPersistant) {
+            LoadBehavior(UCrc32(BEHAVIOR_MECHANIC_RIGIDBODY), UCrc32("RigidBody"), rbparams);
+        } else {
+            LoadBehavior(UCrc32(BEHAVIOR_MECHANIC_RIGIDBODY), UCrc32("RBSmackable"), rbparams);
+        }
+    }
+    LoadBehavior(UCrc32(BEHAVIOR_MECHANIC_EFFECTS), UCrc32("EffectsSmackable"), Sim::Param());
+    for (unsigned int i = 0; i < mAttributes.Num_BEHAVIORS(); ++i) {
+        const Attrib::StringKey &key = mAttributes.BEHAVIORS(i);
+        if (key.IsNotEmpty()) {
+            LoadBehavior(UCrc32(key), UCrc32(key), Sim::Param());
+        }
+    }
+    Attach(scenery);
+    mManageTask = AddTask("Physics", 0.1f, 0.0f, Sim::TASK_FRAME_FIXED);
+    CalcSimplificationWeight();
+    if (mAttributes.EventSequencer().IsNotEmpty()) {
+        Sim::Collision::AddListener(static_cast<Sim::Collision::IListener *>(this),
+                                    GetInstanceHandle(), "Smackable");
+    }
+}
+
+Smackable::~Smackable() {
+    DetachAll();
+    if (mManageTask != nullptr) {
+        RemoveTask(mManageTask);
+        mManageTask = nullptr;
+    }
+    if (mModel != nullptr) {
+        Detach(mModel);
+        mModel = nullptr;
+    }
+    ReleaseBehavior(UCrc32(BEHAVIOR_MECHANIC_EFFECTS));
+    ReleaseBehavior(UCrc32(BEHAVIOR_MECHANIC_RIGIDBODY));
+    Sim::Collision::RemoveListener(static_cast<Sim::Collision::IListener *>(this));
+}
+
+bool Smackable::SetDynamicData(const EventSequencer::System *system, EventDynamicData *data) {
+    data->fPosition = mLastCollisionPosition;
+    return true;
+}
+
+template void UTL::Vector<ISimpleBody *, 16>::push_back(ISimpleBody *const &);
+
+bool Smackable::OnExplosion(const UMath::Vector3 &normal, const UMath::Vector3 &position,
+                            float dT, IExplosion *explosion) {
+    unsigned int targets = explosion->GetTargets();
+    if ((targets & 1) == 0) {
+        return false;
+    }
+    IRigidBody *irb = GetRigidBody();
+    float factor = mAttributes.ExplosionEffect();
+    if (!(0.0f < factor)) {
+        return false;
+    }
+    float targetspeed = explosion->GetExpansionSpeed() * factor;
+    UMath::Vector3 point_velocity;
+    irb->GetPointVelocity(position, point_velocity);
+    float speed = UMath::Dot(point_velocity, normal);
+    if (speed < targetspeed) {
+        float deltaspeed = targetspeed - speed;
+        UMath::Vector3 impactvel;
+        UMath::Scale(normal, deltaspeed, impactvel);
+        UMath::Vector3 force;
+        UMath::Scale(impactvel, irb->GetMass() / dT, force);
+        irb->ResolveForce(force, position);
+    }
+    EventSequencer::IEngine *sequencer = static_cast<ISimable *>(this)->GetEventSequencer();
+    if (sequencer != nullptr) {
+        sequencer->ProcessStimulus(0xab556d39, Sim::GetTime(), nullptr,
+                                   EventSequencer::QUEUE_ALLOW);
+        if (explosion->HasDamage()) {
+            sequencer->ProcessStimulus(0xffcd8a63, Sim::GetTime(), nullptr,
+                                       EventSequencer::QUEUE_ALLOW);
+        }
+    }
+    if (!static_cast<ISimable *>(this)->GetCausality() && explosion->GetCausality()) {
+        ICause *cause = ICause::FindInstance(explosion->GetCausality());
+        if (cause != nullptr) {
+            cause->OnCausedExplosion(explosion, static_cast<ISimable *>(this));
+        }
+    }
+    return true;
+}
+
+void Smackable::OnBehaviorChange(const UCrc32 &mechanic) {
+    PhysicsObject::OnBehaviorChange(mechanic);
+    if (mechanic == UCrc32(BEHAVIOR_MECHANIC_RIGIDBODY)) {
+        if (static_cast<ISimable *>(this)->QueryInterface(&mCollisionBody)) {
+            float detach = mAttributes.DETACH_FORCE();
+            if (mVirgin && detach != 0.0f) {
+                mCollisionBody->AttachedToWorld(true, UMath::Max(0.0f, detach));
+            }
+            const CollisionGeometry::Bounds *cog =
+                mGeometry->GetChild(UCrc32(0x28b0bb8d));
+            if (cog != nullptr) {
+                UMath::Vector3 cog_position;
+                cog->GetPosition(cog_position);
+                mCollisionBody->SetCenterOfGravity(cog_position);
+            } else {
+                mCollisionBody->DistributeMass();
+            }
+        }
+        if (static_cast<ISimable *>(this)->QueryInterface(&mSimpleBody)) {
+            mSimpleBody->ModifyFlags(0, 0x20b);
+            ReleaseBehavior(UCrc32(BEHAVIOR_MECHANIC_EFFECTS));
+        }
+    }
+}
+
+void Smackable::DoImpactStimulus(unsigned int systemid, float intensity) {
+    float time;
+    EventSequencer::IEngine *iev;
+    EventSequencer::System *system;
+    unsigned int level;
+    time = Sim::GetTime();
+    iev = static_cast<ISimable *>(this)->GetEventSequencer();
+    if (iev != nullptr) {
+        system = iev->FindSystem(systemid);
+        if (system != nullptr) {
+            intensity = UMath::Clamp(intensity, 0.0f, 1.0f);
+            level = static_cast<unsigned int>(intensity * 6.0f);
+            for (unsigned int i = 0; i < level + 1; i++) {
+                system->ProcessStimulus(DamageZone::GetImpactStimulus(i).GetValue(), time,
+                                        static_cast<EventSequencer::IContext *>(this),
+                                        EventSequencer::QUEUE_ALLOW);
+            }
+        }
+    }
+}
+
+void Smackable::OnImpact(float acceleration, float speed,
+                         Sim::Collision::Info::CollisionType type, ISimable *iother) {
+    float time;
+    EventSequencer::IEngine *iev;
+    EventSequencer::System *system;
+    float intensity;
+    time = Sim::GetTime();
+    iev = static_cast<ISimable *>(this)->GetEventSequencer();
+    if (iev != nullptr) {
+        switch (type) {
+        case Sim::Collision::Info::OBJECT:
+            if (iother != nullptr) {
+                float intensity = acceleration / MPH2MPS(100.0f);
+                DoImpactStimulus(0xd59062c8, intensity);
+                if (iother->IsPlayer()) {
+                    DoImpactStimulus(0x2f698829, intensity);
+                }
+                if (iother->GetSimableType() == SIMABLE_VEHICLE) {
+                    DoImpactStimulus(0x80b88c1d, intensity);
+                }
+            }
+            break;
+        case Sim::Collision::Info::GROUND:
+            DoImpactStimulus(0x2bf74e61, speed * 0.1f);
+            break;
+        case Sim::Collision::Info::WORLD:
+            DoImpactStimulus(0x7ebe81c0, speed / MPH2MPS(100.0f));
+            break;
+        default:
+            break;
+        }
+    }
+}
+
+void Smackable::OnCollision(const Sim::Collision::Info &cinfo) {
+    EventSequencer::IEngine *iev = static_cast<ISimable *>(this)->GetEventSequencer();
+    if (iev == nullptr) {
+        return;
+    }
+    float speed = UMath::Length(cinfo.closingVel);
+    if (speed < 0.0f) {
+        return;
+    }
+    mLastCollisionPosition = UMath::Vector4Make(cinfo.position, 0.0f);
+    if (cinfo.objA == static_cast<ISimable *>(this)->GetInstanceHandle()) {
+        UMath::Vector3 normal = cinfo.normal;
+        mLastImpactSpeed = cinfo.objAVel;
+        float impact_acceleration = cinfo.impulseA;
+        OnImpact(impact_acceleration, speed, cinfo.Type(), ISimable::FindInstance(cinfo.objB));
+    } else if (cinfo.objB == static_cast<ISimable *>(this)->GetInstanceHandle()) {
+        UMath::Vector3 normal;
+        UMath::Scale(cinfo.normal, -1.0f, normal);
+        mLastImpactSpeed = cinfo.objBVel;
+        float impact_acceleration = cinfo.impulseB;
+        OnImpact(impact_acceleration, speed, cinfo.Type(), ISimable::FindInstance(cinfo.objA));
+    }
+}
+
+bool Smackable::InView() const {
+    if (mModel != nullptr) {
+        return mModel->InView();
+    }
+    return false;
+}
+
+bool Smackable::IsRenderable() const { return mModel != nullptr; }
+
+const IModel *Smackable::GetModel() const { return mModel; }
+IModel *Smackable::GetModel() { return mModel; }
+
+float Smackable::DistanceToView() const {
+    if (mModel != nullptr) {
+        return mModel->DistanceToView();
+    }
+    return 0.0f;
+}
+
+void Smackable::Kill() {
+    if (mManageTask != nullptr) {
+        RemoveTask(mManageTask);
+        mManageTask = nullptr;
+    }
+    if (mModel != nullptr && !mPersistant) {
+        mModel->ReleaseModel();
+        mModel = nullptr;
+    }
+    if (mCollisionBody != nullptr) {
+        mCollisionBody->DisableModeling();
+        mCollisionBody->DisableTriggering();
+    }
+    if (mSimpleBody != nullptr) {
+        mSimpleBody->ModifyFlags(0x308, 0);
+    }
+    PhysicsObject::Kill();
+}
+
+bool Smackable::Dropout() {
+    if (mCollisionBody == nullptr) {
+        return false;
+    }
+    if (mDropOutTimerMax <= 0.0f) {
+        return false;
+    }
+    if (!mCollisionBody->IsAttachedToWorld()) {
+        mCollisionBody->DisableModeling();
+        mCollisionBody->DisableTriggering();
+        mDropTimer = mDropOutTimerMax;
+        return true;
+    }
+    return false;
+}
+
+bool Smackable::ValidateWorld() {
+    const UMath::Vector3 &position = static_cast<ISimable *>(this)->GetPosition();
+    WWorldPos &wpos = static_cast<ISimable *>(this)->GetWPos();
+    wpos.FindClosestFace(position, true);
+    if (!wpos.OnValidFace()) {
+        goto fail;
+    }
+    {
+        float height = wpos.HeightAtPoint(position);
+        IRigidBody *irb = GetRigidBody();
+        float radius = irb->GetRadius();
+        if (height <= position.y + radius) {
+            goto success;
+        }
+    }
+fail:
+    return false;
+success:
+    return true;
+}
+
+bool Smackable::ShouldDie() {
+    if (mDroppingOut) {
+        return false;
+    }
+    if (mCollisionBody == nullptr) {
+        return false;
+    }
+    if (mCollisionBody->IsSleeping()) {
+        if (!mCollisionBody->HasHadObjectCollision()) {
+            return true;
+        }
+    }
+    if (mCollisionBody == nullptr) {
+        goto shouldnt_die;
+    }
+    if (mCollisionBody->IsModeling()) {
+        goto shouldnt_die;
+    }
+    return true;
+shouldnt_die:
+    return false;
+}
+
+bool Smackable::CanRetrigger() const {
+    if (mCollisionBody == nullptr) {
+        return false;
+    }
+    if (!GetWPos().OnValidFace()) {
+        return false;
+    }
+    if (mCollisionBody->IsSleeping()) {
+        return true;
+    }
+    return false;
+}
+
+void Smackable::ProcessDeath(float dT) {
+    if (ShouldDie()) {
+        if (mLife > 0.0f) {
+            mLife -= dT;
+            return;
+        }
+        if (Dropout()) {
+            return;
+        }
+        if (mModel != nullptr) {
+            if (CanRetrigger()) {
+                if (mVirgin && mCollisionBody != nullptr &&
+                    mCollisionBody->IsAttachedToWorld()) {
+                    ISceneryModel *iscenery = nullptr;
+                    if (mModel->QueryInterface(&iscenery)) {
+                        iscenery->RestoreScene();
+                        mModel = nullptr;
+                    }
+                } else {
+                    ITriggerableModel *itrigger = nullptr;
+                    if (mModel->QueryInterface(&itrigger)) {
+                        UMath::Matrix4 mat;
+                        static_cast<ISimable *>(this)->GetTransform(mat);
+                        itrigger->PlaceTrigger(mat, true);
+                        static_cast<ISimable *>(this)->Detach(mModel);
+                        mModel = nullptr;
+                    }
+                }
+            } else if (mModel != nullptr && !mPersistant) {
+                mModel->ReleaseModel();
+                mModel = nullptr;
+            }
+        }
+        static_cast<ISimable *>(this)->Kill();
+        return;
+    }
+    mLife = 0.125f;
+}
+
+bool Smackable::ProcessDropout(float dT) {
+    if (mDropOutTimerMax > 0.0f && mDropTimer > 0.0f) {
+        IRigidBody &rb = *GetRigidBody();
+        mDropTimer -= dT;
+        const float dropspeed = mAttributes.DROPOUT(1);
+        rb.ModifyYPos(-dropspeed * dT);
+        if (mDropTimer <= 0.0f) {
+            static_cast<ISimable *>(this)->Kill();
+            mDropTimer = 0.0f;
+        }
+        return true;
+    }
+    return false;
+}
+
+void Smackable::ProcessOffWorld(float dT) {
+    if (mAttributes.ALLOW_OFF_WORLD()) {
+        return;
+    }
+    if (!ValidateWorld()) {
+        mOffWorldTimer += dT;
+        if (mOffWorldTimer >= 1.0f) {
+            if (mModel != nullptr && !mPersistant) {
+                mModel->ReleaseModel();
+                mModel = nullptr;
+            }
+            static_cast<ISimable *>(this)->Kill();
+        }
+    } else {
+        mOffWorldTimer = 0.0f;
+    }
+}
+
+bool Smackable::OnTask(HSIMTASK htask, float dT) {
+    if (htask == mManageTask) {
+        Manage(dT);
+        return true;
+    }
+    return PhysicsObject::OnTask(htask, dT);
+}
+
+void Smackable::OnDetached(IAttachable *pOther) {
+    if (UTL::COM::ComparePtr(pOther, mModel)) {
+        mModel = nullptr;
+        if (!UTL::Collections::GarbageNode< PhysicsObject, 160 >::IsDirty()) {
+            static_cast<ISimable *>(this)->Kill();
+        }
+    }
+    PhysicsObject::OnDetached(pOther);
+}
+
+void Smackable::CalcSimplificationWeight() {
+    if (mCollisionBody == nullptr || mPersistant) {
+        mSimplifyWeight = -1.0f;
+    }
+    float dist = Sim::DistanceToCamera(static_cast<ISimable *>(this)->GetPosition());
+    float radius = GetRigidBody()->GetRadius();
+    float baseweight = static_cast<float>(mAttributes.CAN_SIMPLIFY());
+    if (!static_cast<IRenderable *>(this)->InView()) {
+        baseweight += baseweight;
+    }
+    mSimplifyWeight = (dist + baseweight) / radius;
+}
+
+void Smackable::Manage(float dT) {
+    ProcessDeath(dT);
+    ProcessOffWorld(dT);
+    CalcSimplificationWeight();
+}
+
+void Smackable::OnTaskSimulate(float dT) {
+    mAge += dT;
+    if (mCollisionBody != nullptr && mAutoSimplify > 0.0f && mAge > mAutoSimplify) {
+        Simplify();
+    }
+    mDroppingOut = ProcessDropout(dT);
+    IRigidBody *irb = GetRigidBody();
+    if (mSimpleBody != nullptr) {
+        UMath::Vector3 gravity = UMath::Vector3Make(0.0f, mRBSpecs.GRAVITY(), 0.0f);
+        UMath::Scale(gravity, irb->GetMass());
+        irb->ResolveForce(gravity);
+    }
+}
+
+Smackable::Manager::Manager(float rate) : Sim::Activity(0) {
+    mManageTask = AddTask("Smackable", rate, 0.0f, Sim::TASK_FRAME_FIXED);
+}
+
+Smackable::Manager::~Manager() {
+    RemoveTask(mManageTask);
+}
+
+bool Smackable::Manager::OnTask(HSIMTASK htask, float dT) {
+    if (htask == mManageTask) {
+        UTL::Collections::Listable< Smackable, 160 >::Sort(Smackable::SimplifySort);
+        if (Smackable_RigidCount > 0xa) {
+            TrySimplify();
+        }
+        return true;
+    }
+    return Sim::Object::OnTask(htask, dT);
+}
+
+Behavior *RBSmackable::Construct(const BehaviorParams &parms) {
+    const RBComplexParams rp = parms.fparams.Fetch< RBComplexParams >(UCrc32(0xa6b47fac));
+    return new RBSmackable(parms, rp);
+}
+
+RBSmackable::RBSmackable(const BehaviorParams &parms, const RBComplexParams &rp)
+    : RigidBody(parms, rp) //
+    , mSpecs(this, 0) //
+{
+    mFrame = 0;
+    Smackable_RigidCount++;
+}
+
+RBSmackable::~RBSmackable() { Smackable_RigidCount--; }
+
+bool RBSmackable::ShouldSleep() const {
+    if (Dynamics::Articulation::IsJoined(this)) {
+        return false;
+    }
+    return RigidBody::ShouldSleep();
+}
+
+void RBSmackable::OnTaskSimulate(float dT) {
+    RigidBody::OnTaskSimulate(dT);
+    mFrame++;
+}
+
+bool RBSmackable::CanCollideWith(const RigidBody &other) const {
+    if (Dynamics::Articulation::IsJoined(this, &other)) {
+        return false;
+    }
+    return RigidBody::CanCollideWith(other);
+}
+
+bool RBSmackable::CanCollideWithGround() const {
+    if (IsAttachedToWorld()) {
+        return false;
+    }
+    return RigidBody::CanCollideWithGround();
+}
+
+bool RBSmackable::CanCollideWithWorld() const {
+    if (IsAttachedToWorld()) {
+        return false;
+    }
+    if (!HasHadCollision()) {
+        float velSquare = UMath::LengthSquare(GetLinearVelocity());
+        if (velSquare < 4.0f) {
+            if ((mFrame & 3) != 0) {
+                return false;
+            }
+        } else if (velSquare < 225.0f) {
+            if ((mFrame & 1) != 0) {
+                return false;
+            }
+        }
+    }
+    return RigidBody::CanCollideWithWorld();
+}
+
+HeirarchyModel::HeirarchyModel(bHash32 rendermesh, const CollisionGeometry::Bounds *geometry,
+                               UCrc32 nodename, HeirarchyModel *parent,
+                               const Attrib::Collection *attribs, const ModelHeirarchy *heirarchy,
+                               unsigned int child_index, bool visible)
+    : Sim::Model(parent != nullptr ? static_cast<IModel *>(parent) : nullptr, geometry,
+                 nodename, 6) //
+    , IBody(this) //
+    , ITriggerableModel(this) //
+    , Attrib::Gen::smackable(attribs, 0, nullptr) //
+{
+    mTriggerAvoid = UMath::Vector4::kZero;
+    mHeirarchy = const_cast<ModelHeirarchy *>(heirarchy);
+    mHeirarchyNode = static_cast<unsigned short>(child_index);
+    mRenderMesh = rendermesh;
+    mOffScreenTimer = 10.0f;
+    mChildVisibility = 0xFFFFFFFF;
+    mAvoidable = nullptr;
+    mTrigger = nullptr;
+    mFlags = 0;
+    Attrib::Gen::smackable smackable(attribs, 0, nullptr);
+    if (visible) {
+        RenderConn::Pkt_Smackable_Open pkt(mRenderMesh, GetWorldID(), GetCollisionGeometry(),
+                                           mHeirarchy, mHeirarchyNode);
+        BeginDraw(UCrc32(0x804c146e), &pkt);
+    }
+    if (smackable.AI_AVOIDABLE()) {
+        if (mAvoidable == nullptr) {
+            mAvoidable = new SmackableAvoidable(this);
+        }
+    }
+    if (smackable.CAMERA_AVOIDABLE()) {
+        SetCameraAvoidable(true);
+    }
+}
+
+void HeirarchyModel::SetCameraAvoidable(bool b) {
+    bool is_avoidable = mFlags & 1;
+    if (static_cast<unsigned short>(b) != is_avoidable) {
+        if (b) {
+            if (!CAMERA_AVOIDABLE()) {
+                return;
+            }
+            CameraAI::AddAvoidable(static_cast<IBody *>(this));
+            mFlags = mFlags | 1;
+        } else {
+            CameraAI::RemoveAvoidable(static_cast<IBody *>(this));
+            mFlags = mFlags & 0xFFFE;
+        }
+    }
+}
+
+bool HeirarchyModel::OnRemoveOffScreen(float dT) {
+    if (0.0f < mOffScreenTimer) {
+        if (!static_cast<IModel *>(this)->InView()) {
+            mOffScreenTimer = mOffScreenTimer - dT;
+            if (mOffScreenTimer < 0.0f) {
+                mOffScreenTimer = 0.0f;
+                return true;
+            }
+        } else {
+            mOffScreenTimer = KILL_OFF_SCREEN();
+        }
+    }
+    return false;
+}
+
+void HeirarchyModel::OnProcessFrame(float dT) {
+    if (OnRemoveOffScreen(dT)) {
+        ReleaseModel();
+    }
+}
+
+void HeirarchyModel::HidePart(const UCrc32 &nodename) {
+    int index = FindHeirarchyChild(nodename);
+    if (index > -1) {
+        mChildVisibility = mChildVisibility & ~(1 << index);
+    }
+}
+
+void HeirarchyModel::ShowPart(const UCrc32 &nodename) {
+    int index = FindHeirarchyChild(nodename);
+    if (index > -1) {
+        mChildVisibility = mChildVisibility | (1 << index);
+    }
+}
+
+bool HeirarchyModel::IsPartVisible(const UCrc32 &nodename) const {
+    int index = FindHeirarchyChild(nodename);
+    if (index < 0) {
+        return false;
+    }
+    if ((mChildVisibility & (1 << index)) == 0) {
+        return false;
+    }
+    return true;
+}
+
+int HeirarchyModel::FindHeirarchyChild(const UCrc32 &nodename) const {
+    if (mHeirarchy == nullptr) {
+        return -1;
+    }
+    const ModelHeirarchy::Node *nodes = mHeirarchy->GetNodes();
+    const ModelHeirarchy::Node &node = nodes[mHeirarchyNode];
+    unsigned int numChildren = node.mNumChildren;
+    int childindex = -1;
+    for (unsigned int i = 0; i < numChildren; ++i) {
+        int idx = node.mChildIndex + i;
+        if (nodes[idx].mNodeName == nodename) {
+            childindex = idx;
+            break;
+        }
+    }
+    return childindex;
+}
+
+IModel *HeirarchyModel::SpawnModel(UCrc32 rendernode, UCrc32 collisionnode, UCrc32 attributes) {
+    if (mHeirarchy != nullptr && !IsDirty()) {
+        if (UTL::Collections::Listable< IModel, 434 >::Count() > 434u) {
+            return nullptr;
+        }
+        int childindex = FindHeirarchyChild(rendernode);
+        if (childindex > -1) {
+            const CollisionGeometry::Bounds *geom = GetCollisionGeometry();
+            const CollisionGeometry::Bounds *bounds =
+                geom->GetChild(collisionnode);
+            if (bounds != nullptr) {
+                const Attrib::Collection *attribs =
+                    SmokeableSpawner::FindAttributes(attributes);
+                if (attribs != nullptr) {
+                    const ModelHeirarchy::Node *nodes = mHeirarchy->GetNodes();
+                    eModel *emodel =
+                        reinterpret_cast<eModel *>(nodes[childindex].mModel);
+                    if (emodel != nullptr) {
+                        bHash32 meshname(emodel->GetNameHash());
+                        HeirarchyModel *child = new HeirarchyModel(
+                            meshname, bounds, rendernode, this, attribs, mHeirarchy,
+                            childindex, true);
+                        IModel *result = nullptr;
+                        if (child != nullptr) {
+                            result = static_cast<IModel *>(child);
+                        }
+                        return result;
+                    }
+                }
+            }
+        }
+    }
+    return nullptr;
+}
+
+HeirarchyModel::~HeirarchyModel() {
+    EndSimulation();
+    RemoveTrigger();
+    ReleaseChildModels();
+    if (mAvoidable != nullptr) {
+        delete mAvoidable;
+        mAvoidable = nullptr;
+    }
+    SetCameraAvoidable(false);
+}
+
+void HeirarchyModel::OnBeginDraw() {
+    StartSequencer(UCrc32(EventSequencer()));
+    mOffScreenTimer = KILL_OFF_SCREEN();
+}
+
+void HeirarchyModel::OnEndDraw() {
+    mOffScreenTimer = 0.0f;
+    if ((mFlags & 1) != 0) {
+        CameraAI::RemoveAvoidable(static_cast<IBody *>(this));
+        mFlags = mFlags & 0xFFFE;
+    }
+}
+
+void HeirarchyModel::GetTransform(UMath::Matrix4 &matrix) const {
+    if (static_cast<const IModel *>(this)->GetSimable()) {
+        static_cast<const IModel *>(this)->GetSimable()->GetTransform(matrix);
+    } else if (mTrigger != nullptr) {
+        mTrigger->GetObjectMatrix(matrix);
+    } else {
+        matrix = UMath::Matrix4::kIdentity;
+    }
+}
+
+void HeirarchyModel::GetAngularVelocity(UMath::Vector3 &velocity) const {
+    if (static_cast<const IModel *>(this)->GetSimable()) {
+        velocity = static_cast<const IModel *>(this)->GetSimable()->GetRigidBody()->GetAngularVelocity();
+    } else {
+        velocity = UMath::Vector3::kZero;
+    }
+}
+
+void HeirarchyModel::RemoveTrigger() {
+    if (mTrigger != nullptr) {
+        delete mTrigger;
+        mTrigger = nullptr;
+    }
+}
+
+void HeirarchyModel::DisableTrigger() {
+    if (mTrigger != nullptr) {
+        mTrigger->Disable();
+    }
+}
+
+void HeirarchyModel::SetTrigger(const UMath::Matrix4 &matrix, bool virgin) {
+    UMath::Vector3 dim;
+    GetCollisionGeometry()->GetHalfDimensions(dim);
+    if (mTrigger == nullptr) {
+        mTrigger = new SmackableTrigger(GetInstanceHandle(), virgin, matrix, dim, 0);
+    } else {
+        mTrigger->Move(matrix, dim, virgin);
+        mTrigger->Enable();
+    }
+    mTriggerAvoid = matrix.v3;
+    float zz = dim.y * matrix.v1.z;
+    float zx = dim.y * matrix.v1.x;
+    zz += dim.x * matrix.v0.z;
+    zx += dim.x * matrix.v0.x;
+    zz += dim.z * matrix.v2.z;
+    zx += dim.z * matrix.v2.x;
+    mTriggerAvoid.w = UMath::Sqrt(zx * zx + zz * zz);
+}
+
+void HeirarchyModel::PlaceTrigger(const UMath::Matrix4 &matrix, bool enable) {
+    SetTrigger(matrix, false);
+    if (!enable) {
+        DisableTrigger();
+    }
+}
+
+void HeirarchyModel::OnEndSimulation() {
+    if (mAvoidable != nullptr) {
+        mAvoidable->SetRefrence(static_cast<IBody *>(this));
+    }
+}
+
+void HeirarchyModel::OnBeginSimulation() {
+    DisableTrigger();
+    if (mAvoidable != nullptr) {
+        mAvoidable->SetRefrence(static_cast<IModel *>(this)->GetSimable());
+    }
+    RenderConn::Pkt_Smackable_Open pkt(mRenderMesh,
+                                       static_cast<IModel *>(this)->GetWorldID(),
+                                       static_cast<IModel *>(this)->GetCollisionGeometry(),
+                                       mHeirarchy,
+                                       mHeirarchyNode);
+    BeginDraw(UCrc32(0x804c146e), &pkt);
+}
+
+bool HeirarchyModel::OnDraw(Sim::Packet *service) {
+    RenderConn::Pkt_Smackable_Service *pss =
+        static_cast<RenderConn::Pkt_Smackable_Service *>(service);
+    UpdateVisibility(pss->IsVisible(), pss->DistanceToView());
+    pss->SetChildVisibility(mChildVisibility);
+    return true;
+}
+
+PlaceableScenery::PlaceableScenery(bHash32 rendermesh,
+                                   const CollisionGeometry::Bounds *geometry,
+                                   const Attrib::Collection *attribs,
+                                   const ModelHeirarchy *heirarchy)
+    : HeirarchyModel(rendermesh, geometry, UCrc32(0x9756df79), nullptr, attribs, heirarchy, 0,
+                     false) //
+    , IPlaceableScenery(this) //
+{
+}
+
+void PlaceableScenery::ReleaseModel() {
+    static_cast<IPlaceableScenery *>(this)->Destroy();
+}
+
+PlaceableScenery *PlaceableScenery::Construct(const char *name, unsigned int attributes) {
+    if (static_cast<unsigned int>(UTL::Collections::Listable< IModel, 434 >::Count()) > 434u) {
+        return nullptr;
+    }
+    if (static_cast<unsigned int>(UTL::Collections::Countable< IPlaceableScenery >::Count()) > 12u) {
+        return nullptr;
+    }
+    bHash32 render_name(bStringHash(name));
+    UCrc32 collision_name(name);
+    bHash32 heirarchy_name(render_name);
+    const ModelHeirarchy *heirarchy = FindSceneryHeirarchyByName(render_name.GetValue());
+    const CollisionGeometry::Collection *collection = CollisionGeometry::Lookup(collision_name);
+    if (collection == nullptr) {
+        return nullptr;
+    }
+    const CollisionGeometry::Bounds *bounds = collection->GetRoot();
+    if (bounds != nullptr) {
+        eModel model;
+        model.Init(render_name.GetValue());
+        if (model.GetSolid() == nullptr) {
+            bHash32 fallback(0xc7395a8);
+            render_name = fallback;
+            heirarchy_name = fallback;
+        }
+        const Attrib::Collection *attribs =
+            Attrib::FindCollection(Attrib::Gen::smackable::ClassKey(), attributes);
+        Attrib::Gen::smackable smk_attribs(attribs, 0, nullptr);
+        PlaceableScenery *result = new PlaceableScenery(heirarchy_name, bounds,
+                                                        smk_attribs.GetConstCollection(),
+                                                        heirarchy);
+        return result;
+    }
+    return nullptr;
+}
+
+void PlaceableScenery::PickUp() {
+    ReleaseChildModels();
+    StopEffects();
+    EndDraw();
+    EndSimulation();
+    ReleaseSequencer();
+    DisableTrigger();
+}
+
+bool PlaceableScenery::Place(const UMath::Matrix4 &transform, bool snap_to_ground) {
+    static_cast<IPlaceableScenery *>(this)->Destroy();
+    UMath::Matrix4 mat;
+    UMath::Copy(transform, mat);
+    if (snap_to_ground) {
+        WCollisionMgr wcm(0, 3);
+        float worldHeight = 1000.0f;
+        if (!wcm.GetWorldHeightAtPointRigorous(UMath::Vector4To3(mat.v3), worldHeight, nullptr)) {
+            return false;
+        }
+        UMath::Vector3 dim;
+        GetDimension(dim);
+        mat.v3.y = worldHeight + dim.y;
+    }
+    PlaceTrigger(mat, false);
+    SmackableParams sp(mat, true, static_cast<IModel *>(this), false);
+    ISimable *physics = UTL::COM::Factory< Sim::Param, ISimable, UCrc32 >::CreateInstance(
+        UCrc32("Smackable"), sp);
+    if (physics == nullptr) {
+        static_cast<IPlaceableScenery *>(this)->Destroy();
+        return false;
+    }
+    return true;
+}
+
+SmackableAvoidable::SmackableAvoidable(HeirarchyModel *model)
+    : AIAvoidable(
+          mModel != nullptr
+              ? static_cast<UTL::COM::IUnknown *>(static_cast<IModel *>(mModel))
+              : nullptr) //
+    , mModel(model) //
+{
+    SetAvoidableObject(mModel != nullptr
+                           ? static_cast<UTL::COM::IUnknown *>(static_cast<IBody *>(mModel))
+                           : nullptr);
+}
+
+bool SmackableAvoidable::OnUpdateAvoidable(UMath::Vector3 &pos, float &sweep) {
+    return mModel->OnUpdateAvoidable(pos, sweep);
+}
+
+inline bool Smackable::SimplifySort(const Smackable *lhs, const Smackable *rhs) {
+    if (lhs->mSimplifyWeight > rhs->mSimplifyWeight) {
+        return true;
+    }
+    if (lhs->mSimplifyWeight < rhs->mSimplifyWeight) {
+        return false;
+    }
+    return lhs->GetInstanceHandle() < rhs->GetInstanceHandle();
+}
+
+IPlaceableScenery *IPlaceableScenery::CreateInstance(const char *name, unsigned int attributes) {
+    return PlaceableScenery::Construct(name, attributes);
+}
+
+PlaceableScenery::~PlaceableScenery() {}

--- a/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Smackable.cpp
@@ -177,7 +177,7 @@ Smackable::Smackable(const UMath::Matrix4 &matrix, const Attrib::Gen::smackable 
     dimension.z = UMath::Max(dimension.z, 0.025f);
     float radius = UMath::Length(dimension);
     float mass = attributes.MASS();
-    Dynamics::Inertia::Box inertia(mass, dimension.x, dimension.y, dimension.z);
+    Dynamics::Inertia::Box inertia(mass, dimension.x * 2.0f, dimension.y * 2.0f, dimension.z * 2.0f);
     UMath::Scale(inertia, 2.0f, inertia);
     UMath::Vector3 moment;
     if (attributes.MOMENT(moment)) {

--- a/src/Speed/Indep/Src/Physics/Common/SmokeableInfo.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/SmokeableInfo.cpp
@@ -1,0 +1,470 @@
+#include "Speed/Indep/Src/Physics/SceneryModel.h"
+#include "Speed/Indep/Src/Physics/SmokeableInfo.hpp"
+
+#include "Speed/Indep/Src/Gameplay/GManager.h"
+#include "Speed/Indep/Src/Gameplay/GRaceStatus.h"
+#include "Speed/Indep/Src/Misc/ResourceLoader.hpp"
+#include "Speed/Indep/Src/Sim/SimSubSystem.h"
+#include "Speed/Indep/Src/Sim/Simulation.h"
+#include "Speed/Indep/Src/World/Scenery.hpp"
+
+void ResetPropTimers();
+
+SmokeableSectionQ TheSmokeableSections;
+
+static void SceneryModel_InitSystem() {
+    SceneryModel::InitSystem();
+}
+
+static void SceneryModel_RestoreSystem() {
+    SceneryModel::RestoreSystem();
+}
+
+static Sim::SubSystem _Physics_System_SceneryModel("SceneryModel", SceneryModel_InitSystem, SceneryModel_RestoreSystem);
+int SceneryModel::mSceneryCount = 0;
+
+SmokeableSection *SmokeableSectionQ::FindOrAdd(int section_id) {
+    SmokeableSection *section = nullptr;
+    for (int i = 0; i < mQueue.size(); i++) {
+        SmokeableSection &this_section = mQueue[i];
+        if (this_section.SectionID == section_id) {
+            SmokeableSection new_section(this_section);
+            mQueue.dequeue();
+            mQueue.enqueue(new_section);
+            section = &mQueue.head();
+            break;
+        }
+    }
+    if (section == nullptr) {
+        SmokeableSection new_section(section_id);
+        mQueue.enqueue(new_section);
+        section = &mQueue.head();
+    }
+    return section;
+}
+
+SmokeableSection *SmokeableSectionQ::Find(int section_id) {
+    for (int i = 0; i < mQueue.size(); i++) {
+        SmokeableSection &this_section = mQueue[i];
+        if (this_section.SectionID == section_id) {
+            return &this_section;
+        }
+    }
+    return nullptr;
+}
+
+SceneryModel::SceneryModel(SmokeableSpawner *spawner, const CollisionGeometry::Bounds *geometry,
+                           const Attrib::Collection *attribs, bool hidden)
+    : HeirarchyModel(spawner->GetRenderMesh(), geometry, UCrc32(0x9756DF79u), nullptr, attribs, //
+                     spawner->GetRenderHeirarchy(), 0, false) //
+    , ISceneryModel(this) {
+    mInstanceVisible = true;
+    mSpawner = spawner;
+    if (!hidden) {
+        InitScene();
+    } else {
+        StartOverride();
+    }
+    mSceneryCount++;
+}
+
+SceneryModel::~SceneryModel() {
+    if (mSpawner != nullptr) {
+        mSpawner->mSimModel = nullptr;
+        ShowInstance(true);
+    }
+    mSceneryCount--;
+}
+
+void SceneryModel::ShowInstance(bool show) {
+    if (mSpawner != nullptr && show != mInstanceVisible) {
+        if (show) {
+            mSpawner->ShowInstance();
+        } else {
+            mSpawner->HideInstance();
+        }
+        mInstanceVisible = show;
+    }
+}
+
+void SceneryModel::OnBeginDraw() {
+    HeirarchyModel::OnBeginDraw();
+    StartOverride();
+}
+
+void SceneryModel::HideModel() {
+    Sim::Model::HideModel();
+    StartOverride();
+}
+
+void SceneryModel::EndOverride() {
+    ShowInstance(true);
+}
+
+void SceneryModel::StartOverride() {
+    ShowInstance(false);
+}
+
+void SceneryModel::GetTransform(UMath::Matrix4 &matrix) const {
+    if (mInstanceVisible) {
+        if (!GetSceneryTransform(matrix)) {
+            matrix = UMath::Matrix4::kIdentity;
+        }
+    } else {
+        HeirarchyModel::GetTransform(matrix);
+    }
+}
+
+void SceneryModel::InitScene() {
+    UMath::Matrix4 scenery_matrix;
+
+    ReleaseChildModels();
+    StopEffects();
+    Sim::Model::EndDraw();
+    Sim::Model::EndSimulation();
+    Sim::Model::ReleaseSequencer();
+    EndOverride();
+    SetCausality(0, 0.0f);
+
+    if (GetSceneryTransform(scenery_matrix)) {
+        SetTrigger(scenery_matrix, true);
+    } else {
+        RemoveTrigger();
+    }
+
+    bool enable_sequencer = start_sequencer();
+
+    if (no_trigger()) {
+        SmackableTrigger *trigger = GetTrigger();
+        if (trigger != nullptr) {
+            trigger->Disable();
+        }
+        enable_sequencer = true;
+    }
+
+    if (enable_sequencer) {
+        Sim::Model::StartSequencer(UCrc32(EventSequencer()));
+    }
+
+    SetCameraAvoidable(true);
+}
+
+bool SceneryModel::GetSceneryTransform(UMath::Matrix4 &matrix) const {
+    const CollisionGeometry::Bounds *bounds = GetCollisionGeometry();
+    if (bounds != nullptr) {
+        UMath::Vector3 pivot;
+        bounds->GetPivot(pivot);
+        UMath::QuaternionToMatrix4(mSpawner->GetOrientation(), matrix);
+        UMath::Rotate(pivot, matrix, UMath::Vector4To3(matrix.v3));
+        UMath::Addxyz(matrix.v3, mSpawner->GetPosition(), matrix.v3);
+        return true;
+    }
+    return false;
+}
+
+void SceneryModel::OnEndSimulation() {
+    HeirarchyModel::OnEndSimulation();
+}
+
+SceneryModel *SceneryModel::Construct(SmokeableSpawner *data, const Attrib::Collection *attributes, bool hidden) {
+    if (static_cast<unsigned int>(mSceneryCount) < 256) {
+        const CollisionGeometry::Collection *col = CollisionGeometry::Lookup(data->GetCollisionName());
+        if (col != nullptr) {
+            const CollisionGeometry::Bounds *bounds = col->GetRoot();
+            if (bounds != nullptr) {
+                if (attributes == nullptr) {
+                    return nullptr;
+                }
+                bounds = col->GetRoot();
+                if (bounds != nullptr) {
+                    UMath::Vector3 dimension;
+                    bounds->GetHalfDimensions(dimension);
+                    if (UMath::LengthSquare(dimension) > 0.0f) {
+                        return new SceneryModel(data, bounds, attributes, hidden);
+                    }
+                }
+            }
+        }
+    }
+    return nullptr;
+}
+
+void SceneryModel::WakeUp() {
+    SmackableTrigger *trigger = GetTrigger();
+    if (trigger != nullptr && !IsRendering() && !IsSimulating()) {
+        trigger->Fire();
+        trigger->Disable();
+    }
+}
+
+void SceneryModel::RestoreScene() {
+    InitScene();
+}
+
+void SceneryModel::ReleaseModel() {
+    Sim::Model::EndDraw();
+    Sim::Model::EndSimulation();
+    StopEffects();
+    HeirarchyModel::DisableTrigger();
+}
+
+void SceneryModel::InitSystem() {
+    ResetPropTimers();
+}
+
+void SceneryModel::RestoreSystem() {
+    ResetPropTimers();
+}
+
+void ResetPropTimers() {
+    TheSmokeableSections.Reset();
+}
+
+static const Attrib::Class *TheSmackableClass;
+
+void SmokeableSpawnerPack::OnUnload() {
+    SmokeableSection *section = TheSmokeableSections.FindOrAdd(static_cast<int>(ScenerySectionNumber));
+    section->LastLoadTime = Sim::GetTime();
+
+    for (int n = 0; n < NumSmokeableSpawners; n++) {
+        {
+            SmokeableSpawner *spawner = &SmokeableSpawners[n];
+            if (static_cast<unsigned int>(n) < 256) {
+                if (!spawner->IsInstanceVisible()) {
+                    section->Rebuilds.Set(static_cast<unsigned int>(n));
+                } else {
+                    section->Rebuilds.Clear(static_cast<unsigned int>(n));
+                }
+            }
+            spawner->OnUnload();
+        }
+    }
+}
+
+void SmokeableSpawnerPack::EndianSwap() {
+    if (EndianSwapped) {
+        return;
+    }
+    EndianSwapped = 1;
+    bPlatEndianSwap(&ScenerySectionNumber);
+    bPlatEndianSwap(&FirstSmokeableSpawnerID);
+    bPlatEndianSwap(&NumSmokeableSpawners);
+    for (int n = 0; n < NumSmokeableSpawners; n++) {
+        SmokeableSpawners[n].EndianSwap();
+    }
+}
+
+void SmokeableSpawnerPack::OnMoved() {
+    for (int n = 0; n < NumSmokeableSpawners; n++) {
+        SmokeableSpawners[n].OnMoved();
+    }
+}
+
+void SmokeableSpawnerPack::OnLoad(unsigned int exclude_flags) {
+    SmokeableSection *section = TheSmokeableSections.Find(static_cast<int>(ScenerySectionNumber));
+
+    if (!GRaceStatus::Exists() || !GRaceStatus::Get().GetActivelyRacing()) {
+        if (section != nullptr) {
+            if (section->LastLoadTime + 180.0f < Sim::GetTime()) {
+                section->Rebuilds.Clear();
+                section = nullptr;
+            }
+        }
+    }
+
+    if (section == nullptr || !section->Rebuilds.Test()) {
+        GManager::Get().RestorePursuitBreakerIcons(static_cast<int>(ScenerySectionNumber));
+    }
+
+    for (int n = 0; n < NumSmokeableSpawners; n++) {
+        bool ignore = false;
+        if (section != nullptr && static_cast<unsigned int>(n) < 256 && section->Rebuilds.Test(static_cast<unsigned int>(n))) {
+            ignore = true;
+        }
+        SmokeableSpawners[n].OnLoad(exclude_flags, ignore);
+    }
+}
+
+const Attrib::Collection *SmokeableSpawner::FindAttributes(UCrc32 name) {
+    return TheSmackableClass->GetCollection(name.GetValue());
+}
+
+void SmokeableSpawner::Init() {
+    TheSmackableClass = Attrib::Database::Get().GetClass(Attrib::Gen::smackable::ClassKey());
+}
+
+void SmokeableSpawner::EndianSwap() {
+    bPlatEndianSwap(&mOrientation);
+    bPlatEndianSwap(&mPosition);
+    bPlatEndianSwap(&mModel);
+    bPlatEndianSwap(&mCollisionName);
+    bPlatEndianSwap(&mAttributes);
+    bPlatEndianSwap(&mSceneryOverrideInfoNumber);
+    bPlatEndianSwap(&mUniqueID);
+    bPlatEndianSwap(&mExcludeFlags);
+}
+
+void SmokeableSpawner::OnUnload() {
+    if (mSimModel != nullptr) {
+        delete mSimModel;
+        mSimModel = nullptr;
+    }
+}
+
+const ModelHeirarchy *SmokeableSpawner::GetRenderHeirarchy() const {
+    ModelHeirarchy *heirarchy;
+    SceneryOverrideInfo *info = GetSceneryOverrideInfo(mSceneryOverrideInfoNumber);
+    if (info != nullptr) {
+        ScenerySectionHeader *section_header = GetScenerySectionHeader(static_cast<int>(info->SectionNumber));
+        if (section_header != nullptr) {
+            SceneryInstance *scenery_instance = section_header->GetSceneryInstance(static_cast<int>(info->InstanceNumber));
+            if (scenery_instance != nullptr) {
+                SceneryInfo *sinfo = section_header->GetSceneryInfo(scenery_instance);
+                if (sinfo != nullptr) {
+                    heirarchy = sinfo->mHeirarchy;
+                    return heirarchy;
+                }
+            }
+        }
+    }
+    return nullptr;
+}
+
+bHash32 SmokeableSpawner::GetRenderMesh() const {
+    SceneryOverrideInfo *soi = GetSceneryOverrideInfo(mSceneryOverrideInfoNumber);
+    if (soi != nullptr) {
+        ScenerySectionHeader *section_header = GetScenerySectionHeader(static_cast<int>(soi->SectionNumber));
+        if (section_header != nullptr) {
+            SceneryInstance *scenery_instance = section_header->GetSceneryInstance(static_cast<int>(soi->InstanceNumber));
+            if (scenery_instance != nullptr) {
+                SceneryInfo *scenery_info = section_header->GetSceneryInfo(scenery_instance);
+                if (scenery_info != nullptr) {
+                    for (int i = 0; i < 4; i++) {
+                        if (scenery_info->NameHash[i] != 0) {
+                            return bHash32(scenery_info->NameHash[i]);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return bHash32(0x0C7395A8u);
+}
+
+void SmokeableSpawner::ShowInstance() const {
+    SceneryOverrideInfo *info = GetSceneryOverrideInfo(mSceneryOverrideInfoNumber);
+    if (info != nullptr) {
+        info->EnableRendering();
+        info->AssignOverrides();
+    }
+}
+
+bool SmokeableSpawner::IsInstanceVisible() const {
+    SceneryOverrideInfo *info = GetSceneryOverrideInfo(mSceneryOverrideInfoNumber);
+    if (info != nullptr) {
+        return (info->ExcludeFlags & 0x10) == 0;
+    }
+    return false;
+}
+
+void SmokeableSpawner::HideInstance() const {
+    SceneryOverrideInfo *info = GetSceneryOverrideInfo(mSceneryOverrideInfoNumber);
+    if (info != nullptr) {
+        info->DisableRendering();
+        info->AssignOverrides();
+    }
+}
+
+void SmokeableSpawner::OnMoved() {
+    if (mSimModel != nullptr) {
+        mSimModel->mSpawner = this;
+    }
+}
+
+void SmokeableSpawner::OnLoad(unsigned int exclude_flags, bool hidden) {
+    if ((exclude_flags & mExcludeFlags) == 0) {
+        ShowInstance();
+        const Attrib::Collection *collection = FindAttributes(UCrc32(mAttributes));
+        if (collection != nullptr) {
+            mSimModel = SceneryModel::Construct(this, collection, hidden);
+        } else {
+            mSimModel = nullptr;
+        }
+    }
+    if (mSimModel == nullptr) {
+        HideInstance();
+    }
+}
+
+int SmokeableSpawnerPack::Loader(bChunk *chunk) {
+    if (chunk->GetID() == 0x34027) {
+        SmokeableSpawnerPack *spawner_pack = reinterpret_cast<SmokeableSpawnerPack *>(chunk->GetAlignedData(16));
+        if (AreChunksBeingMoved()) {
+            spawner_pack->OnMoved();
+        } else {
+            spawner_pack->EndianSwap();
+            if (Sim::Exists()) {
+                unsigned int exclude_flags = static_cast<unsigned int>(Sim::GetUserMode() == Sim::USER_SPLIT_SCREEN);
+                if (GRaceStatus::Exists() && GRaceStatus::Get().GetPlayMode() == GRaceStatus::kPlayMode_Racing) {
+                    exclude_flags |= 4;
+                }
+                spawner_pack->OnLoad(exclude_flags);
+            }
+        }
+        return 1;
+    }
+    return 0;
+}
+
+int SmokeableSpawnerPack::Unloader(bChunk *chunk) {
+    if (chunk->GetID() == 0x34027) {
+        if (!AreChunksBeingMoved() && Sim::Exists()) {
+            SmokeableSpawnerPack *pack = reinterpret_cast<SmokeableSpawnerPack *>(chunk->GetAlignedData(16));
+            pack->OnUnload();
+        }
+        return 1;
+    }
+    return 0;
+}
+
+bChunkLoader SmokeableSpawnerPack::mLoader(0x34027, SmokeableSpawnerPack::Loader, SmokeableSpawnerPack::Unloader);
+
+inline bool SceneryModel::IsHidden() const {
+    bool visible = mInstanceVisible || !Sim::Model::IsHidden();
+    return !visible;
+}
+
+inline bool SceneryModel::IsExcluded(unsigned int scenery_exclusion_flag) const {
+    unsigned int my_flags = 0;
+    if (mSpawner != nullptr) {
+        my_flags = mSpawner->GetExcludeFlags();
+    }
+    return (my_flags & scenery_exclusion_flag) != 0;
+}
+
+inline unsigned int SceneryModel::GetSpawnerID() const {
+    if (mSpawner != nullptr) {
+        return mSpawner->GetUniqueID();
+    }
+    return 0xFFFFFFFF;
+}
+
+bool HeirarchyModel::OnUpdateAvoidable(UMath::Vector3 &pos, float &sweep) {
+    if (mTrigger != nullptr && mTrigger->IsEnabled()) {
+        if (0.0f < mTriggerAvoid.w) {
+            pos = UMath::Vector4To3(mTriggerAvoid);
+            sweep = mTriggerAvoid.w;
+            return true;
+        }
+    } else {
+        if (GetSimable() != nullptr) {
+            IRigidBody *irb = GetSimable()->GetRigidBody();
+            if (irb != nullptr) {
+                sweep = irb->GetRadius();
+                pos = irb->GetPosition();
+                return true;
+            }
+        }
+    }
+    return false;
+}

--- a/src/Speed/Indep/Src/Physics/Common/SmokeableInfo.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/SmokeableInfo.cpp
@@ -220,7 +220,7 @@ void ResetPropTimers() {
     TheSmokeableSections.Reset();
 }
 
-static const Attrib::Class *TheSmackableClass;
+static const Attrib::Class *TheSmackableClass = nullptr;
 
 void SmokeableSpawnerPack::OnUnload() {
     SmokeableSection *section = TheSmokeableSections.FindOrAdd(static_cast<int>(ScenerySectionNumber));

--- a/src/Speed/Indep/Src/Physics/Common/SmokeableInfo.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/SmokeableInfo.cpp
@@ -355,7 +355,6 @@ void SmokeableSpawner::ShowInstance() const {
     SceneryOverrideInfo *info = GetSceneryOverrideInfo(mSceneryOverrideInfoNumber);
     if (info != nullptr) {
         info->EnableRendering();
-        info->AssignOverrides();
     }
 }
 
@@ -371,7 +370,6 @@ void SmokeableSpawner::HideInstance() const {
     SceneryOverrideInfo *info = GetSceneryOverrideInfo(mSceneryOverrideInfoNumber);
     if (info != nullptr) {
         info->DisableRendering();
-        info->AssignOverrides();
     }
 }
 

--- a/src/Speed/Indep/Src/Physics/Common/SmokeableInfo.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/SmokeableInfo.cpp
@@ -12,15 +12,7 @@ void ResetPropTimers();
 
 SmokeableSectionQ TheSmokeableSections;
 
-static void SceneryModel_InitSystem() {
-    SceneryModel::InitSystem();
-}
-
-static void SceneryModel_RestoreSystem() {
-    SceneryModel::RestoreSystem();
-}
-
-static Sim::SubSystem _Physics_System_SceneryModel("SceneryModel", SceneryModel_InitSystem, SceneryModel_RestoreSystem);
+static Sim::SubSystem _Physics_System_SceneryModel("SceneryModel", SceneryModel::InitSystem, SceneryModel::RestoreSystem);
 int SceneryModel::mSceneryCount = 0;
 
 SmokeableSection *SmokeableSectionQ::FindOrAdd(int section_id) {

--- a/src/Speed/Indep/Src/Physics/Common/SmokeableInfo.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/SmokeableInfo.cpp
@@ -282,7 +282,8 @@ const Attrib::Collection *SmokeableSpawner::FindAttributes(UCrc32 name) {
 }
 
 void SmokeableSpawner::Init() {
-    TheSmackableClass = Attrib::Database::Get().GetClass(Attrib::Gen::smackable::ClassKey());
+    const Attrib::Class *smackable_class = Attrib::Database::Get().GetClass(Attrib::Gen::smackable::ClassKey());
+    TheSmackableClass = smackable_class;
 }
 
 void SmokeableSpawner::EndianSwap() {

--- a/src/Speed/Indep/Src/Physics/Common/VehicleBehaviors.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/VehicleBehaviors.cpp
@@ -1,0 +1,6 @@
+#include "Speed/Indep/Src/Physics/VehicleBehaviors.h"
+#include "Speed/Indep/Src/Interfaces/Simables/IVehicle.h"
+
+VehicleBehavior::VehicleBehavior(const BehaviorParams &bp, unsigned int num_interfaces) : Behavior(bp, num_interfaces), mVehicle(nullptr) {
+    this->GetOwner()->QueryInterface(&this->mVehicle);
+}

--- a/src/Speed/Indep/Src/Physics/Common/VehicleSystem.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/VehicleSystem.cpp
@@ -1,7 +1,37 @@
 #include "VehicleSystem.h"
+#include "Speed/Indep/Src/Main/stubs.h"
+#include "Speed/Indep/Src/Sim/SimSubSystem.h"
 
 namespace VehicleSystem {
 
 float ENABLE_ROLL_STOPS_THRESHOLD = 0.2f;
+float PAD_DEAD_ZONE = 0.05f;
 
-};
+static void InitializeVehicleGlobals() {
+    dbattrib(0.0f, 0.0f, 0, 0.0f, 0.0f, 0);
+    dbattrib(0.0f, 0.0f, 0, 0.0f, 0.0f, 0);
+    dbattrib(0.0f, 0.0f, 0, 0.0f, 0.0f, 0);
+    dbattrib(0.0f, 0.0f, 0, 0.0f, 0.0f, 0);
+    dbattrib(0.0f, 0.0f, 0, 0.0f, 0.0f, 0);
+    dbattrib(0, 0, 0, 0, 0, 0);
+    dbattrib(0.0f, 0.0f, 0, 0.0f, 0.0f, 0);
+    dbattrib(0.0f, 0.0f, 0, 0.0f, 0.0f, 0);
+    dbattrib(0.0f, 0.0f, 0, 0.0f, 0.0f, 0);
+    dbattrib(0.0f, 0.0f, 0, 0.0f, 0.0f, 0);
+    dbattrib(0, 0, 0, 0, 0, 0);
+    dbattrib(0.0f, 0.0f, 0, 0.0f, 0.0f, 0);
+    dbattrib(0, 0, 0, 0, 0, 0);
+    dbattrib(0.0f, 0.0f, 0, 0.0f, 0.0f, 0);
+    dbattrib(0.0f, 0.0f, 0, 0.0f, 0.0f, 0);
+}
+
+static void InitializeGlobals() {}
+
+static void Init() {
+    InitializeGlobals();
+    InitializeVehicleGlobals();
+}
+
+static void Shutdown() {}
+
+}; // namespace VehicleSystem

--- a/src/Speed/Indep/Src/Physics/Common/VehicleSystem.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/VehicleSystem.cpp
@@ -27,11 +27,13 @@ static void InitializeVehicleGlobals() {
 
 static void InitializeGlobals() {}
 
-static void Init() {
+void Init() {
     InitializeGlobals();
     InitializeVehicleGlobals();
 }
 
-static void Shutdown() {}
+void Shutdown() {}
 
 }; // namespace VehicleSystem
+
+BIND_SIM_SUBSYSTEM(VehicleSystem, VehicleSystem::Init, VehicleSystem::Shutdown)

--- a/src/Speed/Indep/Src/Physics/Common/Wheel.cpp
+++ b/src/Speed/Indep/Src/Physics/Common/Wheel.cpp
@@ -1,6 +1,62 @@
 #include "Speed/Indep/Src/Physics/Wheel.h"
 #include "Speed/Indep/Libs/Support/Utility/UTypes.h"
 
+Wheel::Wheel(unsigned int flags)
+    : mWorldPos(0.025f),                //
+      mNormal(UMath::Vector4::kZero),   //
+      mPosition(UMath::Vector3::kZero), //
+      mFlags(flags),                    //
+      mForce(UMath::Vector3::kZero),    //
+      mAirTime(0.0f),                   //
+      mLocalArm(UMath::Vector3::kZero), //
+      mCompression(0.0f),               //
+      mWorldArm(UMath::Vector3::kZero), //
+      mVelocity(UMath::Vector3::kZero), //
+      mSurface(SimSurface::kNull),      //
+      mSurfaceStick(0.0f),              //
+      mIntegral(UMath::Vector4::kZero) {}
+
+void Wheel::UpdateTime(float dT) {
+    if (this->mSurfaceStick > 0.0f && dT < this->mSurfaceStick) {
+        this->mSurfaceStick = this->mSurfaceStick - dT;
+        return;
+    }
+    this->mSurfaceStick = 0.0f;
+}
+
+void Wheel::UpdateSurface(const SimSurface &surface) {
+    if (this->mSurfaceStick <= 0.0f) {
+        this->mSurface = surface;
+        surface.STICK();
+    } else {
+        if (!(surface == this->mSurface)) {
+            return;
+        }
+    }
+    this->mSurfaceStick = surface.STICK();
+    this->mSurface.DebugOverride();
+}
+
+void Wheel::Reset() {
+    this->mIntegral = UMath::Vector4::kZero;
+    this->mSurfaceStick = 0.0f;
+    this->mAirTime = 0.0f;
+    this->mVelocity = UMath::Vector3::kZero;
+    this->mCompression = 0.0f;
+    this->mNormal = UMath::Vector4::kZero;
+    this->mForce = UMath::Vector3::kZero;
+    this->mSurface = SimSurface::kNull;
+    this->mWorldPos = WWorldPos(0.025f);
+}
+
+bool Wheel::InitPosition(const IRigidBody &rb, float maxcompression) {
+    UMath::Matrix4 matrix;
+    rb.GetMatrix4(matrix);
+    matrix.v3 = UMath::Vector4Make(rb.GetPosition(), 1.0f);
+    return this->UpdatePosition(rb.GetAngularVelocity(), rb.GetLinearVelocity(), matrix, UMath::Vector3::kZero, 0.0f, maxcompression, false,
+                                rb.GetWCollider(), rb.GetDimension().y * 2.0f);
+}
+
 bool Wheel::UpdatePosition(const UMath::Vector3 &body_av, const UMath::Vector3 &body_lv, 
     const UMath::Matrix4 &body_matrix, const UMath::Vector3 &cog,
     float dT, float wheel_radius, bool usecache, const WCollider *collider, float vehicle_height) {

--- a/src/Speed/Indep/Src/Physics/Dynamics.h
+++ b/src/Speed/Indep/Src/Physics/Dynamics.h
@@ -27,8 +27,26 @@ class IEntity {
 
 namespace Articulation {
 
+struct HJOINT__;
+
+enum eJointFlags {
+    JF_NONE = 0,
+    JF_IMMOBILE_MALE = 1,
+    JF_IMMOBILE_FEMALE = 2,
+};
+
+enum eConstraint {
+    PRISMATIC = 0,
+    HYPERBOLIC = 1,
+    CONICAL = 2,
+};
+
+HJOINT__ *Create(IEntity *female, const UMath::Vector3 &female_lever, IEntity *male, const UMath::Vector3 &male_lever, eJointFlags flags);
+void Constrain(HJOINT__ *hjoint, IEntity *entity, const UMath::Matrix4 &mat, float theta1, float theta2, const UMath::Vector3 &post_vec,
+               eConstraint type);
 void Release(IEntity *rb0);
 bool IsJoined(const IEntity *rb);
+bool IsJoined(const IEntity *rb0, const IEntity *rb1);
 
 }; // namespace Articulation
 

--- a/src/Speed/Indep/Src/Physics/Explosion.h
+++ b/src/Speed/Indep/Src/Physics/Explosion.h
@@ -1,6 +1,11 @@
 #ifndef __EXPLOSION_H
 #define __EXPLOSION_H
 
+#include "Speed/Indep/Src/Interfaces/Simables/IExplosion.h"
+#include "Speed/Indep/Src/Interfaces/Simables/IRigidBody.h"
+#include "Speed/Indep/Src/Interfaces/Simables/ISimpleBody.h"
+#include "Speed/Indep/Src/Interfaces/SimModels/IModel.h"
+#include "Speed/Indep/Src/Physics/PhysicsObject.h"
 #include "Speed/Indep/Src/Sim/SimTypes.h"
 
 // total size: 0x30
@@ -25,6 +30,87 @@ struct ExplosionParams : public Sim::Param {
     bool fEffectSource;              // offset 0x24, size 0x1
     bool fDamage;                    // offset 0x28, size 0x1
     unsigned int fTargets;           // offset 0x2C, size 0x4
+};
+
+class Explosion : public PhysicsObject, public IExplosion {
+  public:
+    static ISimable *Construct(Sim::Param params);
+    void *operator new(std::size_t size) {
+        return gFastMem.Alloc(size, nullptr);
+    }
+
+    void operator delete(void *mem, std::size_t size) {
+        if (mem) {
+            gFastMem.Free(mem, size, nullptr);
+        }
+    }
+
+    virtual const UMath::Vector3 &GetOrigin() const override {
+        return PhysicsObject::GetPosition();
+    }
+
+    virtual float GetExpansionSpeed() const override {
+        return mExpansionSpeed;
+    }
+
+    virtual float GetMaximumRadius() const override {
+        return mExpansionRadius;
+    }
+
+    virtual float GetRadius() const override;
+
+    virtual HCAUSE GetCausality() const override {
+        return mCausality;
+    }
+
+    virtual float GetCausalityTime() const override {
+        return mCauseTime;
+    }
+
+    virtual bool HasDamage() const override {
+        return mDamages;
+    }
+
+    virtual unsigned int GetTargets() const override {
+        return mTargets;
+    }
+
+    virtual HMODEL GetSource() const override {
+        return mSource;
+    }
+
+    virtual void SetCausality(HCAUSE from, float time) override {
+        mCausality = from;
+        mCauseTime = time;
+    }
+
+    virtual IModel *GetModel() override {
+        return nullptr;
+    }
+
+    virtual const IModel *GetModel() const override {
+        return nullptr;
+    }
+
+  protected:
+    Explosion(const ExplosionParams &params, Sim::Param sp);
+    virtual ~Explosion();
+    virtual void OnTaskSimulate(float dT) override;
+    virtual void OnBehaviorChange(const UCrc32 &mechanic) override;
+
+  private:
+    void TestCollisions(float dT);
+    void OnCollide(IRigidBody *other, float dT, float radius, const Dynamics::Collision::Geometry &explosion_sphere);
+
+    const float mExpansionSpeed;
+    const float mExpansionRadius;
+    const HMODEL mSource;
+    ISimpleBody *mIRBSimple;
+    bool mEffectSource;
+    HCAUSE mCausality;
+    float mCauseTime;
+    const bool mDamages;
+    const unsigned int mTargets;
 };
 
 #endif

--- a/src/Speed/Indep/Src/Physics/HeirarchyModel.h
+++ b/src/Speed/Indep/Src/Physics/HeirarchyModel.h
@@ -1,0 +1,85 @@
+#ifndef PHYSICS_HEIRARCHYMODEL_H
+#define PHYSICS_HEIRARCHYMODEL_H
+
+#ifdef EA_PRAGMA_ONCE_SUPPORTED
+#pragma once
+#endif
+
+#include "Speed/Indep/Libs/Support/Utility/FastMem.h"
+#include "Speed/Indep/Src/Generated/AttribSys/Classes/smackable.h"
+#include "Speed/Indep/Src/Interfaces/IBody.h"
+#include "Speed/Indep/Src/Interfaces/SimModels/ITriggerableModel.h"
+#include "Speed/Indep/Src/Physics/Smackable.h"
+#include "Speed/Indep/Src/Physics/SmackableTrigger.h"
+#include "Speed/Indep/Src/Sim/SimModel.h"
+#include "Speed/Indep/Src/World/Scenery.hpp"
+
+class HeirarchyModel : public Sim::Model, public IBody, public ITriggerableModel, public Attrib::Gen::smackable {
+  public:
+    void *operator new(std::size_t size) { return gFastMem.Alloc(size, nullptr); }
+    void operator delete(void *mem, std::size_t size) {
+        if (mem) { gFastMem.Free(mem, size, nullptr); }
+    }
+
+    HeirarchyModel(bHash32 rendermesh, const CollisionGeometry::Bounds *geometry, UCrc32 nodename,
+                   HeirarchyModel *parent, const Attrib::Collection *attribs, const ModelHeirarchy *heirarchy,
+                   unsigned int child_index, bool visible);
+
+    ~HeirarchyModel() override;
+
+    void OnBeginDraw() override;
+    void OnEndDraw() override;
+    bool OnDraw(Sim::Packet *service) override;
+    void OnBeginSimulation() override;
+    void OnEndSimulation() override;
+
+    void GetTransform(UMath::Matrix4 &matrix) const override;
+    void GetLinearVelocity(UMath::Vector3 &velocity) const override {
+        Sim::Model::GetLinearVelocity(velocity);
+    }
+    void GetAngularVelocity(UMath::Vector3 &velocity) const override;
+    void GetDimension(UMath::Vector3 &dim) const override {
+        GetCollisionGeometry()->GetHalfDimensions(dim);
+    }
+    const Attrib::Instance &GetAttributes() const override {
+        return static_cast<const Attrib::Gen::smackable *>(this)->GetBase();
+    }
+    unsigned int GetWorldID() const override {
+        return Sim::Model::GetWorldID();
+    }
+
+    IModel *SpawnModel(UCrc32 rendernode, UCrc32 collisionnode, UCrc32 attributes) override;
+    void HidePart(const UCrc32 &nodename) override;
+    void ShowPart(const UCrc32 &nodename) override;
+    bool IsPartVisible(const UCrc32 &nodename) const override;
+    void ReleaseModel() override;
+
+    void PlaceTrigger(const UMath::Matrix4 &mat, bool retrigger) override;
+
+    void OnProcessFrame(float dT) override;
+    virtual bool OnUpdateAvoidable(UMath::Vector3 &pos, float &sweep);
+    virtual bool OnRemoveOffScreen(float time);
+
+    int FindHeirarchyChild(const UCrc32 &nodename) const;
+    void DisableTrigger();
+    void SetTrigger(const UMath::Matrix4 &matrix, bool enable);
+    void RemoveTrigger();
+    void SetCameraAvoidable(bool enable);
+
+    SmackableTrigger *GetTrigger() {
+        return mTrigger;
+    }
+
+  protected:
+    UMath::Vector4 mTriggerAvoid;
+    ModelHeirarchy *mHeirarchy;
+    bHash32 mRenderMesh;
+    SmackableTrigger *mTrigger;
+    float mOffScreenTimer;
+    unsigned short mHeirarchyNode;
+    unsigned short mFlags;
+    unsigned int mChildVisibility;
+    SmackableAvoidable *mAvoidable;
+};
+
+#endif

--- a/src/Speed/Indep/Src/Physics/HeirarchyModel.h
+++ b/src/Speed/Indep/Src/Physics/HeirarchyModel.h
@@ -70,6 +70,10 @@ class HeirarchyModel : public Sim::Model, public IBody, public ITriggerableModel
         return mTrigger;
     }
 
+    bool HasAvoidable() const {
+        return mAvoidable != nullptr;
+    }
+
   protected:
     UMath::Vector4 mTriggerAvoid;
     ModelHeirarchy *mHeirarchy;

--- a/src/Speed/Indep/Src/Physics/HeirarchyModel.h
+++ b/src/Speed/Indep/Src/Physics/HeirarchyModel.h
@@ -74,6 +74,18 @@ class HeirarchyModel : public Sim::Model, public IBody, public ITriggerableModel
         return mAvoidable != nullptr;
     }
 
+    void SetAvoidable(bool b) {
+        bool isavoidable = mAvoidable != nullptr;
+        if (isavoidable != b) {
+            if (b) {
+                mAvoidable = new SmackableAvoidable(this);
+            } else {
+                delete mAvoidable;
+                mAvoidable = nullptr;
+            }
+        }
+    }
+
   protected:
     UMath::Vector4 mTriggerAvoid;
     ModelHeirarchy *mHeirarchy;

--- a/src/Speed/Indep/Src/Physics/PVehicle.h
+++ b/src/Speed/Indep/Src/Physics/PVehicle.h
@@ -127,7 +127,11 @@ class PVehicle : public PhysicsObject,
     };
 
     struct ManageNode {
-        ManageNode() {}
+        ManageNode() {
+            result = VCR_DONTCARE;
+            resource.Flags = 0;
+            instancecount = 0;
+        }
         static void print(const ManageNode &n) {}
         static bool sort_remove_resources(const ManageNode &lhs, const ManageNode &rhs) {
             if (rhs.resource.Type != lhs.resource.Type) {

--- a/src/Speed/Indep/Src/Physics/PVehicle.h
+++ b/src/Speed/Indep/Src/Physics/PVehicle.h
@@ -282,9 +282,7 @@ class PVehicle : public PhysicsObject,
     virtual void SetSpeed(float speed) override;
     virtual void GlareOn(VehicleFX::ID glare) override;
     virtual void GlareOff(VehicleFX::ID glare) override;
-    virtual bool IsGlareOn(VehicleFX::ID glare) const override {
-        return (mGlareState & glare) != 0;
-    }
+    virtual bool IsGlareOn(VehicleFX::ID glare) override;
     virtual bool IsCollidingWithSoftBarrier() override {
         return false;
     }

--- a/src/Speed/Indep/Src/Physics/PVehicle.h
+++ b/src/Speed/Indep/Src/Physics/PVehicle.h
@@ -2,10 +2,32 @@
 #define PHYSICS_PVEHICLE_H
 
 #include "Speed/Indep/Libs/Support/Utility/UCrc.h"
+#include "Speed/Indep/Libs/Support/Utility/UStandard.h"
+#include "Speed/Indep/Src/Debug/Debugable.h"
 #include "Speed/Indep/Src/Generated/Hash.hpp"
+#include "Speed/Indep/Src/Interfaces/IAttributeable.h"
 #include "Speed/Indep/Src/Interfaces/SimActivities/IVehicleCache.h"
+#include "Speed/Indep/Src/Interfaces/Simables/IDamageable.h"
+#include "Speed/Indep/Src/Interfaces/Simables/IExplodeable.h"
 #include "Speed/Indep/Src/Interfaces/Simables/IVehicle.h"
+#include "Speed/Indep/Src/Main/EventSequencer.h"
+#include "Speed/Indep/Src/Physics/PhysicsObject.h"
 #include "Speed/Indep/Src/Sim/SimTypes.h"
+#include "Speed/Indep/bWare/Inc/bList.hpp"
+
+DECLARE_CONTAINER_TYPE(ID_PVehicleChangeReq);
+
+struct FECustomizationRecord;
+class IInput;
+class ICollisionBody;
+class ISuspension;
+class IEngine;
+class IDamageable;
+class ITransmission;
+class IVehicleAI;
+class IArticulatedVehicle;
+class IRenderable;
+class IAudible;
 
 namespace VehicleClass {
 
@@ -53,6 +75,320 @@ struct VehicleParams : public Sim::Param {
     IVehicleCache *VehicleCache;                // offset 0x24, size 0x4
     const Physics::Info::Performance *matched;  // offset 0x28, size 0x4
     unsigned int Flags;                         // offset 0x2C, size 0x4
+};
+
+
+class PVehicle : public PhysicsObject,
+                 public bTNode<PVehicle>,
+                 public IVehicle,
+                 public Debugable,
+                 public EventSequencer::IContext,
+                 public IExplodeable,
+                 public IAttributeable {
+  public:
+    static void *operator new(unsigned int size) {
+        return gFastMem.Alloc(size, nullptr);
+    }
+
+    static void operator delete(void *mem, unsigned int size) {
+        if (mem) {
+            gFastMem.Free(mem, size, nullptr);
+        }
+    }
+
+    struct LaunchState {
+        LaunchState();
+        void Clear();
+        bool IsSet() const;
+        void Set(float time);
+        void Tick(float dT);
+
+        float Time;   // offset 0x0, size 0x4
+        float Amount; // offset 0x4, size 0x4
+    };
+
+    struct Resource {
+        enum eFlags {
+            VALID = 1,
+            SPOOL = 2,
+            NEEDS_COMPOSITING = 4,
+        };
+
+        Resource() {}
+        Resource(const Attrib::Gen::pvehicle &pvehicle, bool spool, bool is_player);
+        bool NeedsCompositing() const { return (Flags & NEEDS_COMPOSITING) != 0; }
+        bool IsValid() const { return (Flags & VALID) != 0; }
+        bool IsSpooled() const { return (Flags & SPOOL) != 0; }
+        void Invalidate() { Flags &= ~VALID; }
+
+        CarType Type;        // offset 0x0, size 0x4
+        unsigned int Cost;   // offset 0x4, size 0x4
+        unsigned int Flags;  // offset 0x8, size 0x4
+    };
+
+    struct ManageNode {
+        ManageNode() {}
+        static void print(const ManageNode &n) {}
+        static bool sort_remove_resources(const ManageNode &lhs, const ManageNode &rhs) {
+            if (rhs.resource.Type != lhs.resource.Type) {
+                if (lhs.instancecount < rhs.instancecount) {
+                    return true;
+                }
+                if (lhs.resource.Cost > rhs.resource.Cost) {
+                    return true;
+                }
+            }
+            return lhs.resource.Type < rhs.resource.Type;
+        }
+        static bool sort_remove_instances(const ManageNode &lhs, const ManageNode &rhs) {
+            if (rhs.resource.Type != lhs.resource.Type) {
+                if (lhs.instancecount > rhs.instancecount) {
+                    return true;
+                }
+                if (lhs.resource.Cost > rhs.resource.Cost) {
+                    return true;
+                }
+            }
+            return lhs.resource.Type < rhs.resource.Type;
+        }
+        static bool sort_by_keep(const ManageNode &lhs, const ManageNode &rhs) {
+            if (rhs.resource.Type == lhs.resource.Type) {
+                if (lhs.result == VCR_WANT) {
+                    if (rhs.result == VCR_DONTCARE) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+            return lhs.resource.Type < rhs.resource.Type;
+        }
+        static bool is_kept(const ManageNode &h) {
+            return h.result == VCR_WANT;
+        }
+
+        PVehicle *vehicle;            // offset 0x0, size 0x4
+        Resource resource;            // offset 0x4, size 0xC
+        eVehicleCacheResult result;   // offset 0x10, size 0x4
+        unsigned int instancecount;   // offset 0x14, size 0x4
+    };
+
+    struct ManagementList : public UTL::FixedVector<ManageNode, 10, 16> {
+        void print() const {}
+    };
+
+    typedef UTL::Std::list<Resource, _type_list> ResourceList;
+    typedef UTL::Std::map<UCrc32, UCrc32, _type_ID_PVehicleChangeReq> ChangeRequest;
+
+
+    PVehicle(DriverClass dc, const Attrib::Gen::pvehicle &attribs, const UMath::Vector3 &initialVec,
+             const UMath::Vector3 &initialPos, const CollisionGeometry::Bounds *bounds,
+             const FECustomizationRecord *customization, const Resource &resource,
+             const Physics::Info::Performance *performance, const char *cache_name);
+    virtual ~PVehicle();
+
+    static ISimable *Construct(Sim::Param params);
+    static bool MakeRoom(IVehicleCache *cache, const UTL::Std::list<Resource, _type_list> &resources);
+    static void CleanResources();
+    static unsigned int CountResources();
+
+    virtual void Kill() override;
+    virtual void Reset() override;
+    virtual void DebugObject() override;
+    virtual bool OnTask(HSIMTASK htask, float dT) override;
+    virtual void OnTaskSimulate(float dT) override;
+    virtual void OnBehaviorChange(const UCrc32 &mechanic) override;
+    virtual EventSequencer::IEngine *GetEventSequencer() override {
+        return mSequencer;
+    }
+    virtual IModel *GetModel() override;
+    virtual const IModel *GetModel() const override;
+    virtual UMath::Vector3 &GetPosition() const override {
+        return const_cast<UMath::Vector3 &>(PhysicsObject::GetPosition());
+    }
+    virtual void OnDebugDraw();
+    virtual const ISimable *GetSimable() const override;
+    virtual ISimable *GetSimable() override;
+    virtual Attrib::Gen::pvehicle &GetVehicleAttributes() const override {
+        return const_cast<Attrib::Gen::pvehicle &>(mAttributes);
+    }
+    virtual const UCrc32 &GetVehicleClass() const override {
+        return mClass;
+    }
+    virtual const char *GetVehicleName() const override {
+        return mAttributes.CollectionName();
+    }
+    virtual unsigned int GetVehicleKey() const override {
+        return mAttributes.GetCollection();
+    }
+    virtual void SetDriverClass(DriverClass cclass) override;
+    virtual DriverClass GetDriverClass() const override {
+        return mDriverClass;
+    }
+    virtual void SetDriverStyle(DriverStyle style) override;
+    virtual DriverStyle GetDriverStyle() const override {
+        return mDriverStyle;
+    }
+    virtual void SetBehaviorOverride(UCrc32 mechanic, UCrc32 behavior) override;
+    virtual void RemoveBehaviorOverride(UCrc32 mechanic) override;
+    virtual void CommitBehaviorOverrides() override;
+    virtual bool SetVehicleOnGround(const UMath::Vector3 &resetPos, const UMath::Vector3 &initialVec) override;
+    virtual char GetForceStop() override {
+        return mForceStop;
+    }
+    virtual void ForceStopOn(char forceStopBits) override;
+    virtual void ForceStopOff(char forceStopBits) override;
+    virtual bool IsOffWorld() const override {
+        return mOffWorld;
+    }
+    virtual CarType GetModelType() const override {
+        return mResources.Type;
+    }
+    virtual bool IsSpooled() const override {
+        return mResources.IsSpooled();
+    }
+    virtual void SetStaging(bool staging) override;
+    virtual bool IsStaging() const override {
+        return mStaging;
+    }
+    virtual void Launch() override;
+    virtual float GetPerfectLaunch() const override;
+    virtual bool IsLoading() const override;
+    virtual float GetOffscreenTime() const override {
+        return mOffScreenTime;
+    }
+    virtual float GetOnScreenTime() const override {
+        return mOnScreenTime;
+    }
+    virtual bool InShock() const override {
+        if (mDamage == nullptr) {
+            return false;
+        }
+        return mDamage->InShock() > 0.0f;
+    }
+    virtual bool IsDestroyed() const override {
+        if (mDamage != nullptr) {
+            return mDamage->IsDestroyed();
+        } else {
+            return false;
+        }
+    }
+    virtual float GetAbsoluteSpeed() const override {
+        return mAbsSpeed;
+    }
+    virtual float GetSpeedometer() const override {
+        return mSpeedometer;
+    }
+    virtual float GetSpeed() const override;
+    virtual void SetSpeed(float speed) override;
+    virtual void GlareOn(VehicleFX::ID glare) override;
+    virtual void GlareOff(VehicleFX::ID glare) override;
+    virtual bool IsGlareOn(VehicleFX::ID glare) const override {
+        return (mGlareState & glare) != 0;
+    }
+    virtual bool IsCollidingWithSoftBarrier() override {
+        return false;
+    }
+    virtual bool IsAnimating() const override {
+        return mAnimating;
+    }
+    virtual void SetAnimating(bool animate) override;
+    virtual void Activate() override;
+    virtual void Deactivate() override;
+    virtual bool IsActive() const override {
+        return mPhysicsMode != PHYSICS_MODE_INACTIVE;
+    }
+    virtual void SetPhysicsMode(PhysicsMode mode) override;
+    virtual PhysicsMode GetPhysicsMode() const override {
+        return mPhysicsMode;
+    }
+    virtual IVehicleAI *GetAIVehiclePtr() const override {
+        return mAI;
+    }
+    virtual float GetSlipAngle() const override {
+        return mSlipAngle;
+    }
+    virtual UMath::Vector3 &GetLocalVelocity() const override {
+        return const_cast<UMath::Vector3 &>(mLocalVel);
+    }
+    virtual const FECustomizationRecord *GetCustomizations() const override {
+        return mCustomization;
+    }
+    virtual const Physics::Tunings *GetTunings() const override;
+    virtual void SetTunings(const Physics::Tunings &tunings) override;
+    virtual void ComputeHeading(UMath::Vector3 *v) override;
+    virtual bool GetPerformance(Physics::Info::Performance &performance) const override {
+        performance = mPerformance;
+        return mPerformanceValid;
+    }
+    virtual const char *GetCacheName() const override {
+        return mCacheName;
+    }
+    virtual bool OnExplosion(const UMath::Vector3 &normal, const UMath::Vector3 &position, float dT, IExplosion *explosion) override;
+    virtual bool SetDynamicData(const EventSequencer::System *system, EventDynamicData *data) override;
+    virtual void OnAttributeChange(const Attrib::Collection *collection, unsigned int attribkey) override;
+
+    static bTList<PVehicle> mInstances;
+
+  private:
+    void OnBeginMode(const PhysicsMode mode);
+    void OnEndMode(const PhysicsMode mode);
+    void DoDebug(float dT);
+    void DoStaging(float dT);
+    void CheckOffWorld();
+    void LoadBehaviors(const UMath::Vector3 &pos, const UMath::Matrix4 &matrix);
+    UCrc32 LookupBehaviorSignature(const Attrib::StringKey &mechanic) const;
+    void ReloadBehaviors();
+    void UpdateLocalVelocities();
+    void OnDisableModeling();
+    void OnEnableModeling();
+    void UpdateListing();
+    void OnTaskFX(float dT);
+
+    Attrib::Gen::pvehicle mAttributes;
+    FECustomizationRecord *mCustomization;
+    IInput *mInput;
+    ICollisionBody *mCollisionBody;
+    ISuspension *mSuspension;
+    IEngine *mEngine;
+    IDamageable *mDamage;
+    ITransmission *mTranny;
+    IVehicleAI *mAI;
+    IArticulatedVehicle *mArticulation;
+    IRenderable *mRenderable;
+    IAudible *mAudible;
+    EventSequencer::IEngine *mSequencer;
+    HSIMTASK mTaskFX;
+    UCrc32 mClass;
+    float mSpeed;
+    float mAbsSpeed;
+    float mSpeedometer;
+    float mTimeInAir;
+    float mSlipAngle;
+    unsigned int mWheelsOnGround;
+    UMath::Vector3 mLocalVel;
+    DriverClass mDriverClass;
+    DriverStyle mDriverStyle;
+    unsigned int mGlareState;
+    float mStartingNOS;
+    float mBrakeTime;
+    char mForceStop;
+    PhysicsMode mPhysicsMode;
+    bool mAnimating;
+    bool mStaging;
+    LaunchState mPerfectLaunch;
+    UTL::Std::map<UCrc32, UCrc32, _type_ID_PVehicleChangeReq> mBehaviorOverrides;
+    bool mOverrideDirty;
+    const CollisionGeometry::Bounds *mBounds;
+    bool mIsModeling;
+    float mOffScreenTime;
+    float mOnScreenTime;
+    bool mOffWorld;
+    static bool mRunDyno;
+    bool mHasDyno;
+    Resource mResources;
+    Physics::Info::Performance mPerformance;
+    bool mPerformanceValid;
+    const char *mCacheName;
 };
 
 #endif

--- a/src/Speed/Indep/Src/Physics/PhysicsInfo.cpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsInfo.cpp
@@ -1,10 +1,20 @@
 #include "PhysicsInfo.hpp"
+#include "PhysicsUpgrades.hpp"
+#include "Speed/Indep/Src/Generated/AttribSys/Classes/brakes.h"
+#include "Speed/Indep/Src/Misc/Table.hpp"
+#include "Speed/Indep/bWare/Inc/bWare.hpp"
 #include "PhysicsTunings.h"
 #include "Speed/Indep/Libs/Support/Utility/UMath.h"
 #include "Speed/Indep/Src/Sim/UTil.h"
 #include "Speed/Indep/Tools/Inc/ConversionUtil.hpp"
 
 using namespace Attrib::Gen;
+
+static PerfStats top_stats;
+static PerfStats bottom_stats;
+static PerformanceMaps TheStockCars;
+static int Physics_Info_initialized;
+Physics::Info::Performance Physics::Info::PerformanceWeights[7];
 
 // Credits: Brawltendo
 float Physics::Info::AerodynamicDownforce(const Attrib::Gen::chassis &chassis, const float speed) {
@@ -401,4 +411,527 @@ unsigned int Physics::Info::NumFowardGears(const Attrib::Gen::transmission &tran
 unsigned int Physics::Info::NumFowardGears(const Attrib::Gen::pvehicle &pvehicle) {
     const Attrib::Gen::transmission trans(pvehicle.transmission(0), 0, nullptr);
     return NumFowardGears(trans);
+}
+
+bool Physics::Info::HasPerformanceRatings(const Attrib::Gen::pvehicle &pvehicle) {
+    float base_handling = pvehicle.HandlingRating(0);
+    float top_handling = pvehicle.HandlingRating(1);
+    return base_handling < top_handling && 0.0f < top_handling;
+}
+
+bool PerfStats::Fetch(const Attrib::Gen::pvehicle &vehicle, bVector2 *graph_data, int *num_data) {
+    Time0To100 = 0.0f;
+    TopSpeed = 0.0f;
+    HandlingRating = 0.0f;
+
+    Attrib::Gen::engine eng(vehicle.engine(0), 0, nullptr);
+    Attrib::Gen::induction ind(vehicle.induction(0), 0, nullptr);
+    Attrib::Gen::transmission trans(vehicle.transmission(0), 0, nullptr);
+    Attrib::Gen::chassis chas(vehicle.chassis(0), 0, nullptr);
+    Attrib::Gen::tires tir(vehicle.tires(0), 0, nullptr);
+    Attrib::Gen::brakes bra(vehicle.brakes(0).GetCollection(), 0, nullptr);
+    Attrib::Gen::nos n(vehicle.nos(0), 0, nullptr);
+
+    float max_torque_rpm;
+    Physics::Info::MaxTorque(eng, max_torque_rpm);
+    float wheel_diameter = Physics::Info::WheelDiameter(vehicle, false);
+    float idle_rpm = eng.IDLE();
+    float redline_rpm = eng.RED_LINE();
+    float min_w = RPM2RPS(idle_rpm);
+    float max_w = RPM2RPS(redline_rpm);
+    float wheel_radius = wheel_diameter * 0.5f;
+    float final_gear = trans.FINAL_GEAR();
+    float speed_limiter = MPH2MPS(eng.SPEED_LIMITER(0));
+
+    float shift_up[12];
+    float shift_down[12];
+
+    if (!Physics::Info::ShiftPoints(trans, eng, ind, shift_up, shift_down, 12) ||
+        wheel_radius <= 0.0f || final_gear <= 0.0f) {
+        return false;
+    }
+
+    float speed = 0.0f;
+    unsigned int gear = 0;
+    float time = 0.0f;
+    float mass = vehicle.MASS();
+    float dT = 0.125f;
+    int data_index = 0;
+    if (graph_data != nullptr) {
+        dT = 1.0f;
+    }
+    int max_data_index = 0;
+    if (num_data != nullptr) {
+        max_data_index = *num_data;
+    }
+    float power_range = max_w - min_w;
+    unsigned int num_gears = Physics::Info::NumFowardGears(vehicle);
+    unsigned int last_gear = num_gears - 1;
+
+    do {
+        float total_gear_ratio = trans.GEAR_RATIO(gear + G_FIRST) * final_gear;
+        float differential_rpm = RPS2RPM(min_w + (speed / wheel_radius) * total_gear_ratio * (power_range / max_w));
+        float rpm = UMath::Min(differential_rpm, redline_rpm);
+        rpm = UMath::Max(rpm, idle_rpm);
+
+        if (gear == 0) {
+            rpm = UMath::Max(rpm, max_torque_rpm);
+        }
+
+        float torque = Physics::Info::Torque(eng, rpm) * FTLB2NM(1.0f);
+        float boost = Physics::Info::InductionBoost(eng, ind, rpm, 1.0f, nullptr, nullptr);
+        float nos_capacity = Physics::Info::NosCapacity(n, nullptr);
+        float force = torque * (boost + 1.0f) * total_gear_ratio;
+        if (time < nos_capacity && speed > 5.0f) {
+            float nos_boost = Physics::Info::NosBoost(n, nullptr);
+            force *= nos_boost;
+        }
+        float accel = (force / wheel_radius) / mass;
+
+        if (graph_data != nullptr) {
+            int idx = data_index;
+            if (max_data_index < idx) {
+                idx = max_data_index;
+            }
+            graph_data[idx].y = accel;
+            graph_data[idx].x = speed;
+            data_index++;
+        }
+
+        float drag = UMath::Abs(speed * speed * chas.DRAG_COEFFICIENT()) / mass;
+        speed = (speed + accel * dT) - drag * dT;
+
+        if (speed >= MPH2MPS(100.0f) && Time0To100 <= 0.0f) {
+            Time0To100 = time;
+            dT = 1.0f;
+        }
+
+        if (speed_limiter <= 0.0f || speed < speed_limiter) {
+            if (gear == last_gear &&
+                (accel < drag || redline_rpm <= rpm) &&
+                TopSpeed <= 0.0f) {
+                TopSpeed = speed;
+            }
+        } else {
+            TopSpeed = speed_limiter;
+        }
+
+        time += dT;
+
+        if (TopSpeed > 0.0f) {
+            if (Time0To100 > 0.0f) break;
+        }
+
+        if (rpm >= shift_up[gear + G_FIRST]) {
+            unsigned int next_gear = gear + 1;
+            gear = last_gear;
+            if (next_gear < last_gear) {
+                gear = next_gear;
+            }
+        }
+    } while (time < 120.0f);
+
+    if (gear == last_gear || TopSpeed <= 0.0f) {
+        TopSpeed = speed;
+    }
+
+    float base_handling = vehicle.HandlingRating(0);
+    float top_handling = vehicle.HandlingRating(1);
+    float handling_sum = 0.0f;
+    float diff = top_handling - base_handling;
+    float *pw = &Physics::Info::PerformanceWeights[0].Handling;
+    float weight_sum = 0.0f;
+    Physics::Upgrades::Type type = Physics::Upgrades::PUT_TIRES;
+    do {
+        Physics::Upgrades::Type next = static_cast<Physics::Upgrades::Type>(type + Physics::Upgrades::PUT_BRAKES);
+        weight_sum += *pw;
+        float pct = Physics::Upgrades::GetPercent(vehicle, type);
+        float w = *pw;
+        pw += 3;
+        handling_sum += pct * w;
+        type = next;
+    } while (static_cast<int>(type) < 7);
+    if (weight_sum > 1e-6f) {
+        handling_sum /= weight_sum;
+    }
+    HandlingRating = UMath::Lerp(base_handling, top_handling, handling_sum);
+
+    if (num_data != nullptr) {
+        *num_data = data_index;
+    }
+
+    bool success = false;
+    if (TopSpeed > 0.0f) {
+        success = Time0To100 > 0.0f;
+    }
+    return success;
+}
+
+void PerfLevel::Print(const char *) {
+}
+
+void PerfLevel::Rate() {
+    Stock.Handling = UMath::Ramp(Stats.HandlingRating, bottom_stats.HandlingRating, top_stats.HandlingRating);
+    Stock.Acceleration = 1.0f - UMath::Ramp(Stats.Time0To100, bottom_stats.Time0To100, top_stats.Time0To100);
+    Stock.TopSpeed = UMath::Ramp(Stats.TopSpeed, bottom_stats.TopSpeed, top_stats.TopSpeed);
+}
+
+bool PerfLevel::Analyze(const Attrib::Gen::pvehicle &pvehicle) {
+    Analyzed = false;
+    if (!Stats.Fetch(pvehicle, nullptr, nullptr)) {
+        return false;
+    }
+    Analyzed = true;
+    return true;
+}
+
+void PerformanceMaps::FindLimits(float direction, PerfStats &out) const {
+    PerfStats temp;
+    bMemSet(&temp, 0, sizeof(PerfStats));
+    out = temp;
+
+    for (const_iterator iter = begin(); iter != end(); iter++) {
+        const PerfLevel &p = *iter;
+        if (iter == begin()) {
+            out = p.Stats;
+        } else {
+            if (p.Stats.HandlingRating * direction > out.HandlingRating * direction) {
+                out.HandlingRating = p.Stats.HandlingRating;
+            }
+            if (p.Stats.Time0To100 * direction > out.Time0To100 * direction) {
+                out.Time0To100 = p.Stats.Time0To100;
+            }
+            if (p.Stats.TopSpeed * direction > out.TopSpeed * direction) {
+                out.TopSpeed = p.Stats.TopSpeed;
+            }
+        }
+    }
+}
+
+void Physics::Info::Init() {
+    const Attrib::Class *aclass = Attrib::Database::Get().GetClass(Attrib::Gen::pvehicle::ClassKey());
+    unsigned int key = aclass->GetFirstCollection();
+
+    PerformanceMaps all_cars;
+    PerformanceMaps upgraded_cars;
+
+    while (key != 0) {
+        Attrib::Gen::pvehicle vehicle(key, 0, nullptr);
+        if (vehicle.MODEL().GetHash32() != UCrc32::kNull.GetValue() && !vehicle.IsDynamic()) {
+            if (HasPerformanceRatings(vehicle)) {
+                PerfLevel performance(key);
+                if (performance.Analyze(vehicle)) {
+                    TheStockCars.push_back(performance);
+                    all_cars.push_back(performance);
+                }
+            }
+        }
+        Physics::Upgrades::Flush();
+        key = aclass->GetNextCollection(key);
+    }
+
+    for (PerformanceMaps::iterator iter = TheStockCars.begin(); iter != TheStockCars.end(); iter++) {
+        PerfLevel &p = *iter;
+        Attrib::Gen::pvehicle vehicle(p.Key, 0, nullptr);
+        if (Physics::Upgrades::SetMaximum(vehicle)) {
+            PerfLevel performance(p.Key);
+            if (performance.Analyze(vehicle)) {
+                upgraded_cars.push_back(performance);
+                all_cars.push_back(performance);
+            }
+        }
+        Physics::Upgrades::Flush();
+    }
+
+    int count = 0;
+    for (PerformanceMaps::iterator iter = TheStockCars.begin(); iter != TheStockCars.end(); iter++) {
+        count++;
+    }
+
+    if (count == 0) {
+        return;
+    }
+
+    all_cars.FindLimits(-1.0f, bottom_stats);
+    all_cars.FindLimits(1.0f, top_stats);
+
+    for (PerformanceMaps::iterator iter = TheStockCars.begin(); iter != TheStockCars.end(); iter++) {
+        PerfLevel &p = *iter;
+        p.Rate();
+        p.Print("Stock Performance");
+    }
+
+    for (PerformanceMaps::iterator iter = upgraded_cars.begin(); iter != upgraded_cars.end(); iter++) {
+        PerfLevel &p = *iter;
+        p.Rate();
+        p.Print("Upgraded Performance");
+    }
+
+    for (PerformanceMaps::iterator iter = TheStockCars.begin(); iter != TheStockCars.end(); iter++) {
+        PerfLevel &p = *iter;
+        p.Upgraded = p.Stock;
+        for (PerformanceMaps::iterator iter2 = upgraded_cars.begin(); iter2 != upgraded_cars.end(); iter2++) {
+            if (p.Key == (*iter2).Key) {
+                p.Upgraded = (*iter2).Stock;
+                break;
+            }
+        }
+    }
+
+    Physics_Info_initialized = 1;
+}
+
+bool Physics::Info::ComputeAccelerationTable(const Attrib::Gen::pvehicle &vehicle, float &top_speed, float *table, int num_entries) {
+    Attrib::Gen::transmission trans(vehicle.transmission(0), 0, nullptr);
+    Attrib::Gen::tires tir(vehicle.tires(0), 0, nullptr);
+    Attrib::Gen::chassis chas(vehicle.chassis(0), 0, nullptr);
+    Attrib::Gen::engine eng(vehicle.engine(0), 0, nullptr);
+    Attrib::Gen::induction ind(vehicle.induction(0), 0, nullptr);
+
+    float avg_torque = AvgInductedTorque(eng, ind, trans, true, nullptr);
+    avg_torque = avg_torque * FTLB2NM(1.0f);
+
+    if (avg_torque <= 0.0f || num_entries < 2 || table == nullptr) {
+        return false;
+    }
+
+    bVector2 graph_data[10];
+
+    unsigned int num_gears = NumFowardGears(trans);
+    if (num_gears == 0) {
+        return false;
+    }
+
+    float mass = vehicle.MASS();
+    float final_gear = trans.FINAL_GEAR();
+    float wheel_radius = WheelDiameter(tir, false) * 0.5f;
+
+    if (wheel_radius <= 0.001f) {
+        return false;
+    }
+
+    top_speed = 0.0f;
+    int graph_max = 0;
+    float prev_accel = 0.0f;
+    float prev_speed = 0.0f;
+
+    for (unsigned int foward_gear = 0; foward_gear < num_gears; foward_gear++) {
+        float gear_ratio = trans.GEAR_RATIO(foward_gear + G_FIRST) * final_gear;
+        float gear_eff = trans.GEAR_EFFICIENCY(foward_gear + G_FIRST);
+
+        if (gear_ratio <= 0.0f) break;
+
+        float speed = (eng.RED_LINE() * RPM2RPS(1.0f) * wheel_radius) / gear_ratio;
+        float force = (avg_torque * gear_ratio * gear_eff) / wheel_radius;
+        float drag = speed * speed * chas.DRAG_COEFFICIENT();
+        float accel = (force - drag) / mass;
+
+        if (accel <= 0.0f) {
+            if (prev_accel <= 0.0f) break;
+            speed = UMath::Lerp(prev_speed, speed, prev_accel / (prev_accel - accel));
+            accel = 0.0f;
+        }
+
+        top_speed = UMath::Max(top_speed, speed);
+
+        graph_data[graph_max].x = speed;
+        graph_data[graph_max].y = accel;
+        graph_max++;
+        prev_accel = accel;
+        prev_speed = speed;
+    }
+
+    if (graph_max == 0) {
+        return false;
+    }
+
+    Graph accel_graph(graph_data, graph_max);
+    float max_speed = top_speed;
+
+    if (max_speed <= 0.0f) {
+        return false;
+    }
+
+    float inc = max_speed / static_cast<float>(num_entries - 1);
+    for (int i = 0; i < num_entries; i++) {
+        table[i] = accel_graph.GetValue(inc * static_cast<float>(i));
+    }
+
+    return true;
+}
+
+bool Physics::Info::EstimatePerformance(const Attrib::Gen::pvehicle &vehicle, Performance &perf) {
+    Performance stock;
+    Performance upgraded;
+
+    bool success = GetStockPerformance(vehicle, stock);
+    bool result = false;
+    if (success) {
+        success = GetMaximumPerformance(vehicle, upgraded);
+        if (success) {
+            perf.TopSpeed = 0.0f;
+            perf.Acceleration = 0.0f;
+            perf.Handling = 0.0f;
+
+            Performance weights;
+            Performance junk;
+            Performance junk_weights;
+
+            Physics::Info::Performance *pw = PerformanceWeights;
+            Physics::Upgrades::Type type = Physics::Upgrades::PUT_TIRES;
+            do {
+                float value = Physics::Upgrades::GetPercent(vehicle, type);
+
+                junk_weights.Handling += pw->Handling;
+                junk_weights.Acceleration += pw->Acceleration;
+                junk_weights.TopSpeed += pw->TopSpeed;
+
+                if (Physics::Upgrades::GetJunkman(vehicle, type)) {
+                    junk.Handling += pw->Handling;
+                    junk.Acceleration += pw->Acceleration;
+                    junk.TopSpeed += pw->TopSpeed;
+                }
+
+                float hw = pw->Handling;
+                type = static_cast<Physics::Upgrades::Type>(type + Physics::Upgrades::PUT_BRAKES);
+                float handling = hw * value + perf.Handling;
+                weights.Handling += hw;
+                perf.Handling = handling;
+                weights.Acceleration += pw->Acceleration;
+                perf.Acceleration += pw->Acceleration * value;
+                weights.TopSpeed += pw->TopSpeed;
+                perf.TopSpeed += pw->TopSpeed * value;
+                pw++;
+            } while (static_cast<int>(type) < 7);
+
+            if (weights.Handling > 1e-6f) {
+                perf.Handling = perf.Handling / weights.Handling;
+            }
+            if (weights.Acceleration > 1e-6f) {
+                perf.Acceleration = perf.Acceleration / weights.Acceleration;
+            }
+            if (weights.TopSpeed > 1e-6f) {
+                perf.TopSpeed = perf.TopSpeed / weights.TopSpeed;
+            }
+
+            if (junk_weights.Handling > 1e-6f) {
+                float junk_ratio = junk.Handling / junk_weights.Handling;
+                upgraded.Handling = UMath::Lerp(upgraded.Handling, 1.0f, junk_ratio);
+                float bonus = junk_ratio * 0.33f;
+                float h = perf.Handling * (bonus + 1.0f);
+                perf.Handling = h;
+                stock.Handling = UMath::Lerp(stock.Handling, upgraded.Handling, bonus);
+                perf.Handling = UMath::Min(h, 1.0f);
+            }
+
+            if (junk_weights.Acceleration > 1e-6f) {
+                float junk_ratio = junk.Acceleration / junk_weights.Acceleration;
+                upgraded.Acceleration = UMath::Lerp(upgraded.Acceleration, 1.0f, junk_ratio);
+                float bonus = junk_ratio * 0.33f;
+                float a = perf.Acceleration * (bonus + 1.0f);
+                perf.Acceleration = a;
+                stock.Acceleration = UMath::Lerp(stock.Acceleration, upgraded.Acceleration, bonus);
+                perf.Acceleration = UMath::Min(a, 1.0f);
+            }
+
+            if (junk_weights.TopSpeed > 1e-6f) {
+                float junk_ratio = junk.TopSpeed / junk_weights.TopSpeed;
+                upgraded.TopSpeed = UMath::Lerp(upgraded.TopSpeed, 1.0f, junk_ratio);
+                float bonus = junk_ratio * 0.33f;
+                float t = perf.TopSpeed * (bonus + 1.0f);
+                perf.TopSpeed = t;
+                stock.TopSpeed = UMath::Lerp(stock.TopSpeed, upgraded.TopSpeed, bonus);
+                perf.TopSpeed = UMath::Min(t, 1.0f);
+            }
+
+            result = true;
+            perf.Handling = UMath::Lerp(stock.Handling, upgraded.Handling, perf.Handling);
+            perf.Acceleration = UMath::Lerp(stock.Acceleration, upgraded.Acceleration, perf.Acceleration);
+            perf.TopSpeed = UMath::Lerp(stock.TopSpeed, upgraded.TopSpeed, perf.TopSpeed);
+        } else {
+            result = false;
+        }
+    }
+    return result;
+}
+
+bool Physics::Info::ComputePerformance(const Attrib::Gen::pvehicle &vehicle, Performance &perf) {
+    if (!HasPerformanceRatings(vehicle)) {
+        return false;
+    }
+
+    for (PerformanceMaps::iterator iter = TheStockCars.begin(); iter != TheStockCars.end(); iter++) {
+        if ((*iter).Key == vehicle.GetCollection()) {
+            perf = (*iter).Stock;
+            return true;
+        }
+    }
+
+    unsigned int coll_key = vehicle.GetCollection();
+    PerfLevel perf_level(coll_key);
+    if (!perf_level.Analyze(vehicle)) {
+        return false;
+    }
+    perf_level.Rate();
+    perf = perf_level.Stock;
+    return true;
+}
+
+bool Physics::Info::GetStockPerformance(const Attrib::Gen::pvehicle &pvehicle, Performance &perf) {
+    if (!HasPerformanceRatings(pvehicle)) {
+        return false;
+    }
+
+    unsigned int key = pvehicle.GetCollection();
+    if (pvehicle.IsDynamic()) {
+        key = pvehicle.GetParent();
+    }
+
+    for (PerformanceMaps::const_iterator iter = TheStockCars.begin(); iter != TheStockCars.end(); iter++) {
+        const PerfLevel &p = *iter;
+        if (p.Key == key) {
+            perf = p.Stock;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool Physics::Info::GetMaximumPerformance(const Attrib::Gen::pvehicle &pvehicle, Performance &perf) {
+    if (!HasPerformanceRatings(pvehicle)) {
+        return false;
+    }
+
+    unsigned int key = pvehicle.GetCollection();
+    if (pvehicle.IsDynamic()) {
+        key = pvehicle.GetParent();
+    }
+
+    for (PerformanceMaps::const_iterator iter = TheStockCars.begin(); iter != TheStockCars.end(); iter++) {
+        const PerfLevel &p = *iter;
+        if (p.Key == key) {
+            perf = p.Upgraded;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void Physics::Info::FindPerformanceCandidates(const Performance &minimum_perf, const Performance &maximum_perf,
+                                              UTL::Std::list<unsigned int, _type_list> &vlist) {
+    vlist.clear();
+
+    for (PerformanceMaps::const_iterator iter = TheStockCars.begin(); iter != TheStockCars.end(); iter++) {
+        const PerfLevel &p = *iter;
+        if (p.Stock.TopSpeed <= maximum_perf.TopSpeed &&
+            p.Stock.Acceleration <= maximum_perf.Acceleration &&
+            p.Stock.Handling <= maximum_perf.Handling &&
+            p.Upgraded.TopSpeed >= minimum_perf.TopSpeed &&
+            p.Upgraded.Acceleration >= minimum_perf.Acceleration &&
+            p.Upgraded.Handling >= minimum_perf.Handling) {
+            vlist.push_back(p.Key);
+        }
+    }
 }

--- a/src/Speed/Indep/Src/Physics/PhysicsInfo.cpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsInfo.cpp
@@ -489,16 +489,14 @@ bool PerfStats::Fetch(const Attrib::Gen::pvehicle &vehicle, bVector2 *graph_data
         float accel = (force / wheel_radius) / mass;
 
         if (graph_data != nullptr) {
-            int idx = data_index;
+            int idx = data_index++;
             if (max_data_index < idx) {
                 idx = max_data_index;
             }
-            graph_data[idx].y = accel;
-            graph_data[idx].x = speed;
-            data_index++;
+            graph_data[idx] = bVector2(speed, accel);
         }
 
-        float drag = UMath::Abs(speed * speed * chas.DRAG_COEFFICIENT()) / mass;
+        float drag = UMath::Abs(speed * (speed * chas.DRAG_COEFFICIENT())) / mass;
         speed = (speed + accel * dT) - drag * dT;
 
         if (speed >= MPH2MPS(100.0f) && Time0To100 <= 0.0f) {

--- a/src/Speed/Indep/Src/Physics/PhysicsInfo.cpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsInfo.cpp
@@ -643,10 +643,7 @@ void Physics::Info::Init() {
         Physics::Upgrades::Flush();
     }
 
-    int count = 0;
-    for (PerformanceMaps::iterator iter = TheStockCars.begin(); iter != TheStockCars.end(); iter++) {
-        count++;
-    }
+    int count = TheStockCars.size();
 
     if (count == 0) {
         return;

--- a/src/Speed/Indep/Src/Physics/PhysicsInfo.cpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsInfo.cpp
@@ -760,45 +760,44 @@ bool Physics::Info::EstimatePerformance(const Attrib::Gen::pvehicle &vehicle, Pe
     Performance stock;
     Performance upgraded;
 
-    bool success = GetStockPerformance(vehicle, stock);
-    bool result = false;
-    if (success) {
-        success = GetMaximumPerformance(vehicle, upgraded);
-        if (success) {
-            perf.TopSpeed = 0.0f;
+    if (!GetStockPerformance(vehicle, stock)) {
+        return false;
+    }
+    if (!GetMaximumPerformance(vehicle, upgraded)) {
+        return false;
+    }
+    {
+        {
             perf.Acceleration = 0.0f;
             perf.Handling = 0.0f;
+            perf.TopSpeed = 0.0f;
 
             Performance weights;
             Performance junk;
             Performance junk_weights;
 
-            Physics::Info::Performance *pw = PerformanceWeights;
-            Physics::Upgrades::Type type = Physics::Upgrades::PUT_TIRES;
-            do {
-                float value = Physics::Upgrades::GetPercent(vehicle, type);
+            for (int type = 0; type < 7; type++) {
+                float value = Physics::Upgrades::GetPercent(vehicle, static_cast<Physics::Upgrades::Type>(type));
 
-                junk_weights.Handling += pw->Handling;
-                junk_weights.Acceleration += pw->Acceleration;
-                junk_weights.TopSpeed += pw->TopSpeed;
+                junk_weights.Handling += PerformanceWeights[type].Handling;
+                junk_weights.Acceleration += PerformanceWeights[type].Acceleration;
+                junk_weights.TopSpeed += PerformanceWeights[type].TopSpeed;
 
-                if (Physics::Upgrades::GetJunkman(vehicle, type)) {
-                    junk.Handling += pw->Handling;
-                    junk.Acceleration += pw->Acceleration;
-                    junk.TopSpeed += pw->TopSpeed;
+                if (Physics::Upgrades::GetJunkman(vehicle, static_cast<Physics::Upgrades::Type>(type))) {
+                    junk.Handling += PerformanceWeights[type].Handling;
+                    junk.Acceleration += PerformanceWeights[type].Acceleration;
+                    junk.TopSpeed += PerformanceWeights[type].TopSpeed;
                 }
 
-                float hw = pw->Handling;
-                type = static_cast<Physics::Upgrades::Type>(type + Physics::Upgrades::PUT_BRAKES);
-                float handling = hw * value + perf.Handling;
-                weights.Handling += hw;
-                perf.Handling = handling;
-                weights.Acceleration += pw->Acceleration;
-                perf.Acceleration += pw->Acceleration * value;
-                weights.TopSpeed += pw->TopSpeed;
-                perf.TopSpeed += pw->TopSpeed * value;
-                pw++;
-            } while (static_cast<int>(type) < 7);
+                weights.Handling += PerformanceWeights[type].Handling;
+                perf.Handling = PerformanceWeights[type].Handling * value + perf.Handling;
+
+                weights.Acceleration += PerformanceWeights[type].Acceleration;
+                perf.Acceleration = PerformanceWeights[type].Acceleration * value + perf.Acceleration;
+
+                weights.TopSpeed += PerformanceWeights[type].TopSpeed;
+                perf.TopSpeed = PerformanceWeights[type].TopSpeed * value + perf.TopSpeed;
+            }
 
             if (weights.Handling > 1e-6f) {
                 perf.Handling = perf.Handling / weights.Handling;
@@ -811,9 +810,9 @@ bool Physics::Info::EstimatePerformance(const Attrib::Gen::pvehicle &vehicle, Pe
             }
 
             if (junk_weights.Handling > 1e-6f) {
-                float junk_ratio = junk.Handling / junk_weights.Handling;
-                upgraded.Handling = UMath::Lerp(upgraded.Handling, 1.0f, junk_ratio);
-                float bonus = junk_ratio * 0.33f;
+                junk.Handling = junk.Handling / junk_weights.Handling;
+                upgraded.Handling = UMath::Lerp(upgraded.Handling, 1.0f, junk.Handling);
+                float bonus = junk.Handling * 0.33f;
                 float h = perf.Handling * (bonus + 1.0f);
                 perf.Handling = h;
                 stock.Handling = UMath::Lerp(stock.Handling, upgraded.Handling, bonus);
@@ -821,9 +820,9 @@ bool Physics::Info::EstimatePerformance(const Attrib::Gen::pvehicle &vehicle, Pe
             }
 
             if (junk_weights.Acceleration > 1e-6f) {
-                float junk_ratio = junk.Acceleration / junk_weights.Acceleration;
-                upgraded.Acceleration = UMath::Lerp(upgraded.Acceleration, 1.0f, junk_ratio);
-                float bonus = junk_ratio * 0.33f;
+                junk.Acceleration = junk.Acceleration / junk_weights.Acceleration;
+                upgraded.Acceleration = UMath::Lerp(upgraded.Acceleration, 1.0f, junk.Acceleration);
+                float bonus = junk.Acceleration * 0.33f;
                 float a = perf.Acceleration * (bonus + 1.0f);
                 perf.Acceleration = a;
                 stock.Acceleration = UMath::Lerp(stock.Acceleration, upgraded.Acceleration, bonus);
@@ -831,24 +830,21 @@ bool Physics::Info::EstimatePerformance(const Attrib::Gen::pvehicle &vehicle, Pe
             }
 
             if (junk_weights.TopSpeed > 1e-6f) {
-                float junk_ratio = junk.TopSpeed / junk_weights.TopSpeed;
-                upgraded.TopSpeed = UMath::Lerp(upgraded.TopSpeed, 1.0f, junk_ratio);
-                float bonus = junk_ratio * 0.33f;
+                junk.TopSpeed = junk.TopSpeed / junk_weights.TopSpeed;
+                upgraded.TopSpeed = UMath::Lerp(upgraded.TopSpeed, 1.0f, junk.TopSpeed);
+                float bonus = junk.TopSpeed * 0.33f;
                 float t = perf.TopSpeed * (bonus + 1.0f);
                 perf.TopSpeed = t;
                 stock.TopSpeed = UMath::Lerp(stock.TopSpeed, upgraded.TopSpeed, bonus);
                 perf.TopSpeed = UMath::Min(t, 1.0f);
             }
 
-            result = true;
             perf.Handling = UMath::Lerp(stock.Handling, upgraded.Handling, perf.Handling);
             perf.Acceleration = UMath::Lerp(stock.Acceleration, upgraded.Acceleration, perf.Acceleration);
             perf.TopSpeed = UMath::Lerp(stock.TopSpeed, upgraded.TopSpeed, perf.TopSpeed);
-        } else {
-            result = false;
         }
     }
-    return result;
+    return true;
 }
 
 bool Physics::Info::ComputePerformance(const Attrib::Gen::pvehicle &vehicle, Performance &perf) {
@@ -857,14 +853,14 @@ bool Physics::Info::ComputePerformance(const Attrib::Gen::pvehicle &vehicle, Per
     }
 
     for (PerformanceMaps::iterator iter = TheStockCars.begin(); iter != TheStockCars.end(); iter++) {
-        if ((*iter).Key == vehicle.GetCollection()) {
-            perf = (*iter).Stock;
+        PerfLevel &p = *iter;
+        if (p.Key == vehicle.GetCollection()) {
+            perf = p.Stock;
             return true;
         }
     }
 
-    unsigned int coll_key = vehicle.GetCollection();
-    PerfLevel perf_level(coll_key);
+    PerfLevel perf_level(vehicle.GetCollection());
     if (!perf_level.Analyze(vehicle)) {
         return false;
     }

--- a/src/Speed/Indep/Src/Physics/PhysicsInfo.cpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsInfo.cpp
@@ -719,8 +719,9 @@ bool Physics::Info::ComputeAccelerationTable(const Attrib::Gen::pvehicle &vehicl
     float prev_speed = 0.0f;
 
     for (unsigned int foward_gear = 0; foward_gear < num_gears; foward_gear++) {
-        float gear_ratio = trans.GEAR_RATIO(foward_gear + G_FIRST) * final_gear;
-        float gear_eff = trans.GEAR_EFFICIENCY(foward_gear + G_FIRST);
+        unsigned int gear = foward_gear + G_FIRST;
+        float gear_ratio = trans.GEAR_RATIO(gear) * final_gear;
+        float gear_eff = trans.GEAR_EFFICIENCY(gear);
 
         float force = (avg_torque * gear_ratio * gear_eff) / wheel_radius;
 
@@ -740,9 +741,9 @@ bool Physics::Info::ComputeAccelerationTable(const Attrib::Gen::pvehicle &vehicl
 
         graph_data[graph_max].x = speed;
         graph_data[graph_max].y = accel;
-        graph_max++;
         prev_accel = accel;
         prev_speed = speed;
+        graph_max++;
     }
 
     if (graph_max == 0) {
@@ -752,16 +753,15 @@ bool Physics::Info::ComputeAccelerationTable(const Attrib::Gen::pvehicle &vehicl
     Graph accel_graph(graph_data, graph_max);
     float max_speed = top_speed;
 
-    if (!(max_speed > 0.0f)) {
-        return false;
+    if (max_speed > 0.0f) {
+        float inc = max_speed / static_cast<float>(num_entries - 1);
+        for (int i = 0; i < num_entries; i++) {
+            table[i] = accel_graph.GetValue(inc * static_cast<float>(i));
+        }
+        return true;
     }
 
-    float inc = max_speed / static_cast<float>(num_entries - 1);
-    for (int i = 0; i < num_entries; i++) {
-        table[i] = accel_graph.GetValue(inc * static_cast<float>(i));
-    }
-
-    return true;
+    return false;
 }
 
 bool Physics::Info::EstimatePerformance(const Attrib::Gen::pvehicle &vehicle, Performance &perf) {

--- a/src/Speed/Indep/Src/Physics/PhysicsInfo.cpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsInfo.cpp
@@ -427,43 +427,46 @@ bool Physics::Info::HasPerformanceRatings(const Attrib::Gen::pvehicle &pvehicle)
     return base_handling < top_handling && 0.0f < top_handling;
 }
 
-bool PerfStats::Fetch(const Attrib::Gen::pvehicle &vehicle, bVector2 *graph_data, int *num_data) {
+bool PerfStats::Fetch(const Attrib::Gen::pvehicle &pvehicle, bVector2 *graph_data, int *num_data) {
     Time0To100 = 0.0f;
     TopSpeed = 0.0f;
     HandlingRating = 0.0f;
 
-    Attrib::Gen::engine eng(vehicle.engine(0), 0, nullptr);
-    Attrib::Gen::induction ind(vehicle.induction(0), 0, nullptr);
-    Attrib::Gen::transmission trans(vehicle.transmission(0), 0, nullptr);
-    Attrib::Gen::chassis chas(vehicle.chassis(0), 0, nullptr);
-    Attrib::Gen::tires tir(vehicle.tires(0), 0, nullptr);
-    Attrib::Gen::brakes bra(vehicle.brakes(0), 0, nullptr);
-    Attrib::Gen::nos n(vehicle.nos(0), 0, nullptr);
+    Attrib::Gen::engine engine(pvehicle.engine(0), 0, nullptr);
+    Attrib::Gen::induction induction(pvehicle.induction(0), 0, nullptr);
+    Attrib::Gen::transmission transmission(pvehicle.transmission(0), 0, nullptr);
+    Attrib::Gen::chassis chassis(pvehicle.chassis(0), 0, nullptr);
+    Attrib::Gen::tires tires(pvehicle.tires(0), 0, nullptr);
+    Attrib::Gen::brakes brakes(pvehicle.brakes(0), 0, nullptr);
+    Attrib::Gen::nos nos(pvehicle.nos(0), 0, nullptr);
 
     float max_torque_rpm;
-    Physics::Info::MaxTorque(eng, max_torque_rpm);
-    float wheel_radius = Physics::Info::WheelDiameter(vehicle, false) * 0.5f;
-    float idle_rpm = eng.IDLE();
-    float redline_rpm = eng.RED_LINE();
-    float min_w = RPM2RPS(idle_rpm);
-    float max_w = RPM2RPS(redline_rpm);
-    float final_gear = trans.FINAL_GEAR();
-    float speed_limiter = MPH2MPS(eng.SPEED_LIMITER(0));
+    float max_torque = Physics::Info::MaxTorque(engine, max_torque_rpm);
+    float wheel_radius = Physics::Info::WheelDiameter(pvehicle, false) * 0.5f;
+    float final_gear = transmission.FINAL_GEAR();
 
     float shift_up[12];
     float shift_down[12];
 
-    if (!Physics::Info::ShiftPoints(trans, eng, ind, shift_up, shift_down, 12) ||
-        wheel_radius <= 0.0f || final_gear <= 0.0f) {
+    float idle = engine.IDLE();
+    float redline = engine.RED_LINE();
+    float min_w = RPM2RPS(idle);
+    float max_w = RPM2RPS(redline);
+    float limiter = MPH2MPS(engine.SPEED_LIMITER(0));
+
+    if (!Physics::Info::ShiftPoints(transmission, engine, induction, shift_up, shift_down, 12)) {
+        return false;
+    }
+    if (wheel_radius <= 0.0f || final_gear <= 0.0f) {
         return false;
     }
 
-    float speed = 0.0f;
     unsigned int gear = 0;
     float time = 0.0f;
-    float mass = vehicle.MASS();
-    float dT;
+    float speed = 0.0f;
     int data_index = 0;
+    float mass = pvehicle.MASS();
+    float dT;
     if (graph_data != nullptr) {
         dT = 1.0f;
     } else {
@@ -473,50 +476,46 @@ bool PerfStats::Fetch(const Attrib::Gen::pvehicle &vehicle, bVector2 *graph_data
     if (num_data != nullptr) {
         max_data_index = *num_data;
     }
-    unsigned int num_gears = Physics::Info::NumFowardGears(vehicle);
-    unsigned int last_gear = num_gears - 1;
+    unsigned int topgear = Physics::Info::NumFowardGears(pvehicle) - 1;
 
     while (time < 120.0f) {
-        float total_gear_ratio = trans.GEAR_RATIO(gear + G_FIRST) * final_gear;
-        float differential_rpm = RPS2RPM(min_w + (speed / wheel_radius) * total_gear_ratio * ((max_w - min_w) / max_w));
-        float rpm = UMath::Min(differential_rpm, redline_rpm);
-        rpm = UMath::Max(rpm, idle_rpm);
+        float total_gear_ratio = transmission.GEAR_RATIO(gear + G_FIRST) * final_gear;
+        float differential_w = (speed / wheel_radius) * total_gear_ratio;
+        float power_range = (max_w - min_w) / max_w;
+        float w = min_w + differential_w * power_range;
+        float rpm = UMath::Clamp(RPS2RPM(w), idle, redline);
 
         if (gear == 0) {
             rpm = UMath::Max(rpm, max_torque_rpm);
         }
 
-        float torque = Physics::Info::Torque(eng, rpm);
+        float torque = Physics::Info::Torque(engine, rpm);
 
-        float force = FTLB2NM(torque) * (Physics::Info::InductionBoost(eng, ind, rpm, 1.0f, nullptr, nullptr) + 1.0f);
+        float force = FTLB2NM(torque) * (Physics::Info::InductionBoost(engine, induction, rpm, 1.0f, nullptr, nullptr) + 1.0f);
         force *= total_gear_ratio;
 
-        if (time < Physics::Info::NosCapacity(n, nullptr) && speed > 5.0f) {
-            force *= Physics::Info::NosBoost(n, nullptr);
+        if (time < Physics::Info::NosCapacity(nos, nullptr) && speed > 5.0f) {
+            force *= Physics::Info::NosBoost(nos, nullptr);
         }
-        float accel = (force / wheel_radius) / mass;
+        float acc = (force / wheel_radius) / mass;
 
         if (graph_data != nullptr) {
-            int idx = data_index++;
-            if (max_data_index < idx) {
-                idx = max_data_index;
-            }
-            graph_data[idx] = bVector2(speed, accel);
+            graph_data[bMin(max_data_index, data_index++)] = bVector2(speed, acc);
         }
 
-        float drag = UMath::Abs(speed * (speed * chas.DRAG_COEFFICIENT())) / mass;
-        speed = (speed + accel * dT) - drag * dT;
+        const float dragcoef_spec = chassis.DRAG_COEFFICIENT();
+        float drag = speed * (speed * dragcoef_spec);
+        float dec = UMath::Abs(drag) / mass;
+        speed = (speed + acc * dT) - dec * dT;
 
         if (speed >= MPH2MPS(100.0f) && Time0To100 <= 0.0f) {
             Time0To100 = time;
             dT = 1.0f;
         }
 
-        if (speed_limiter > 0.0f && speed >= speed_limiter) {
-            TopSpeed = speed_limiter;
-        } else if (gear == last_gear &&
-                   (accel < drag || redline_rpm <= rpm) &&
-                   TopSpeed <= 0.0f) {
+        if (limiter > 0.0f && speed >= limiter) {
+            TopSpeed = limiter;
+        } else if (gear == topgear && (acc < dec || redline <= rpm) && TopSpeed <= 0.0f) {
             TopSpeed = speed;
         }
 
@@ -527,39 +526,33 @@ bool PerfStats::Fetch(const Attrib::Gen::pvehicle &vehicle, bVector2 *graph_data
         }
 
         if (rpm >= shift_up[gear + G_FIRST]) {
-            gear = UMath::Min(gear + 1, last_gear);
+            gear = UMath::Min(gear + 1, topgear);
         }
     }
 
-    if (gear == last_gear || TopSpeed <= 0.0f) {
+    if (gear == topgear || TopSpeed <= 0.0f) {
         TopSpeed = speed;
     }
 
-    float base_handling = vehicle.HandlingRating(0);
-    float top_handling = vehicle.HandlingRating(1);
-    float handling_sum = 0.0f;
-    float weight_sum = 0.0f;
-    int type = Physics::Upgrades::PUT_TIRES;
-    do {
-        weight_sum += PerformanceWeights[type].Handling;
-        handling_sum += Physics::Upgrades::GetPercent(vehicle, static_cast<Physics::Upgrades::Type>(type)) *
-                        PerformanceWeights[type].Handling;
-        type++;
-    } while (type < 7);
-    if (weight_sum > 1e-6f) {
-        handling_sum /= weight_sum;
+    float base_handling = pvehicle.HandlingRating(0);
+    float top_handling = pvehicle.HandlingRating(1);
+    float ratio = 0.0f;
+    float weights = 0.0f;
+    for (int i = 0; i < 7; i++) {
+        Physics::Upgrades::Type path = static_cast<Physics::Upgrades::Type>(i);
+        weights += PerformanceWeights[i].Handling;
+        ratio += Physics::Upgrades::GetPercent(pvehicle, path) * PerformanceWeights[i].Handling;
     }
-    HandlingRating = UMath::Lerp(base_handling, top_handling, handling_sum);
+    if (weights > 1e-6f) {
+        ratio /= weights;
+    }
+    HandlingRating = UMath::Lerp(base_handling, top_handling, ratio);
 
     if (num_data != nullptr) {
         *num_data = data_index;
     }
 
-    bool success = false;
-    if (TopSpeed > 0.0f) {
-        success = Time0To100 > 0.0f;
-    }
-    return success;
+    return TopSpeed > 0.0f && Time0To100 > 0.0f;
 }
 
 void PerfLevel::Print(const char *) {

--- a/src/Speed/Indep/Src/Physics/PhysicsInfo.cpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsInfo.cpp
@@ -666,15 +666,15 @@ void Physics::Info::Init() {
     Physics_Info_initialized = 1;
 }
 
-bool Physics::Info::ComputeAccelerationTable(const Attrib::Gen::pvehicle &vehicle, float &top_speed, float *table, int num_entries) {
-    Attrib::Gen::transmission trans(vehicle.transmission(0), 0, nullptr);
-    Attrib::Gen::tires tir(vehicle.tires(0), 0, nullptr);
-    Attrib::Gen::chassis chas(vehicle.chassis(0), 0, nullptr);
-    Attrib::Gen::engine eng(vehicle.engine(0), 0, nullptr);
-    Attrib::Gen::induction ind(vehicle.induction(0), 0, nullptr);
+bool Physics::Info::ComputeAccelerationTable(const Attrib::Gen::pvehicle &pvehicle, float &top_speed, float *table, int num_entries) {
+    Attrib::Gen::transmission transmission(pvehicle.transmission(0), 0, nullptr);
+    Attrib::Gen::tires tires(pvehicle.tires(0), 0, nullptr);
+    Attrib::Gen::chassis chassis(pvehicle.chassis(0), 0, nullptr);
+    Attrib::Gen::engine engine(pvehicle.engine(0), 0, nullptr);
+    Attrib::Gen::induction induction(pvehicle.induction(0), 0, nullptr);
 
-    float avg_torque = AvgInductedTorque(eng, ind, trans, true, nullptr);
-    avg_torque = avg_torque * FTLB2NM(1.0f);
+    float ft_lbs = AvgInductedTorque(engine, induction, transmission, true, nullptr);
+    float avg_torque = FTLB2NM(ft_lbs);
 
     if (avg_torque <= 0.0f || num_entries < 2 || table == nullptr) {
         return false;
@@ -682,40 +682,42 @@ bool Physics::Info::ComputeAccelerationTable(const Attrib::Gen::pvehicle &vehicl
 
     bVector2 graph_data[10];
 
-    unsigned int num_gears = NumFowardGears(trans);
+    unsigned int num_gears = NumFowardGears(transmission);
     if (num_gears == 0) {
         return false;
     }
 
-    float mass = vehicle.MASS();
-    float final_gear = trans.FINAL_GEAR();
-    float wheel_radius = WheelDiameter(tir, false) * 0.5f;
+    float final_gear = transmission.FINAL_GEAR();
+    float mass = pvehicle.MASS();
+    float wheel_radius = WheelDiameter(tires, false) * 0.5f;
 
     if (wheel_radius <= 0.001f) {
         return false;
     }
 
     top_speed = 0.0f;
-    int graph_max = 0;
+    unsigned int graph_max = 0;
     float prev_accel = 0.0f;
     float prev_speed = 0.0f;
 
     for (unsigned int foward_gear = 0; foward_gear < num_gears; foward_gear++) {
-        unsigned int gear = foward_gear + G_FIRST;
-        float gear_ratio = trans.GEAR_RATIO(gear) * final_gear;
-        float gear_eff = trans.GEAR_EFFICIENCY(gear);
+        GearID gear = static_cast<GearID>(foward_gear + G_FIRST);
+        float gear_ratio = transmission.GEAR_RATIO(gear) * final_gear;
+        float drive_torque = avg_torque * gear_ratio * transmission.GEAR_EFFICIENCY(gear);
+        float force = drive_torque / wheel_radius;
 
-        float force = (avg_torque * gear_ratio * gear_eff) / wheel_radius;
+        if (gear_ratio <= 0.0f) {
+            return false;
+        }
 
-        if (gear_ratio <= 0.0f) break;
-
-        float speed = (eng.RED_LINE() * RPM2RPS(1.0f) * wheel_radius) / gear_ratio;
-        float drag = speed * speed * chas.DRAG_COEFFICIENT();
+        float speed = (engine.RED_LINE() * RPM2RPS(1.0f) * wheel_radius) / gear_ratio;
+        float drag = speed * speed * chassis.DRAG_COEFFICIENT();
         float accel = (force - drag) / mass;
 
         if (accel <= 0.0f) {
             if (prev_accel <= 0.0f) break;
-            speed = UMath::Lerp(prev_speed, speed, 1.0f - prev_accel / (prev_accel - accel));
+            float ratio = 1.0f - prev_accel / (prev_accel - accel);
+            speed = UMath::Lerp(prev_speed, speed, ratio);
             accel = 0.0f;
         }
 
@@ -733,10 +735,9 @@ bool Physics::Info::ComputeAccelerationTable(const Attrib::Gen::pvehicle &vehicl
     }
 
     Graph accel_graph(graph_data, graph_max);
-    float max_speed = top_speed;
 
-    if (max_speed > 0.0f) {
-        float inc = max_speed / static_cast<float>(num_entries - 1);
+    if (top_speed > 0.0f) {
+        float inc = top_speed / static_cast<float>(num_entries - 1);
         for (int i = 0; i < num_entries; i++) {
             table[i] = accel_graph.GetValue(inc * static_cast<float>(i));
         }

--- a/src/Speed/Indep/Src/Physics/PhysicsInfo.cpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsInfo.cpp
@@ -10,7 +10,7 @@
 
 using namespace Attrib::Gen;
 
-Physics::Info::Performance Physics::Info::PerformanceWeights[7] = {
+static Physics::Info::Performance PerformanceWeights[7] = {
     Physics::Info::Performance(0.25f, 1.5f, 0.25f), // PUT_TIRES
     Physics::Info::Performance(0.0f, 0.5f, 0.0f),   // PUT_BRAKES
     Physics::Info::Performance(0.25f, 1.0f, 0.2f),  // PUT_CHASSIS
@@ -541,9 +541,9 @@ bool PerfStats::Fetch(const Attrib::Gen::pvehicle &vehicle, bVector2 *graph_data
     float weight_sum = 0.0f;
     int type = Physics::Upgrades::PUT_TIRES;
     do {
-        weight_sum += Physics::Info::PerformanceWeights[type].Handling;
+        weight_sum += PerformanceWeights[type].Handling;
         handling_sum += Physics::Upgrades::GetPercent(vehicle, static_cast<Physics::Upgrades::Type>(type)) *
-                        Physics::Info::PerformanceWeights[type].Handling;
+                        PerformanceWeights[type].Handling;
         type++;
     } while (type < 7);
     if (weight_sum > 1e-6f) {

--- a/src/Speed/Indep/Src/Physics/PhysicsInfo.cpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsInfo.cpp
@@ -667,8 +667,9 @@ void Physics::Info::Init() {
         PerfLevel &p = *iter;
         p.Upgraded = p.Stock;
         for (PerformanceMaps::iterator iter2 = upgraded_cars.begin(); iter2 != upgraded_cars.end(); iter2++) {
-            if (p.Key == (*iter2).Key) {
-                p.Upgraded = (*iter2).Stock;
+            PerfLevel &p2 = *iter2;
+            if (p.Key == p2.Key) {
+                p.Upgraded = p2.Stock;
                 break;
             }
         }

--- a/src/Speed/Indep/Src/Physics/PhysicsInfo.cpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsInfo.cpp
@@ -715,16 +715,17 @@ bool Physics::Info::ComputeAccelerationTable(const Attrib::Gen::pvehicle &vehicl
         float gear_ratio = trans.GEAR_RATIO(foward_gear + G_FIRST) * final_gear;
         float gear_eff = trans.GEAR_EFFICIENCY(foward_gear + G_FIRST);
 
+        float force = (avg_torque * gear_ratio * gear_eff) / wheel_radius;
+
         if (gear_ratio <= 0.0f) break;
 
         float speed = (eng.RED_LINE() * RPM2RPS(1.0f) * wheel_radius) / gear_ratio;
-        float force = (avg_torque * gear_ratio * gear_eff) / wheel_radius;
         float drag = speed * speed * chas.DRAG_COEFFICIENT();
         float accel = (force - drag) / mass;
 
         if (accel <= 0.0f) {
             if (prev_accel <= 0.0f) break;
-            speed = UMath::Lerp(prev_speed, speed, prev_accel / (prev_accel - accel));
+            speed = UMath::Lerp(prev_speed, speed, 1.0f - prev_accel / (prev_accel - accel));
             accel = 0.0f;
         }
 
@@ -744,7 +745,7 @@ bool Physics::Info::ComputeAccelerationTable(const Attrib::Gen::pvehicle &vehicl
     Graph accel_graph(graph_data, graph_max);
     float max_speed = top_speed;
 
-    if (max_speed <= 0.0f) {
+    if (!(max_speed > 0.0f)) {
         return false;
     }
 

--- a/src/Speed/Indep/Src/Physics/PhysicsInfo.cpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsInfo.cpp
@@ -486,13 +486,13 @@ bool PerfStats::Fetch(const Attrib::Gen::pvehicle &vehicle, bVector2 *graph_data
             rpm = UMath::Max(rpm, max_torque_rpm);
         }
 
-        float torque = Physics::Info::Torque(eng, rpm) * FTLB2NM(1.0f);
-        float boost = Physics::Info::InductionBoost(eng, ind, rpm, 1.0f, nullptr, nullptr);
-        float nos_capacity = Physics::Info::NosCapacity(n, nullptr);
-        float force = torque * (boost + 1.0f) * total_gear_ratio;
-        if (time < nos_capacity && speed > 5.0f) {
-            float nos_boost = Physics::Info::NosBoost(n, nullptr);
-            force *= nos_boost;
+        float torque = Physics::Info::Torque(eng, rpm);
+
+        float force = FTLB2NM(torque) * (Physics::Info::InductionBoost(eng, ind, rpm, 1.0f, nullptr, nullptr) + 1.0f);
+        force *= total_gear_ratio;
+
+        if (time < Physics::Info::NosCapacity(n, nullptr) && speed > 5.0f) {
+            force *= Physics::Info::NosBoost(n, nullptr);
         }
         float accel = (force / wheel_radius) / mass;
 
@@ -512,14 +512,12 @@ bool PerfStats::Fetch(const Attrib::Gen::pvehicle &vehicle, bVector2 *graph_data
             dT = 1.0f;
         }
 
-        if (speed_limiter <= 0.0f || speed < speed_limiter) {
-            if (gear == last_gear &&
-                (accel < drag || redline_rpm <= rpm) &&
-                TopSpeed <= 0.0f) {
-                TopSpeed = speed;
-            }
-        } else {
+        if (speed_limiter > 0.0f && speed >= speed_limiter) {
             TopSpeed = speed_limiter;
+        } else if (gear == last_gear &&
+                   (accel < drag || redline_rpm <= rpm) &&
+                   TopSpeed <= 0.0f) {
+            TopSpeed = speed;
         }
 
         time += dT;
@@ -529,11 +527,7 @@ bool PerfStats::Fetch(const Attrib::Gen::pvehicle &vehicle, bVector2 *graph_data
         }
 
         if (rpm >= shift_up[gear + G_FIRST]) {
-            unsigned int next_gear = gear + 1;
-            gear = last_gear;
-            if (next_gear < last_gear) {
-                gear = next_gear;
-            }
+            gear = UMath::Min(gear + 1, last_gear);
         }
     }
 
@@ -544,19 +538,14 @@ bool PerfStats::Fetch(const Attrib::Gen::pvehicle &vehicle, bVector2 *graph_data
     float base_handling = vehicle.HandlingRating(0);
     float top_handling = vehicle.HandlingRating(1);
     float handling_sum = 0.0f;
-    float diff = top_handling - base_handling;
-    float *pw = &Physics::Info::PerformanceWeights[0].Handling;
     float weight_sum = 0.0f;
-    Physics::Upgrades::Type type = Physics::Upgrades::PUT_TIRES;
+    int type = Physics::Upgrades::PUT_TIRES;
     do {
-        Physics::Upgrades::Type next = static_cast<Physics::Upgrades::Type>(type + Physics::Upgrades::PUT_BRAKES);
-        weight_sum += *pw;
-        float pct = Physics::Upgrades::GetPercent(vehicle, type);
-        float w = *pw;
-        pw += 3;
-        handling_sum += pct * w;
-        type = next;
-    } while (static_cast<int>(type) < 7);
+        weight_sum += Physics::Info::PerformanceWeights[type].Handling;
+        handling_sum += Physics::Upgrades::GetPercent(vehicle, static_cast<Physics::Upgrades::Type>(type)) *
+                        Physics::Info::PerformanceWeights[type].Handling;
+        type++;
+    } while (type < 7);
     if (weight_sum > 1e-6f) {
         handling_sum /= weight_sum;
     }

--- a/src/Speed/Indep/Src/Physics/PhysicsInfo.cpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsInfo.cpp
@@ -10,11 +10,19 @@
 
 using namespace Attrib::Gen;
 
+Physics::Info::Performance Physics::Info::PerformanceWeights[7] = {
+    Physics::Info::Performance(0.25f, 1.5f, 0.25f), // PUT_TIRES
+    Physics::Info::Performance(0.0f, 0.5f, 0.0f),   // PUT_BRAKES
+    Physics::Info::Performance(0.25f, 1.0f, 0.2f),  // PUT_CHASSIS
+    Physics::Info::Performance(1.0f, 0.0f, 0.75f),  // PUT_TRANSMISSION
+    Physics::Info::Performance(0.5f, 0.0f, 1.0f),   // PUT_ENGINE
+    Physics::Info::Performance(0.25f, 0.0f, 1.25f), // PUT_INDUCTION
+    Physics::Info::Performance(0.25f, 0.0f, 1.5f),  // PUT_NOS
+};
 static PerfStats top_stats;
 static PerfStats bottom_stats;
 static PerformanceMaps TheStockCars;
 static int Physics_Info_initialized;
-Physics::Info::Performance Physics::Info::PerformanceWeights[7];
 
 // Credits: Brawltendo
 float Physics::Info::AerodynamicDownforce(const Attrib::Gen::chassis &chassis, const float speed) {

--- a/src/Speed/Indep/Src/Physics/PhysicsInfo.cpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsInfo.cpp
@@ -618,9 +618,9 @@ void Physics::Info::Init() {
                     TheStockCars.push_back(performance);
                     all_cars.push_back(performance);
                 }
+                Physics::Upgrades::Flush();
             }
         }
-        Physics::Upgrades::Flush();
         key = aclass->GetNextCollection(key);
     }
 
@@ -633,8 +633,8 @@ void Physics::Info::Init() {
                 upgraded_cars.push_back(performance);
                 all_cars.push_back(performance);
             }
+            Physics::Upgrades::Flush();
         }
-        Physics::Upgrades::Flush();
     }
 
     int count = TheStockCars.size();

--- a/src/Speed/Indep/Src/Physics/PhysicsInfo.cpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsInfo.cpp
@@ -429,17 +429,16 @@ bool PerfStats::Fetch(const Attrib::Gen::pvehicle &vehicle, bVector2 *graph_data
     Attrib::Gen::transmission trans(vehicle.transmission(0), 0, nullptr);
     Attrib::Gen::chassis chas(vehicle.chassis(0), 0, nullptr);
     Attrib::Gen::tires tir(vehicle.tires(0), 0, nullptr);
-    Attrib::Gen::brakes bra(vehicle.brakes(0).GetCollection(), 0, nullptr);
+    Attrib::Gen::brakes bra(vehicle.brakes(0), 0, nullptr);
     Attrib::Gen::nos n(vehicle.nos(0), 0, nullptr);
 
     float max_torque_rpm;
     Physics::Info::MaxTorque(eng, max_torque_rpm);
-    float wheel_diameter = Physics::Info::WheelDiameter(vehicle, false);
+    float wheel_radius = Physics::Info::WheelDiameter(vehicle, false) * 0.5f;
     float idle_rpm = eng.IDLE();
     float redline_rpm = eng.RED_LINE();
     float min_w = RPM2RPS(idle_rpm);
     float max_w = RPM2RPS(redline_rpm);
-    float wheel_radius = wheel_diameter * 0.5f;
     float final_gear = trans.FINAL_GEAR();
     float speed_limiter = MPH2MPS(eng.SPEED_LIMITER(0));
 
@@ -455,22 +454,23 @@ bool PerfStats::Fetch(const Attrib::Gen::pvehicle &vehicle, bVector2 *graph_data
     unsigned int gear = 0;
     float time = 0.0f;
     float mass = vehicle.MASS();
-    float dT = 0.125f;
+    float dT;
     int data_index = 0;
     if (graph_data != nullptr) {
         dT = 1.0f;
+    } else {
+        dT = 0.125f;
     }
     int max_data_index = 0;
     if (num_data != nullptr) {
         max_data_index = *num_data;
     }
-    float power_range = max_w - min_w;
     unsigned int num_gears = Physics::Info::NumFowardGears(vehicle);
     unsigned int last_gear = num_gears - 1;
 
-    do {
+    while (time < 120.0f) {
         float total_gear_ratio = trans.GEAR_RATIO(gear + G_FIRST) * final_gear;
-        float differential_rpm = RPS2RPM(min_w + (speed / wheel_radius) * total_gear_ratio * (power_range / max_w));
+        float differential_rpm = RPS2RPM(min_w + (speed / wheel_radius) * total_gear_ratio * ((max_w - min_w) / max_w));
         float rpm = UMath::Min(differential_rpm, redline_rpm);
         rpm = UMath::Max(rpm, idle_rpm);
 
@@ -529,7 +529,7 @@ bool PerfStats::Fetch(const Attrib::Gen::pvehicle &vehicle, bVector2 *graph_data
                 gear = next_gear;
             }
         }
-    } while (time < 120.0f);
+    }
 
     if (gear == last_gear || TopSpeed <= 0.0f) {
         TopSpeed = speed;

--- a/src/Speed/Indep/Src/Physics/PhysicsInfo.cpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsInfo.cpp
@@ -22,6 +22,11 @@ float Physics::Info::EngineInertia(const Attrib::Gen::engine &engine, const bool
     return scale * (engine.FLYWHEEL_MASS() * 0.025f + 0.25f);
 }
 
+Physics::Info::eInductionType Physics::Info::InductionType(const Attrib::Gen::pvehicle &pvehicle) {
+    const Attrib::Gen::induction ind(pvehicle.induction(0), 0, nullptr);
+    return InductionType(ind);
+}
+
 // Credits: Brawltendo
 Physics::Info::eInductionType Physics::Info::InductionType(const Attrib::Gen::induction &induction) {
     if (induction.HIGH_BOOST() > 0.0f || induction.LOW_BOOST() > 0.0f) {
@@ -35,6 +40,15 @@ Physics::Info::eInductionType Physics::Info::InductionType(const Attrib::Gen::in
     } else {
         return INDUCTION_NONE;
     }
+}
+
+bool Physics::Info::HasNos(const Attrib::Gen::pvehicle &pvehicle) {
+    const Attrib::Gen::nos nos(pvehicle.nos(0), 0, nullptr);
+    return nos.TORQUE_BOOST() > 0.0f && nos.NOS_CAPACITY() > 0.0f;
+}
+
+bool Physics::Info::HasRunflatTires(const Attrib::Gen::pvehicle &pvehicle) {
+    return false;
 }
 
 // Credits: Brawltendo
@@ -152,9 +166,145 @@ Meters Physics::Info::WheelDiameter(const Attrib::Gen::tires &tires, bool front)
 
 // Credits: Brawltendo
 // TODO not matching on GC yet
+Meters Physics::Info::WheelDiameter(const Attrib::Gen::pvehicle &pvehicle, bool front) {
+    const Attrib::Gen::tires t(pvehicle.tires(0), 0, nullptr);
+    return WheelDiameter(t, front);
+}
+
+float Physics::Info::MaxInductedPower(const Attrib::Gen::pvehicle &pvehicle, const Tunings *tunings) {
+    Attrib::Gen::engine engine(pvehicle.engine(0), 0, nullptr);
+    Attrib::Gen::induction induction(pvehicle.induction(0), 0, nullptr);
+    unsigned int num_torque = engine.Num_TORQUE();
+
+    if (num_torque < 2) {
+        return 0.0f;
+    }
+
+    float result = 0.0f;
+    float rpm = engine.IDLE();
+    float delta_rpm = (engine.MAX_RPM() - engine.IDLE()) / static_cast<float>(engine.Num_TORQUE() - 1);
+
+    for (unsigned int i = 0; i < engine.Num_TORQUE(); i++) {
+        float pt_torque = engine.TORQUE(i) * (InductionBoost(engine, induction, rpm, 1.0f, tunings, nullptr) + 1.0f);
+        float hp = FTLB2HP(pt_torque, rpm);
+        if (hp > result) {
+            result = hp;
+        }
+        rpm += delta_rpm;
+    }
+
+    return result;
+}
+
+FtLbs Physics::Info::AvgInductedTorque(const Attrib::Gen::engine &engine, const Attrib::Gen::induction &induction,
+                                       const Attrib::Gen::transmission &transmission, bool from_peak, const Tunings *tunings) {
+    unsigned int num_torque = engine.Num_TORQUE();
+    if (num_torque < 2) {
+        return 0.0f;
+    }
+
+    float peak_torque_rpm;
+    float peak_torque = MaxInductedTorque(engine, induction, peak_torque_rpm, tunings);
+    if (!(peak_torque > 0.0f)) {
+        return 0.0f;
+    }
+
+    float torque_converter = transmission.TORQUE_CONVERTER();
+    float torque;
+    float rpm = engine.IDLE();
+    float total_torque = 0.0f;
+    float count = 0.0f;
+    float delta_rpm = (engine.MAX_RPM() - engine.IDLE()) / static_cast<float>(engine.Num_TORQUE() - 1);
+
+    for (unsigned int i = 0; i < engine.Num_TORQUE(); i++) {
+        if (!from_peak || rpm >= peak_torque_rpm) {
+            float converter_ratio = 1.0f + torque_converter * (1.0f - UMath::Ramp(rpm, engine.IDLE(), peak_torque_rpm));
+            torque = converter_ratio * engine.TORQUE(i) * (InductionBoost(engine, induction, rpm, 1.0f, tunings, nullptr) + 1.0f);
+            float torque_pt = torque;
+            total_torque += torque_pt;
+            count += 1.0f;
+        }
+        rpm += delta_rpm;
+        if (rpm >= engine.RED_LINE()) {
+            break;
+        }
+    }
+
+    if (count > 0.0f) {
+        return total_torque / count;
+    }
+    return 0.0f;
+}
+
+FtLbs Physics::Info::MaxInductedTorque(const Attrib::Gen::engine &eng, const Attrib::Gen::induction &ind, float &atrpm, const Tunings *tunings) {
+    if (eng.Num_TORQUE() < 2) {
+        atrpm = eng.IDLE();
+        return 0.0f;
+    }
+
+    float torque = 0.0f;
+    atrpm = eng.IDLE();
+    float rpm = eng.IDLE();
+    float delta_rpm = (eng.MAX_RPM() - eng.IDLE()) / static_cast<float>(eng.Num_TORQUE() - 1);
+
+    for (unsigned int i = 0; i < eng.Num_TORQUE(); i++) {
+        float pt_torque = eng.TORQUE(i) * (InductionBoost(eng, ind, rpm, 1.0f, tunings, nullptr) + 1.0f);
+        if (pt_torque > torque) {
+            atrpm = rpm;
+            torque = pt_torque;
+        }
+        rpm += delta_rpm;
+    }
+
+    atrpm = UMath::Clamp(atrpm, eng.IDLE(), eng.RED_LINE());
+    return torque;
+}
+
+FtLbs Physics::Info::MaxInductedTorque(const Attrib::Gen::pvehicle &pvehicle, Rpm &atrpm, const Tunings *tunings) {
+    const Attrib::Gen::engine eng(pvehicle.engine(0), 0, nullptr);
+    const Attrib::Gen::induction ind(pvehicle.induction(0), 0, nullptr);
+    return MaxInductedTorque(eng, ind, atrpm, tunings);
+}
+
+float Physics::Info::MaxTorque(const Attrib::Gen::engine &eng, float &atrpm) {
+    float torque = 0.0f;
+    int max_pt = 0;
+    unsigned int num_torque = eng.Num_TORQUE();
+
+    if (num_torque == 0) {
+        atrpm = torque;
+    } else {
+        for (unsigned int i = 0; i < eng.Num_TORQUE(); i++) {
+            float pt_torque = eng.TORQUE(i);
+            if (pt_torque > torque) {
+                max_pt = i;
+                torque = pt_torque;
+            }
+        }
+
+        atrpm = eng.IDLE();
+        if (num_torque > 1) {
+            float rpm_ratio = static_cast<float>(max_pt) / static_cast<float>(num_torque - 1);
+            atrpm = rpm_ratio * (eng.MAX_RPM() - eng.IDLE()) + atrpm;
+        }
+
+        atrpm = UMath::Clamp(atrpm, eng.IDLE(), eng.RED_LINE());
+    }
+    return torque;
+}
+
+float Physics::Info::Redline(const Attrib::Gen::engine &engine) {
+    return engine.RED_LINE();
+}
+
+float Physics::Info::Redline(const Attrib::Gen::pvehicle &pvehicle) {
+    const Attrib::Gen::engine eng(pvehicle.engine(0), 0, nullptr);
+    return Redline(eng);
+}
+
 bool Physics::Info::ShiftPoints(const Attrib::Gen::transmission &transmission, const Attrib::Gen::engine &engine,
                                 const Attrib::Gen::induction &induction, float *shift_up, float *shift_down, unsigned int numpts) {
-    for (int i = 0; i < numpts; ++i) {
+    for (unsigned int i = 0; i < numpts; ++i) {
         shift_up[i] = 0.0f;
         shift_down[i] = 0.0f;
     }
@@ -169,13 +319,13 @@ bool Physics::Info::ShiftPoints(const Attrib::Gen::transmission &transmission, c
     for (j = G_FIRST; j < topgear; ++j) {
         float g1 = transmission.GEAR_RATIO(j);
         float g2 = transmission.GEAR_RATIO(j + 1);
-        float rpm = (redline + engine.IDLE()) * 0.5f;
+        float rpm = (engine.IDLE() + redline) * 0.5f;
         float max = rpm;
-        int flag = 0;
+        int flag = 1;
 
         if (rpm < redline) {
             // find the upshift RPM for this gear using predicted engine torque
-            while (!flag) {
+            while (flag) {
                 // seems like the rpm and spool params are swapped in both instances
                 // so either it's a mistake that was copy-pasted or it was a deliberate choice
                 float currenttorque = Torque(engine, max) * (InductionBoost(engine, induction, 1.0f, max, nullptr, nullptr) + 1.0f);
@@ -183,32 +333,32 @@ bool Physics::Info::ShiftPoints(const Attrib::Gen::transmission &transmission, c
                 if (UMath::Abs(g1) > 0.00001f) {
                     float ratio = g2 / g1;
                     float next_rpm = ratio * max;
-                    shiftuptorque = Torque(engine, next_rpm) * (InductionBoost(engine, induction, 1.0f, next_rpm, nullptr, nullptr) + 1.0f) * g2 / g1;
+                    shiftuptorque = Torque(engine, next_rpm) * g2 / g1 * (InductionBoost(engine, induction, 1.0f, next_rpm, nullptr, nullptr) + 1.0f);
                 } else {
                     shiftuptorque = 0.0f;
                 }
 
-                // set the upshift RPM to the current max
-                if (shiftuptorque > currenttorque)
+                if (shiftuptorque > currenttorque) {
+                    // set the upshift RPM to the current max
+                    shift_up[j] = max;
+                    flag = 0;
                     break;
+                }
 
                 max += 50.0f;
-                // set the upshift RPM to the redline RPM
-                flag = static_cast<int>(!(max < redline));
+                if (!(max < redline)) {
+                    break;
+                }
             }
-            if (!flag) {
-                shift_up[j] = max;
-            }
-        } else {
-            flag = 1;
         }
         if (flag) {
+            // set the upshift RPM to the redline RPM
             shift_up[j] = redline - 100.0f;
         }
 
         // calculate downshift RPM for the next gear
         if (UMath::Abs(g1) > 0.00001f) {
-            shift_down[j + 1] = (g2 / g1) * shift_up[j];
+            shift_down[j + 1] = shift_up[j] * g2 / g1;
         } else {
             shift_down[j + 1] = 0.0f;
         }
@@ -218,7 +368,6 @@ bool Physics::Info::ShiftPoints(const Attrib::Gen::transmission &transmission, c
     return true;
 }
 
-// Credits: Brawltendo
 Mps Physics::Info::Speedometer(const Attrib::Gen::transmission &transmission, const Attrib::Gen::engine &engine, const Attrib::Gen::tires &tires,
                                Rpm rpm, GearID gear, const Tunings *tunings) {
     float speed = 0.0f;
@@ -239,4 +388,17 @@ Mps Physics::Info::Speedometer(const Attrib::Gen::transmission &transmission, co
     }
 
     return speed;
+}
+
+unsigned int Physics::Info::NumFowardGears(const Attrib::Gen::transmission &transmission) {
+    unsigned int num_ratios = transmission.Num_GEAR_RATIO();
+    if (num_ratios > 2) {
+        return num_ratios - 2;
+    }
+    return 0;
+}
+
+unsigned int Physics::Info::NumFowardGears(const Attrib::Gen::pvehicle &pvehicle) {
+    const Attrib::Gen::transmission trans(pvehicle.transmission(0), 0, nullptr);
+    return NumFowardGears(trans);
 }

--- a/src/Speed/Indep/Src/Physics/PhysicsInfo.cpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsInfo.cpp
@@ -587,7 +587,6 @@ bool PerfLevel::Analyze(const Attrib::Gen::pvehicle &pvehicle) {
 
 void PerformanceMaps::FindLimits(float direction, PerfStats &out) const {
     PerfStats temp;
-    bMemSet(&temp, 0, sizeof(PerfStats));
     out = temp;
 
     for (const_iterator iter = begin(); iter != end(); iter++) {

--- a/src/Speed/Indep/Src/Physics/PhysicsInfo.hpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsInfo.hpp
@@ -137,7 +137,6 @@ bool GetMaximumPerformance(const Attrib::Gen::pvehicle &pvehicle, Performance &p
 bool ComputeAccelerationTable(const Attrib::Gen::pvehicle &pvehicle, float &top_speed, float *table, int num_entries);
 void FindPerformanceCandidates(const Performance &minimum_perf, const Performance &maximum_perf, UTL::Std::list<unsigned int, _type_list> &candidates);
 
-extern Performance PerformanceWeights[7];
 
 } // namespace Info
 } // namespace Physics

--- a/src/Speed/Indep/Src/Physics/PhysicsInfo.hpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsInfo.hpp
@@ -53,6 +53,7 @@ void Init();
 
 float AerodynamicDownforce(const Attrib::Gen::chassis &chassis, const float speed);
 float EngineInertia(const Attrib::Gen::engine &engine, const bool loaded);
+eInductionType InductionType(const Attrib::Gen::pvehicle &pvehicle);
 eInductionType InductionType(const Attrib::Gen::induction &induction);
 bool HasNos(const Attrib::Gen::pvehicle &pvehicle);
 bool HasRunflatTires(const Attrib::Gen::pvehicle &pvehicle);
@@ -64,6 +65,11 @@ float InductionBoost(const Attrib::Gen::engine &engine, const Attrib::Gen::induc
 float Torque(const Attrib::Gen::engine &engine, float rpm);
 float MaxTorque(const Attrib::Gen::engine &engine, float &atrpm);
 Meters WheelDiameter(const Attrib::Gen::tires &tires, bool front);
+Meters WheelDiameter(const Attrib::Gen::pvehicle &pvehicle, bool front);
+float Redline(const Attrib::Gen::engine &engine);
+float Redline(const Attrib::Gen::pvehicle &pvehicle);
+unsigned int NumFowardGears(const Attrib::Gen::transmission &transmission);
+unsigned int NumFowardGears(const Attrib::Gen::pvehicle &pvehicle);
 float MaxInductedPower(const Attrib::Gen::pvehicle &pvehicle, const Tunings *tunings);
 FtLbs AvgInductedTorque(const Attrib::Gen::engine &engine, const Attrib::Gen::induction &induction, const Attrib::Gen::transmission &transmission,
                         bool from_peak, const Tunings *tunings);

--- a/src/Speed/Indep/Src/Physics/PhysicsInfo.hpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsInfo.hpp
@@ -60,6 +60,10 @@ inline void Performance::Default() {
 
 // total size: 0xC
 struct PerfStats {
+    PerfStats() {
+        bMemSet(this, 0, sizeof(PerfStats));
+    }
+
     bool Fetch(const Attrib::Gen::pvehicle &pvehicle, bVector2 *graph_data, int *num_data);
 
     float Time0To100;      // offset 0x0, size 0x4

--- a/src/Speed/Indep/Src/Physics/PhysicsInfo.hpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsInfo.hpp
@@ -3,6 +3,7 @@
 
 #include "PhysicsTunings.h"
 #include "PhysicsTypes.h"
+#include "Speed/Indep/Libs/Support/Utility/UStandard.h"
 #include "Speed/Indep/Libs/Support/Utility/UMath.h"
 #include "Speed/Indep/Src/Generated/AttribSys/Classes/chassis.h"
 #include "Speed/Indep/Src/Generated/AttribSys/Classes/engine.h"
@@ -11,6 +12,9 @@
 #include "Speed/Indep/Src/Generated/AttribSys/Classes/pvehicle.h"
 #include "Speed/Indep/Src/Generated/AttribSys/Classes/tires.h"
 #include "Speed/Indep/Src/Generated/AttribSys/Classes/transmission.h"
+#include "Speed/Indep/bWare/Inc/bWare.hpp"
+
+DECLARE_CONTAINER_TYPE(PerformanceMaps);
 
 namespace Physics {
 namespace Info {
@@ -51,6 +55,45 @@ inline void Performance::Default() {
     Acceleration = 0.0f;
 }
 
+} // namespace Info
+} // namespace Physics
+
+// total size: 0xC
+struct PerfStats {
+    bool Fetch(const Attrib::Gen::pvehicle &pvehicle, bVector2 *graph_data, int *num_data);
+
+    float Time0To100;      // offset 0x0, size 0x4
+    float TopSpeed;        // offset 0x4, size 0x4
+    float HandlingRating;  // offset 0x8, size 0x4
+};
+
+// total size: 0x2C
+struct PerfLevel {
+    PerfLevel(unsigned int key)
+        : Stats(),       //
+          Stock(),       //
+          Upgraded(),    //
+          Key(key),      //
+          Analyzed(false) {}
+
+    bool Analyze(const Attrib::Gen::pvehicle &pvehicle);
+    void Rate();
+    void Print(const char * = nullptr);
+
+    PerfStats Stats;                     // offset 0x0, size 0xC
+    Physics::Info::Performance Stock;    // offset 0xC, size 0xC
+    Physics::Info::Performance Upgraded; // offset 0x18, size 0xC
+    unsigned int Key;                    // offset 0x24, size 0x4
+    bool Analyzed;                       // offset 0x28, size 0x4
+};
+
+struct PerformanceMaps : public UTL::Std::list<PerfLevel, _type_PerformanceMaps> {
+    void FindLimits(float direction, PerfStats &out) const;
+};
+
+namespace Physics {
+namespace Info {
+
 void Init();
 
 float AerodynamicDownforce(const Attrib::Gen::chassis &chassis, const float speed);
@@ -88,6 +131,7 @@ bool ComputePerformance(const Attrib::Gen::pvehicle &pvehicle, Performance &perf
 bool GetStockPerformance(const Attrib::Gen::pvehicle &pvehicle, Performance &perf);
 bool GetMaximumPerformance(const Attrib::Gen::pvehicle &pvehicle, Performance &perf);
 bool ComputeAccelerationTable(const Attrib::Gen::pvehicle &pvehicle, float &top_speed, float *table, int num_entries);
+void FindPerformanceCandidates(const Performance &minimum_perf, const Performance &maximum_perf, UTL::Std::list<unsigned int, _type_list> &candidates);
 
 extern Performance PerformanceWeights[7];
 

--- a/src/Speed/Indep/Src/Physics/PhysicsInfo.hpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsInfo.hpp
@@ -80,7 +80,11 @@ bool ShiftPoints(const Attrib::Gen::transmission &transmission, const Attrib::Ge
                  float *shift_up, float *shift_down, unsigned int numpts);
 Mps Speedometer(const Attrib::Gen::transmission &transmission, const Attrib::Gen::engine &engine, const Attrib::Gen::tires &tires, Rpm rpm,
                 GearID gear, const Tunings *tunings);
-bool EstimatePerformance(Performance &perf);
+bool HasPerformanceRatings(const Attrib::Gen::pvehicle &pvehicle);
+bool EstimatePerformance(const Attrib::Gen::pvehicle &pvehicle, Performance &perf);
+bool ComputePerformance(const Attrib::Gen::pvehicle &pvehicle, Performance &perf);
+bool GetStockPerformance(const Attrib::Gen::pvehicle &pvehicle, Performance &perf);
+bool GetMaximumPerformance(const Attrib::Gen::pvehicle &pvehicle, Performance &perf);
 bool ComputeAccelerationTable(const Attrib::Gen::pvehicle &pvehicle, float &top_speed, float *table, int num_entries);
 
 extern Performance PerformanceWeights[7];

--- a/src/Speed/Indep/Src/Physics/PhysicsInfo.hpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsInfo.hpp
@@ -32,11 +32,7 @@ struct Performance {
         Acceleration = accel;
     }
 
-    void Default() {
-        TopSpeed = 0.0f;
-        Handling = 0.0f;
-        Acceleration = 0.0f;
-    }
+    void Default();
 
     void Maximize(const Performance &other) {
         TopSpeed = UMath::Max(TopSpeed, other.TopSpeed);
@@ -48,6 +44,12 @@ struct Performance {
     float Handling;
     float Acceleration;
 };
+
+inline void Performance::Default() {
+    TopSpeed = 0.0f;
+    Handling = 0.0f;
+    Acceleration = 0.0f;
+}
 
 void Init();
 

--- a/src/Speed/Indep/Src/Physics/PhysicsObject.h
+++ b/src/Speed/Indep/Src/Physics/PhysicsObject.h
@@ -2,11 +2,11 @@
 #define __PHYSICSOBJECT_H__
 
 #include "Speed/Indep/Src/Interfaces/IBody.h"
+#include "Speed/Indep/Src/Interfaces/Simables/IRigidBody.h"
 #include "Speed/Indep/Src/Interfaces/Simables/ISimable.h"
+#include "Speed/Indep/Src/Physics/Behavior.h"
 #include "Speed/Indep/Src/Sim/SimAttachable.h"
 #include "Speed/Indep/Src/Sim/SimObject.h"
-
-class Behavior;
 
 DECLARE_CONTAINER_TYPE(ID_POMechanics);
 DECLARE_CONTAINER_TYPE(ID_POBehaviors);
@@ -22,16 +22,176 @@ class PhysicsObject : public Sim::Object,
     typedef UTL::Std::map<unsigned int, Behavior *, _type_ID_POMechanics> Mechanics;
 
     struct Behaviors : protected UTL::Std::list<Behavior *, _type_ID_POBehaviors> {
+        typedef UTL::Std::list<Behavior *, _type_ID_POBehaviors> _Base;
+        using _Base::begin;
+        using _Base::const_iterator;
+        using _Base::end;
+        using _Base::iterator;
+
         // total size: 0x8
+        void Add(Behavior *beh);
+        void Remove(Behavior *beh);
+        void Reset();
+
+        void OnAttach(IAttachable *iother) {
+            for (const_iterator iter = this->begin(); iter != this->end(); ++iter) {
+                (*iter)->OnOwnerAttached(iother);
+            }
+        }
+
+        void OnDetach(IAttachable *iother) {
+            for (const_iterator iter = this->begin(); iter != this->end(); ++iter) {
+                (*iter)->OnOwnerDetached(iother);
+            }
+        }
+
+        void Simulate(float dT) {
+            for (const_iterator iter = this->begin(); iter != this->end(); ++iter) {
+                if (!(*iter)->IsPaused()) {
+                    (*iter)->DoSimulate(dT);
+                }
+            }
+        }
+
+        void Changed(const UCrc32 &mechanic) {
+            for (const_iterator iter = this->begin(); iter != this->end(); ++iter) {
+                (*iter)->BehaviorChanged(mechanic);
+            }
+        }
     };
 
     PhysicsObject(const Attrib::Instance &attribs, SimableType objType, WUID wuid, unsigned int num_interfaces);
     PhysicsObject(const char *attributeClass, const char *attribName, SimableType objType, HSIMABLE owner, WUID wuid);
 
     // Overrides
-    virtual ~PhysicsObject();
+    ~PhysicsObject() override;
 
-  private:
+    // ISimable
+    SimableType GetSimableType() const override {
+        return this->mObjType;
+    }
+
+    void Kill() override;
+    bool Attach(UTL::COM::IUnknown *object) override;
+    bool Detach(UTL::COM::IUnknown *object) override;
+
+    const IAttachable::List *GetAttachments() const override {
+        if (this->mAttachments == nullptr) {
+            return nullptr;
+        }
+        return &this->mAttachments->GetList();
+    }
+
+    void AttachEntity(Sim::IEntity *e) override;
+    void DetachEntity() override;
+
+    struct IPlayer *GetPlayer() const override {
+        return this->mPlayer;
+    }
+
+    bool IsPlayer() const override {
+        return this->mPlayer != nullptr;
+    }
+
+    bool IsOwnedByPlayer() const override;
+
+    Sim::IEntity *GetEntity() const override {
+        return this->mEntity;
+    }
+
+    void DebugObject() override;
+
+    HSIMABLE GetOwnerHandle() const override {
+        return this->mOwner;
+    }
+
+    ISimable *GetOwner() const override {
+        return ISimable::FindInstance(this->mOwner);
+    }
+
+    bool IsOwnedBy(ISimable *queriedOwner) const override;
+    void SetOwnerObject(ISimable *pOwner) override;
+
+    const Attrib::Instance &GetAttributes() const override {
+        return this->mAttributes;
+    }
+
+    WWorldPos &GetWPos() override;
+    const WWorldPos &GetWPos() const override;
+    class IRigidBody *GetRigidBody() override;
+
+    const class IRigidBody *GetRigidBody() const override {
+        return this->mRigidBody;
+    }
+
+    bool IsRigidBodySimple() const override {
+        if (this->mRigidBody != nullptr) {
+            return this->mRigidBody->IsSimple();
+        }
+        return false;
+    }
+
+    bool IsRigidBodyComplex() const override {
+        return !this->IsRigidBodySimple();
+    }
+
+    const UMath::Vector3 &GetPosition() const override {
+        return this->mRigidBody != nullptr ? this->mRigidBody->GetPosition() : UMath::Vector3::kZero;
+    }
+
+    void GetTransform(UMath::Matrix4 &matrix) const override;
+    void GetLinearVelocity(UMath::Vector3 &velocity) const override;
+    void GetAngularVelocity(UMath::Vector3 &velocity) const override;
+
+    unsigned int GetWorldID() const override {
+        return this->mWorldID;
+    }
+
+    EventSequencer::IEngine *GetEventSequencer() override {
+        return nullptr;
+    }
+
+    void ProcessStimulus(unsigned int stimulus) override;
+    IModel *GetModel() override;
+    const IModel *GetModel() const override;
+    void SetCausality(HCAUSE from, float time) override;
+    HCAUSE GetCausality() const override;
+    float GetCausalityTime() const override;
+
+    // IAttachable
+    void OnAttached(IAttachable *pOther) override;
+    void OnDetached(IAttachable *pOther) override;
+
+    bool IsAttached(const UTL::COM::IUnknown *pOther) const override {
+        if (this->mAttachments != nullptr) {
+            return this->mAttachments->IsAttached(pOther);
+        }
+        return false;
+    }
+
+    // IBody
+    void GetDimension(UMath::Vector3 &dim) const override;
+
+    // Sim::Object
+    bool OnService(HSIMSERVICE hCon, Sim::Packet *pkt) override;
+    bool OnTask(HSIMTASK htask, float dT) override;
+
+    bool IsBehaviorActive(const UCrc32 &mechanic) const;
+    void PauseBehavior(const UCrc32 &mechanic, bool pause);
+    bool ResetBehavior(const UCrc32 &mechanic);
+    Behavior *FindBehavior(const UCrc32 &mechanic);
+    void DetachAll();
+    void ReleaseBehaviors();
+
+    virtual void Reset();
+
+  protected:
+    Behavior *LoadBehavior(const UCrc32 &mechanic, const UCrc32 &behavior, Sim::Param params);
+    void ReleaseBehavior(const UCrc32 &mechanic);
+    virtual void OnTaskSimulate(float dT);
+    virtual void OnBehaviorChange(const UCrc32 &mechanic);
+
+  protected:
     WWorldPos *mWPos;               // offset 0x58, size 0x4
     SimableType mObjType;           // offset 0x5C, size 0x4
     HSIMABLE mOwner;                // offset 0x60, size 0x4

--- a/src/Speed/Indep/Src/Physics/PhysicsTunings.cpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsTunings.cpp
@@ -1,0 +1,23 @@
+#include "PhysicsTunings.h"
+
+namespace Physics {
+
+static const float TuningLimits[Tunings::MAX_TUNINGS][2] = {
+    {-1.0f, 1.0f}, //
+    {-1.0f, 1.0f}, //
+    {-1.0f, 1.0f}, //
+    {-1.0f, 1.0f}, //
+    {-1.0f, 1.0f}, //
+    {-1.0f, 1.0f}, //
+    {-1.0f, 1.0f},
+};
+
+float Tunings::LowerLimit(Path path) {
+    return TuningLimits[path][0];
+}
+
+float Tunings::UpperLimit(Path path) {
+    return TuningLimits[path][1];
+}
+
+} // namespace Physics

--- a/src/Speed/Indep/Src/Physics/PhysicsTunings.h
+++ b/src/Speed/Indep/Src/Physics/PhysicsTunings.h
@@ -3,6 +3,7 @@
 
 namespace Physics {
 
+// total size: 0x1C
 struct Tunings {
     enum Path {
         STEERING = 0,
@@ -15,8 +16,15 @@ struct Tunings {
         MAX_TUNINGS = 7,
     };
 
+    Tunings() {
+        Default();
+    }
+
     static float LowerLimit(Path path);
+
     static float UpperLimit(Path path);
+
+    void Default();
 
     float Value[7]; // offset 0x0, size 0x1C
 };

--- a/src/Speed/Indep/Src/Physics/PhysicsUpgrades.cpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsUpgrades.cpp
@@ -577,8 +577,6 @@ static bool UpgradeInternal(Attrib::Gen::pvehicle &vehicle, Physics::Upgrades::T
 
 bool Physics::Upgrades::SetLevel(Attrib::Gen::pvehicle &vehicle, Physics::Upgrades::Type type, int level) {
     Attrib::Gen::pvehicle newvehicle(vehicle);
-    int max_level;
-    float weight;
 
     if (GetLevel(vehicle, type) == level) {
         return true;
@@ -587,7 +585,7 @@ bool Physics::Upgrades::SetLevel(Attrib::Gen::pvehicle &vehicle, Physics::Upgrad
     if (level < 1) {
         RemovePart(vehicle, type);
     } else {
-        max_level = GetMaxLevel(newvehicle, type);
+        int max_level = GetMaxLevel(newvehicle, type);
         if (max_level < 1) {
             return false;
         }
@@ -595,7 +593,7 @@ bool Physics::Upgrades::SetLevel(Attrib::Gen::pvehicle &vehicle, Physics::Upgrad
             return false;
         }
 
-        weight = static_cast<float>(level) / static_cast<float>(max_level);
+        float weight = static_cast<float>(level) / static_cast<float>(max_level);
         if (UpgradeInternal(newvehicle, type, level, weight)) {
             vehicle = newvehicle;
         } else {

--- a/src/Speed/Indep/Src/Physics/PhysicsUpgrades.cpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsUpgrades.cpp
@@ -488,8 +488,7 @@ static bool UpgradeInternal(Attrib::Gen::pvehicle &vehicle, Physics::Upgrades::T
         return true;
     }
 
-    int max_level = GetMaxLevel(newvehicle, type);
-    if (max_level <= 0 || weight > 1.0f) {
+    if (GetMaxLevel(newvehicle, type) <= 0 || weight > 1.0f) {
         return false;
     }
 
@@ -511,21 +510,25 @@ static bool UpgradeInternal(Attrib::Gen::pvehicle &vehicle, Physics::Upgrades::T
         return false;
     }
 
-    if (part_attribute.GetType() != 0x2b936eb7 || part_attribute.GetLength() < 2) {
+    if (part_attribute.GetType() != 0x2b936eb7) {
         return false;
     }
 
-    unsigned int base_index = (part_attribute.GetLength() == 3) ? 1 : 0;
-    unsigned int top_index = (part_attribute.GetLength() == 3) ? 2 : 1;
+    if (part_attribute.GetLength() <= 1) {
+        return false;
+    }
 
-    RefSpec basepart;
-    part_attribute.Get(base_index, basepart);
+    unsigned int base_index = 0;
+    unsigned int top_index = 1;
+    if (part_attribute.GetLength() == 3) {
+        base_index = 1;
+        top_index = 2;
+    }
 
-    RefSpec endpart;
-    part_attribute.Get(top_index, endpart);
+    RefSpec basepart = part_attribute.Get<RefSpec>(base_index);
+    RefSpec endpart = part_attribute.Get<RefSpec>(top_index);
 
-    if (basepart.GetClassKey() == 0 || endpart.GetClassKey() == 0 ||
-        basepart.GetCollectionKey() == 0 || endpart.GetCollectionKey() == 0) {
+    if (basepart.GetClassKey() == 0 || endpart.GetClassKey() == 0 || basepart.GetCollectionKey() == 0 || endpart.GetCollectionKey() == 0) {
         return false;
     }
 
@@ -543,8 +546,7 @@ static bool UpgradeInternal(Attrib::Gen::pvehicle &vehicle, Physics::Upgrades::T
 
     if (!newvehicle.IsDynamic()) {
         const char *name = newvehicle.CollectionName();
-        Key uniqueKey = newvehicle.GenerateUniqueKey(name, false);
-        newvehicle.Modify(uniqueKey, newvehicle.LocalAttribCount());
+        newvehicle.Modify(newvehicle.GenerateUniqueKey(name, false), newvehicle.LocalAttribCount());
     }
 
     if (!newvehicle.GetBase().AddAndSet(part_key, &newref, 1)) {

--- a/src/Speed/Indep/Src/Physics/PhysicsUpgrades.cpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsUpgrades.cpp
@@ -16,10 +16,6 @@ using Attrib::RefSpec;
 
 struct PUJunkNode : Attrib::Instance {
     PUJunkNode(const RefSpec &collection, const Attrib::Gen::junkman &junkman, unsigned int junkkey);
-
-    void operator delete(void *ptr, std::size_t bytes) {
-        Attrib::Free(ptr, bytes, "Attrib::Instance");
-    }
 };
 
 struct PUPartNode : Attrib::Instance {
@@ -304,14 +300,17 @@ bool Physics::Upgrades::SetJunkman(Attrib::Gen::pvehicle &vehicle, Physics::Upgr
     }
 
     Attribute part_attribute;
-    if (!newvehicle.Lookup(part_key, part_attribute) || part_attribute.GetType() != 0x2b936eb7) {
+    if (!newvehicle.Lookup(part_key, part_attribute)) {
+        return false;
+    }
+    if (part_attribute.GetType() != 0x2b936eb7) {
         return false;
     }
 
     RefSpec basepart(part_attribute.Get< RefSpec >(0));
 
-    Attrib::Gen::junkman junkman_inst(newvehicle.junkman(), 0, nullptr);
-    PUJunkNode node(basepart, junkman_inst, junk_key);
+    Attrib::Gen::junkman junkman(newvehicle.junkman(), 0, nullptr);
+    PUJunkNode node(basepart, junkman, junk_key);
 
     if (!node.IsValid()) {
         return false;
@@ -320,11 +319,10 @@ bool Physics::Upgrades::SetJunkman(Attrib::Gen::pvehicle &vehicle, Physics::Upgr
     RefSpec newref;
     newref.SetCollection(node.GetConstCollection());
 
-    if (!(newref == basepart)) {
+    if (newref != basepart) {
         if (!newvehicle.IsDynamic()) {
             const char *name = newvehicle.CollectionName();
-            Key uniqueKey = newvehicle.GenerateUniqueKey(name, false);
-            newvehicle.Modify(uniqueKey, 0);
+            newvehicle.Modify(newvehicle.GenerateUniqueKey(name, false), 0);
         } else {
             newvehicle.Remove(part_key);
         }

--- a/src/Speed/Indep/Src/Physics/PhysicsUpgrades.cpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsUpgrades.cpp
@@ -320,7 +320,7 @@ bool Physics::Upgrades::SetJunkman(Attrib::Gen::pvehicle &vehicle, Physics::Upgr
     RefSpec newref;
     newref.SetCollection(node.GetConstCollection());
 
-    if (newref != basepart) {
+    if (!(newref == basepart)) {
         if (!newvehicle.IsDynamic()) {
             const char *name = newvehicle.CollectionName();
             Key uniqueKey = newvehicle.GenerateUniqueKey(name, false);
@@ -339,7 +339,7 @@ bool Physics::Upgrades::SetJunkman(Attrib::Gen::pvehicle &vehicle, Physics::Upgr
         return false;
     }
 
-    vehicle = static_cast<const Attrib::Instance &>(newvehicle);
+    vehicle = newvehicle;
     return true;
 }
 
@@ -347,6 +347,7 @@ bool Physics::Upgrades::ApplyPreset(Attrib::Gen::pvehicle &vehicle, const Attrib
     if (!presetride.IsValid()) {
         return false;
     }
+
     if (!vehicle.IsValid()) {
         return false;
     }
@@ -367,18 +368,27 @@ bool Physics::Upgrades::ApplyPreset(Attrib::Gen::pvehicle &vehicle, const Attrib
         }
 
         Attribute attrib;
-        if (!presetride.Lookup(part->presetkey, attrib) || !attrib.IsValid()) {
+        if (!presetride.Lookup(part->presetkey, attrib)) {
             continue;
         }
 
-        int level = UMath::Min(attrib.Get< int >(0u), max_level);
+        if (!attrib.IsValid()) {
+            continue;
+        }
+
+        int level = 0;
+        if (!attrib.Get(0, level)) {
+            continue;
+        }
+
+        level = UMath::Min(max_level, level);
 
         if (!SetLevel(newvehicle, type, level)) {
             return false;
         }
     }
 
-    vehicle = static_cast<const Attrib::Instance &>(newvehicle);
+    vehicle = newvehicle;
     return true;
 }
 
@@ -620,61 +630,32 @@ bool Physics::Upgrades::MatchPerformance(Attrib::Gen::pvehicle &vehicle, const P
 
     Physics::Info::Performance match_line;
 
-    float acc_range = upgraded_performance.Acceleration - stock_performance.Acceleration;
-    if (acc_range > 1e-06f) {
-        match_line.Acceleration = UMath::Ramp(
-            (matched_performance.Acceleration - stock_performance.Acceleration) / acc_range,
-            0.0f, 1.0f);
-    } else {
-        match_line.Acceleration = 0.0f;
-    }
-
-    float top_range = upgraded_performance.TopSpeed - stock_performance.TopSpeed;
-    if (top_range > 1e-06f) {
-        match_line.TopSpeed = UMath::Ramp(
-            (matched_performance.TopSpeed - stock_performance.TopSpeed) / top_range,
-            0.0f, 1.0f);
-    } else {
-        match_line.TopSpeed = 0.0f;
-    }
-
-    float hand_range = upgraded_performance.Handling - stock_performance.Handling;
-    if (hand_range > 1e-06f) {
-        match_line.Handling = UMath::Ramp(
-            (matched_performance.Handling - stock_performance.Handling) / hand_range,
-            0.0f, 1.0f);
-    } else {
-        match_line.Handling = 0.0f;
-    }
+    match_line.Acceleration = UMath::Ramp(matched_performance.Acceleration, stock_performance.Acceleration, upgraded_performance.Acceleration);
+    match_line.TopSpeed = UMath::Ramp(matched_performance.TopSpeed, stock_performance.TopSpeed, upgraded_performance.TopSpeed);
+    match_line.Handling = UMath::Ramp(matched_performance.Handling, stock_performance.Handling, upgraded_performance.Handling);
 
     for (int i = 0; i < Physics::Upgrades::PUT_MAX; i++) {
         Physics::Upgrades::Type type = static_cast<Physics::Upgrades::Type>(i);
         float weight;
 
         switch (type) {
-        case Physics::Upgrades::PUT_TIRES:
+        case Physics::Upgrades::PUT_BRAKES:
             weight = match_line.Handling;
             break;
-        case Physics::Upgrades::PUT_BRAKES:
+        case Physics::Upgrades::PUT_TIRES:
+        case Physics::Upgrades::PUT_CHASSIS:
             weight = (match_line.Handling + match_line.TopSpeed) * 0.5f;
             break;
-        case Physics::Upgrades::PUT_CHASSIS:
-            weight = match_line.Handling;
-            break;
-        case Physics::Upgrades::PUT_TRANSMISSION:
-            weight = (match_line.Acceleration + match_line.TopSpeed) * 0.5f;
-            break;
-        case Physics::Upgrades::PUT_ENGINE:
-            weight = (match_line.Acceleration + match_line.TopSpeed) * 0.5f;
-            break;
         case Physics::Upgrades::PUT_INDUCTION:
-            weight = match_line.Acceleration;
-            break;
         case Physics::Upgrades::PUT_NOS:
             weight = match_line.Acceleration;
             break;
+        case Physics::Upgrades::PUT_TRANSMISSION:
+        case Physics::Upgrades::PUT_ENGINE:
+            weight = (match_line.Acceleration + match_line.TopSpeed) * 0.5f;
+            break;
         default:
-            weight = (match_line.Acceleration + match_line.TopSpeed + match_line.Handling) / 3.0f;
+            weight = (match_line.Acceleration + match_line.TopSpeed + match_line.Handling) * 0.33333334f;
             break;
         }
 
@@ -683,8 +664,8 @@ bool Physics::Upgrades::MatchPerformance(Attrib::Gen::pvehicle &vehicle, const P
         if (weight > 0.0f) {
             int max_level = GetMaxLevel(vehicle, type);
             if (max_level > 0) {
-                float f_index = UMath::Ceil(weight * static_cast<float>(max_level));
-                int level = static_cast<int>(f_index);
+                float f_index = static_cast<float>(max_level);
+                int level = static_cast<int>(UMath::Ceil(weight * f_index));
                 if (!UpgradeInternal(newvehicle, type, level, weight)) {
                     return false;
                 }

--- a/src/Speed/Indep/Src/Physics/PhysicsUpgrades.cpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsUpgrades.cpp
@@ -588,15 +588,15 @@ bool Physics::Upgrades::SetLevel(Attrib::Gen::pvehicle &vehicle, Physics::Upgrad
     }
 
     int max_level = GetMaxLevel(newvehicle, type);
-    if (max_level >= 1 && level <= max_level) {
-        float weight = static_cast<float>(level) / static_cast<float>(max_level);
-        if (UpgradeInternal(newvehicle, type, level, weight)) {
-            vehicle = newvehicle;
-            return true;
-        }
+    if (max_level < 1 || level > max_level) {
+        return false;
     }
-
-    return false;
+    float weight = static_cast<float>(level) / static_cast<float>(max_level);
+    if (!UpgradeInternal(newvehicle, type, level, weight)) {
+        return false;
+    }
+    vehicle = newvehicle;
+    return true;
 }
 
 void Physics::Upgrades::Clear(Attrib::Gen::pvehicle &vehicle) {

--- a/src/Speed/Indep/Src/Physics/PhysicsUpgrades.cpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsUpgrades.cpp
@@ -324,7 +324,7 @@ bool Physics::Upgrades::SetJunkman(Attrib::Gen::pvehicle &vehicle, Physics::Upgr
         if (!newvehicle.IsDynamic()) {
             const char *name = newvehicle.CollectionName();
             Key uniqueKey = newvehicle.GenerateUniqueKey(name, false);
-            newvehicle.Modify(uniqueKey, newvehicle.LocalAttribCount());
+            newvehicle.Modify(uniqueKey, 0);
         } else {
             newvehicle.Remove(part_key);
         }
@@ -556,7 +556,7 @@ static bool UpgradeInternal(Attrib::Gen::pvehicle &vehicle, Physics::Upgrades::T
 
     if (!newvehicle.IsDynamic()) {
         const char *name = newvehicle.CollectionName();
-        newvehicle.Modify(newvehicle.GenerateUniqueKey(name, false), newvehicle.LocalAttribCount());
+        newvehicle.Modify(newvehicle.GenerateUniqueKey(name, false), 0);
     }
 
     if (!newvehicle.GetBase().AddAndSet(part_key, &newref, 1)) {

--- a/src/Speed/Indep/Src/Physics/PhysicsUpgrades.cpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsUpgrades.cpp
@@ -139,9 +139,10 @@ void BlendParts<int>(const Attribute &start_attribute, const Attribute &end_attr
 template <typename T>
 void ScalePart(Attribute &attrib, unsigned int index, float scale) {
     T start_data = T();
-    T new_data;
 
     attrib.Get(index, start_data);
+
+    T new_data;
 
     float *start_ptr = reinterpret_cast<float *>(&start_data);
     float *new_ptr = reinterpret_cast<float *>(&new_data);
@@ -694,13 +695,11 @@ PUJunkNode::PUJunkNode(const RefSpec &collection, const Attrib::Gen::junkman &ju
     : Instance(collection, 0, nullptr) {
     Attribute junk_attribute;
     if (junkman.Lookup(junkkey, junk_attribute)) {
-        Key uniqueKey = GenerateUniqueKey("junk_upgrade", false);
-        Modify(uniqueKey, 0);
+        Modify(GenerateUniqueKey("junk_upgrade", false), 0);
         unsigned int len = junk_attribute.GetLength();
         for (unsigned int index = 0; index < len; index++) {
             JunkmanMod modifire;
-            junk_attribute.Get(index, modifire);
-            if (&modifire != nullptr) {
+            if (junk_attribute.Get(index, modifire)) {
                 Attribute start_attribute = Get(modifire.DefinitionKey);
                 unsigned int count = start_attribute.GetLength();
                 if (count != 0) {
@@ -708,20 +707,19 @@ PUJunkNode::PUJunkNode(const RefSpec &collection, const Attrib::Gen::junkman &ju
                     Attribute attribute = Get(modifire.DefinitionKey);
                     unsigned int type = attribute.GetType();
                     for (unsigned int i = 0; i < count; i++) {
-                        if (type == 0x4cb36381) {
+                        switch (type) {
+                        case 0x4cb36381:
                             ScalePart<AxlePair>(attribute, i, modifire.Scale);
-                        } else if (type < 0x4cb36382) {
-                            if (type == 0x3c16ec5e) {
-                                ScalePart<float>(attribute, i, modifire.Scale);
-                            } else {
-                                bBreak();
-                            }
-                        } else {
-                            if (type != 0x5763da41) {
-                                bBreak();
-                                continue;
-                            }
+                            break;
+                        case 0x3c16ec5e:
+                            ScalePart<float>(attribute, i, modifire.Scale);
+                            break;
+                        case 0x5763da41:
                             ScalePart<int>(attribute, i, modifire.Scale);
+                            break;
+                        default:
+                            bBreak();
+                            break;
                         }
                     }
                 }
@@ -741,40 +739,41 @@ PUPartNode::PUPartNode(const RefSpec &collection0, const RefSpec &collection1, f
         Instance end_instance(collection1, 0, nullptr);
         Instance start_instance(collection0, 0, nullptr);
         AttributeIterator iter = end_instance.Iterator();
-        while (iter.Valid()) {
-            Key key = iter.GetKey();
-            Attribute end_attribute = end_instance.Get(key);
-            Attribute start_attribute = start_instance.Get(key);
-            unsigned int end_count = end_attribute.GetLength();
-            unsigned int start_count = start_attribute.GetLength();
-            unsigned int count = UMath::Max(end_count, start_count);
-            unsigned int end_type = end_attribute.GetType();
-            unsigned int start_type = start_attribute.GetType();
-            if (end_type == start_type) {
+        if (iter.Valid()) {
+            do {
+                Key key = iter.GetKey();
+                Attribute end_attribute = end_instance.Get(key);
+                Attribute start_attribute = start_instance.Get(key);
+                unsigned int end_count = end_attribute.GetLength();
+                unsigned int start_count = start_attribute.GetLength();
+                unsigned int count = UMath::Max(end_count, start_count);
+                unsigned int end_type = end_attribute.GetType();
+                unsigned int start_type = start_attribute.GetType();
+                if (end_type != start_type) {
+                    continue;
+                }
                 if (count != 0) {
                     Add(key, count);
                     Attribute new_attrib = Get(key);
                     unsigned int type = start_attribute.GetType();
                     for (unsigned int i = 0; i < count; i++) {
-                        if (type == 0x4cb36381) {
+                        switch (type) {
+                        case 0x4cb36381:
                             BlendParts<AxlePair>(start_attribute, end_attribute, i, weight, new_attrib);
-                        } else if (type < 0x4cb36382) {
-                            if (type == 0x3c16ec5e) {
-                                BlendParts<float>(start_attribute, end_attribute, i, weight, new_attrib);
-                            } else {
-                                bBreak();
-                            }
-                        } else {
-                            if (type != 0x5763da41) {
-                                bBreak();
-                                continue;
-                            }
+                            break;
+                        case 0x3c16ec5e:
+                            BlendParts<float>(start_attribute, end_attribute, i, weight, new_attrib);
+                            break;
+                        case 0x5763da41:
                             BlendParts<int>(start_attribute, end_attribute, i, weight, new_attrib);
+                            break;
+                        default:
+                            bBreak();
+                            break;
                         }
                     }
                 }
-            }
-            iter.Advance();
+            } while (iter.Advance());
         }
     }
 }

--- a/src/Speed/Indep/Src/Physics/PhysicsUpgrades.cpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsUpgrades.cpp
@@ -267,13 +267,11 @@ bool Physics::Upgrades::CanInstallJunkman(const Attrib::Gen::pvehicle &vehicle, 
 
     Attrib::Gen::junkman junkman(vehicle.junkman(), 0, nullptr);
     Attribute junk_attribute;
-    if (junkman.Lookup(p->junkkey, junk_attribute)) {
-        if (junk_attribute.GetType() == 0x51ead18d) {
-            return junk_attribute.GetLength() != 0;
-        }
+    if (!junkman.Lookup(p->junkkey, junk_attribute) || junk_attribute.GetType() != 0x51ead18d) {
+        return false;
     }
 
-    return false;
+    return junk_attribute.GetLength() != 0;
 }
 
 bool Physics::Upgrades::SetJunkman(Attrib::Gen::pvehicle &vehicle, Physics::Upgrades::Type type) {
@@ -567,26 +565,30 @@ static bool UpgradeInternal(Attrib::Gen::pvehicle &vehicle, Physics::Upgrades::T
 
 bool Physics::Upgrades::SetLevel(Attrib::Gen::pvehicle &vehicle, Physics::Upgrades::Type type, int level) {
     Attrib::Gen::pvehicle newvehicle(vehicle);
+    int max_level;
+    float weight;
 
-    int cur_level = GetLevel(vehicle, type);
-    if (cur_level == level) {
+    if (GetLevel(vehicle, type) == level) {
         return true;
     }
 
     if (level < 1) {
         RemovePart(vehicle, type);
     } else {
-        int max_level = GetMaxLevel(newvehicle, type);
-        if (max_level < 1 || level > max_level) {
+        max_level = GetMaxLevel(newvehicle, type);
+        if (max_level < 1) {
+            return false;
+        }
+        if (level > max_level) {
             return false;
         }
 
-        float weight = static_cast<float>(level) / static_cast<float>(max_level);
-        if (!UpgradeInternal(newvehicle, type, level, weight)) {
+        weight = static_cast<float>(level) / static_cast<float>(max_level);
+        if (UpgradeInternal(newvehicle, type, level, weight)) {
+            vehicle = newvehicle;
+        } else {
             return false;
         }
-
-        vehicle = static_cast<const Attrib::Instance &>(newvehicle);
     }
 
     return true;
@@ -789,3 +791,13 @@ template void BlendParts<float>(const Attribute &, const Attribute &, unsigned i
 template void ScalePart<AxlePair>(Attribute &, unsigned int, float);
 template void ScalePart<float>(Attribute &, unsigned int, float);
 
+namespace Attrib {
+namespace Gen {
+
+const pvehicle &pvehicle::operator=(const Instance &rhs) {
+    Instance::operator=(rhs);
+    return *this;
+}
+
+} // namespace Gen
+} // namespace Attrib

--- a/src/Speed/Indep/Src/Physics/PhysicsUpgrades.cpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsUpgrades.cpp
@@ -1,0 +1,787 @@
+#include "PhysicsUpgrades.hpp"
+#include "PhysicsInfo.hpp"
+#include "Speed/Indep/Libs/Support/Utility/UMath.h"
+#include "Speed/Indep/bWare/Inc/bDebug.hpp"
+#include "Speed/Indep/Src/Generated/AttribSys/Classes/junkman.h"
+#include "Speed/Indep/Src/Generated/AttribSys/Classes/presetride.h"
+#include "Speed/Indep/Src/Generated/AttribSys/Classes/pvehicle.h"
+#include "Speed/Indep/Src/Physics/PhysicsTypes.h"
+#include "Speed/Indep/Tools/AttribSys/Runtime/AttribSys.h"
+
+using Attrib::Attribute;
+using Attrib::AttributeIterator;
+using Attrib::Database;
+using Attrib::Key;
+using Attrib::RefSpec;
+
+struct PUJunkNode : Attrib::Instance {
+    PUJunkNode(const RefSpec &collection, const Attrib::Gen::junkman &junkman, unsigned int junkkey);
+
+    void operator delete(void *ptr, std::size_t bytes) {
+        Attrib::Free(ptr, bytes, "Attrib::Instance");
+    }
+};
+
+struct PUPartNode : Attrib::Instance {
+    PUPartNode(const RefSpec &collection0, const RefSpec &collection1, float weight);
+
+    void operator delete(void *ptr, std::size_t bytes) {
+        Attrib::Free(ptr, bytes, "Attrib::Instance");
+    }
+};
+
+namespace Physics {
+namespace Upgrades {
+
+struct tPartMap {
+    Type type;
+    const char *name;
+    Key key;
+    Key countkey;
+    Key currentkey;
+    Key junkkey;
+    Key presetkey;
+};
+
+} // namespace Upgrades
+} // namespace Physics
+
+
+static Physics::Upgrades::tPartMap put_maps[] = {
+    {Physics::Upgrades::PUT_TIRES, "tires", 0x570E7E24, 0x3F16D2B1, 0x65E52BDE, 0xC5860F58, 0x5F4A69DB},
+    {Physics::Upgrades::PUT_BRAKES, "brakes", 0x2DD1F36A, 0xA2AEA57C, 0xC316DCD1, 0x56C63B6F, 0xE6C23DE6},
+    {Physics::Upgrades::PUT_CHASSIS, "chassis", 0xF4E2FAD0, 0x20F6C9D5, 0x58CCF9F1, 0xB6495C9E, 0x21DD95EB},
+    {Physics::Upgrades::PUT_TRANSMISSION, "transmission", 0x07A7A3E5, 0x0CB3C7E5, 0x170D5554, 0x25AE629A, 0x3DF99C50},
+    {Physics::Upgrades::PUT_ENGINE, "engine", 0x5B862C53, 0x0CA4AD56, 0x5F8AFDDB, 0x9206EFD2, 0x3A93C8C7},
+    {Physics::Upgrades::PUT_INDUCTION, "induction", 0xC92A0142, 0x99FCA5D3, 0x4DFC0A63, 0x7546359E, 0xFC61F3A5},
+    {Physics::Upgrades::PUT_NOS, "nos", 0xD7B2D8F2, 0x2C48F8EC, 0x1D79C9A4, 0x452D2634, 0xEABB55C5},
+    {(Physics::Upgrades::Type)0, nullptr, 0, 0, 0, 0, 0},
+};
+
+const Physics::Upgrades::tPartMap *FindPartMap(Physics::Upgrades::Type type) {
+    Physics::Upgrades::tPartMap *t;
+    const Physics::Upgrades::tPartMap *type_map = put_maps;
+    if (type_map->key == 0) {
+        goto not_found;
+    }
+    if (type_map->type == type) {
+        return type_map;
+    }
+    do {
+        type_map++;
+        if (type_map->key == 0) {
+            goto not_found;
+        }
+    } while (type_map->type != type);
+    return type_map;
+not_found:
+    return nullptr;
+}
+
+static void DownGradeInternal(Attrib::Gen::pvehicle &vehicle, Physics::Upgrades::Type type) {
+    if (!vehicle.IsDynamic()) {
+        return;
+    }
+
+    const Physics::Upgrades::tPartMap *t = FindPartMap(type);
+    if (t == nullptr) {
+        return;
+    }
+
+    vehicle.Remove(t->key);
+    vehicle.Remove(t->currentkey);
+
+    int mask = 1 << type;
+    int junkman_current = vehicle.junkman_current();
+
+    if (junkman_current & mask) {
+        vehicle.Remove(0xcdc136e8);
+        junkman_current = junkman_current & ~mask;
+        vehicle.GetBase().AddAndSet(0xcdc136e8, &junkman_current, 1);
+    }
+}
+
+template <typename T>
+void BlendParts(const Attribute &start_attribute, const Attribute &end_attribute, unsigned int index, float weight, Attribute &new_attrib) {
+    T start_data = T();
+    T end_data = T();
+
+    start_attribute.Get(index, start_data);
+    end_attribute.Get(index, end_data);
+
+    T new_data;
+
+    float *start_ptr = reinterpret_cast<float *>(&start_data);
+    float *end_ptr = reinterpret_cast<float *>(&end_data);
+    float *new_ptr = reinterpret_cast<float *>(&new_data);
+
+    new_ptr[0] = start_ptr[0] * (1.0f - weight) + end_ptr[0] * weight;
+    if (sizeof(T) > sizeof(float)) {
+        new_ptr[1] = start_ptr[1] * (1.0f - weight) + end_ptr[1] * weight;
+    }
+
+    new_attrib.Set(index, new_data);
+}
+
+template <>
+void BlendParts<int>(const Attribute &start_attribute, const Attribute &end_attribute, unsigned int index, float weight, Attribute &new_attrib) {
+    int start_data = 0;
+    int end_data = 0;
+
+    start_attribute.Get(index, start_data);
+    end_attribute.Get(index, end_data);
+
+    int new_data = static_cast<int>(static_cast<float>(start_data) * (1.0f - weight) + static_cast<float>(end_data) * weight);
+
+    new_attrib.Set(index, new_data);
+}
+
+template <typename T>
+void ScalePart(Attribute &attrib, unsigned int index, float scale) {
+    T start_data = T();
+    T new_data;
+
+    attrib.Get(index, start_data);
+
+    float *start_ptr = reinterpret_cast<float *>(&start_data);
+    float *new_ptr = reinterpret_cast<float *>(&new_data);
+
+    new_ptr[0] = start_ptr[0] * scale;
+    if (sizeof(T) > sizeof(float)) {
+        new_ptr[1] = start_ptr[1] * scale;
+    }
+
+    attrib.Set(index, new_data);
+}
+
+template <>
+void ScalePart<int>(Attribute &attrib, unsigned int index, float scale) {
+    int start_data = 0;
+
+    attrib.Get(index, start_data);
+
+    int new_data = static_cast<int>(static_cast<float>(start_data) * scale);
+
+    attrib.Set(index, new_data);
+}
+
+float Physics::Upgrades::GetPercent(const Attrib::Gen::pvehicle &vehicle, Physics::Upgrades::Type type) {
+    int max_level = GetMaxLevel(vehicle, type);
+    if (max_level == 0) {
+        return 0.0f;
+    }
+    int cur_level = GetLevel(vehicle, type);
+    if (cur_level == max_level) {
+        return 1.0f;
+    }
+    return static_cast<float>(cur_level) / static_cast<float>(max_level);
+}
+
+int Physics::Upgrades::GetLevel(const Attrib::Gen::pvehicle &vehicle, Physics::Upgrades::Type type) {
+    Attribute attrib;
+    const Physics::Upgrades::tPartMap *t = FindPartMap(type);
+    if (t == nullptr || !vehicle.Lookup(t->currentkey, attrib)) {
+        return 0;
+    }
+    return attrib.Get< int >(0u);
+}
+
+void Physics::Upgrades::GetPackage(const Attrib::Gen::pvehicle &vehicle, Package &package) {
+    package.Default();
+
+    for (int i = 0; i < Physics::Upgrades::PUT_MAX; i++) {
+        Physics::Upgrades::Type type = static_cast<Physics::Upgrades::Type>(i);
+        package.Part[i] = GetLevel(vehicle, type);
+        if (GetJunkman(vehicle, type)) {
+            package.Junkman |= (1 << type);
+        }
+    }
+}
+
+bool Physics::Upgrades::SetPackage(Attrib::Gen::pvehicle &vehicle, const Package &package) {
+    Attrib::Gen::pvehicle newvehicle(vehicle);
+    Clear(newvehicle);
+
+    if (!Validate(newvehicle)) {
+        return false;
+    }
+
+    for (int i = 0; i < Physics::Upgrades::PUT_MAX; i++) {
+        Physics::Upgrades::Type type = static_cast<Physics::Upgrades::Type>(i);
+        int mask = 1 << type;
+
+        if (!SetLevel(newvehicle, type, package.Part[i])) {
+            return false;
+        }
+
+        if ((package.Junkman & mask) == 0) {
+            RemoveJunkman(newvehicle, type);
+        } else {
+            if (!SetJunkman(newvehicle, type)) {
+                return false;
+            }
+        }
+    }
+
+    if (!Validate(newvehicle)) {
+        return false;
+    }
+
+    vehicle = newvehicle;
+    return true;
+}
+
+bool Physics::Upgrades::GetJunkman(const Attrib::Gen::pvehicle &vehicle, Physics::Upgrades::Type type) {
+    int junkman_current = vehicle.junkman_current();
+    bool result = true;
+    if (((junkman_current >> type) & 1) == 0) {
+        result = false;
+    }
+    return result;
+}
+
+bool Physics::Upgrades::CanInstallJunkman(const Attrib::Gen::pvehicle &vehicle, Physics::Upgrades::Type type) {
+    const Physics::Upgrades::tPartMap *p = FindPartMap(type);
+    if (p == nullptr) {
+        return false;
+    }
+    if (p->junkkey == 0) {
+        return false;
+    }
+
+    if (type == Physics::Upgrades::PUT_INDUCTION) {
+        if (Physics::Info::InductionType(vehicle) == Physics::Info::INDUCTION_NONE) {
+            return false;
+        }
+    } else if (type == Physics::Upgrades::PUT_NOS) {
+        if (!Physics::Info::HasNos(vehicle)) {
+            return false;
+        }
+    }
+
+    Attrib::Gen::junkman junkman(vehicle.junkman(), 0, nullptr);
+    Attribute junk_attribute;
+    bool found = junkman.Lookup(p->junkkey, junk_attribute);
+    if (found && junk_attribute.GetType() == 0x51ead18d) {
+        unsigned int len = junk_attribute.GetLength();
+        return len != 0;
+    }
+
+    return false;
+}
+
+bool Physics::Upgrades::SetJunkman(Attrib::Gen::pvehicle &vehicle, Physics::Upgrades::Type type) {
+    Attrib::Gen::pvehicle newvehicle(vehicle);
+
+    if (GetJunkman(vehicle, type)) {
+        return true;
+    }
+
+    if (!CanInstallJunkman(vehicle, type)) {
+        return false;
+    }
+
+    const Physics::Upgrades::tPartMap *p = FindPartMap(type);
+    if (p == nullptr) {
+        return false;
+    }
+
+    unsigned int part_key = p->key;
+    unsigned int junk_key = p->junkkey;
+
+    if (part_key == 0 || junk_key == 0) {
+        return false;
+    }
+
+    int junkman_current = vehicle.junkman_current();
+
+    if (newvehicle.IsDynamic()) {
+        newvehicle.Remove(0xcdc136e8);
+    }
+
+    Attribute part_attribute;
+    if (!newvehicle.Lookup(part_key, part_attribute) || part_attribute.GetType() != 0x2b936eb7) {
+        return false;
+    }
+
+    RefSpec basepart(part_attribute.Get< RefSpec >(0));
+
+    Attrib::Gen::junkman junkman_inst(newvehicle.junkman(), 0, nullptr);
+    PUJunkNode node(basepart, junkman_inst, junk_key);
+
+    if (!node.IsValid()) {
+        return false;
+    }
+
+    RefSpec newref;
+    newref.SetCollection(node.GetConstCollection());
+
+    if (newref != basepart) {
+        if (!newvehicle.IsDynamic()) {
+            const char *name = newvehicle.CollectionName();
+            Key uniqueKey = newvehicle.GenerateUniqueKey(name, false);
+            newvehicle.Modify(uniqueKey, newvehicle.LocalAttribCount());
+        } else {
+            newvehicle.Remove(part_key);
+        }
+
+        if (!newvehicle.GetBase().AddAndSet(part_key, &newref, 1)) {
+            return false;
+        }
+    }
+
+    junkman_current |= (1 << type);
+    if (!newvehicle.GetBase().AddAndSet(0xcdc136e8, &junkman_current, 1)) {
+        return false;
+    }
+
+    vehicle = static_cast<const Attrib::Instance &>(newvehicle);
+    return true;
+}
+
+bool Physics::Upgrades::ApplyPreset(Attrib::Gen::pvehicle &vehicle, const Attrib::Gen::presetride &presetride) {
+    if (!presetride.IsValid()) {
+        return false;
+    }
+    if (!vehicle.IsValid()) {
+        return false;
+    }
+
+    Attrib::Gen::pvehicle newvehicle(vehicle);
+    Clear(newvehicle);
+
+    for (int i = 0; i < Physics::Upgrades::PUT_MAX; i++) {
+        Physics::Upgrades::Type type = static_cast<Physics::Upgrades::Type>(i);
+        const Physics::Upgrades::tPartMap *part = FindPartMap(type);
+        if (part == nullptr) {
+            continue;
+        }
+
+        int max_level = GetMaxLevel(vehicle, type);
+        if (max_level <= 0) {
+            continue;
+        }
+
+        Attribute attrib;
+        if (!presetride.Lookup(part->presetkey, attrib) || !attrib.IsValid()) {
+            continue;
+        }
+
+        int level = UMath::Min(attrib.Get< int >(0u), max_level);
+
+        if (!SetLevel(newvehicle, type, level)) {
+            return false;
+        }
+    }
+
+    vehicle = static_cast<const Attrib::Instance &>(newvehicle);
+    return true;
+}
+
+void Physics::Upgrades::RemovePart(Attrib::Gen::pvehicle &vehicle, Physics::Upgrades::Type type) {
+    if (!vehicle.IsDynamic()) {
+        return;
+    }
+
+    if (GetLevel(vehicle, type) == 0) {
+        return;
+    }
+
+    const Physics::Upgrades::tPartMap *t = FindPartMap(type);
+    if (t == nullptr || t->key == 0) {
+        return;
+    }
+
+    bool had_junkman = GetJunkman(vehicle, type);
+    DownGradeInternal(vehicle, type);
+    if (had_junkman) {
+        SetJunkman(vehicle, type);
+    }
+}
+
+void Physics::Upgrades::RemoveJunkman(Attrib::Gen::pvehicle &vehicle, Physics::Upgrades::Type type) {
+    if (!vehicle.IsDynamic()) {
+        return;
+    }
+
+    const Physics::Upgrades::tPartMap *t = FindPartMap(type);
+    if (t == nullptr || t->key == 0) {
+        return;
+    }
+
+    if (!GetJunkman(vehicle, type)) {
+        return;
+    }
+
+    int old_upgrade_level = GetLevel(vehicle, type);
+    DownGradeInternal(vehicle, type);
+    if (old_upgrade_level > 0) {
+        SetLevel(vehicle, type, old_upgrade_level);
+    }
+}
+
+bool Physics::Upgrades::Validate(const Attrib::Gen::pvehicle &vehicle, Physics::Upgrades::Type type) {
+    if (GetJunkman(vehicle, type)) {
+        if (!CanInstallJunkman(vehicle, type)) {
+            return false;
+        }
+    }
+
+    int current = GetLevel(vehicle, type);
+    int max_level = GetMaxLevel(vehicle, type);
+
+    if (current == 0 && max_level != 0) {
+        const Physics::Upgrades::tPartMap *t = FindPartMap(type);
+        if (t == nullptr) {
+            return false;
+        }
+
+        Attrib::Gen::pvehicle base(vehicle);
+        Clear(base);
+        Attribute attrib;
+        if (!base.Lookup(t->key, attrib) || attrib.GetLength() < 2) {
+            return false;
+        }
+    }
+
+    return current <= max_level;
+}
+
+bool Physics::Upgrades::Validate(const Attrib::Gen::pvehicle &vehicle) {
+    for (int i = 0; i < Physics::Upgrades::PUT_MAX; i++) {
+        if (!Validate(vehicle, static_cast<Physics::Upgrades::Type>(i))) {
+            return false;
+        }
+    }
+    return true;
+}
+
+int Physics::Upgrades::GetMaxLevel(const Attrib::Gen::pvehicle &vehicle, Physics::Upgrades::Type type) {
+    Attribute attrib;
+    const Physics::Upgrades::tPartMap *t = FindPartMap(type);
+    if (t == nullptr || !vehicle.Lookup(t->countkey, attrib)) {
+        return 0;
+    }
+    return attrib.Get< int >(0u);
+}
+
+bool Physics::Upgrades::SetMaximum(Attrib::Gen::pvehicle &pvehicle) {
+    Package package;
+    package.Default();
+
+    for (int i = 0; i < Physics::Upgrades::PUT_MAX; i++) {
+        package.Part[i] = GetMaxLevel(pvehicle, static_cast<Physics::Upgrades::Type>(i));
+    }
+
+    return SetPackage(pvehicle, package);
+}
+
+static bool UpgradeInternal(Attrib::Gen::pvehicle &vehicle, Physics::Upgrades::Type type, int level, float weight) {
+    Attrib::Gen::pvehicle newvehicle(vehicle);
+
+    if (weight <= 0.0f) {
+        RemovePart(vehicle, type);
+        return true;
+    }
+
+    int max_level = GetMaxLevel(newvehicle, type);
+    if (max_level <= 0 || weight > 1.0f) {
+        return false;
+    }
+
+    const Physics::Upgrades::tPartMap *p = FindPartMap(type);
+    if (p == nullptr) {
+        return false;
+    }
+
+    unsigned int part_key = p->key;
+    if (part_key == 0) {
+        return false;
+    }
+
+    bool had_junkman = GetJunkman(vehicle, type);
+    DownGradeInternal(newvehicle, type);
+
+    Attribute part_attribute;
+    if (!newvehicle.Lookup(part_key, part_attribute)) {
+        return false;
+    }
+
+    if (part_attribute.GetType() != 0x2b936eb7 || part_attribute.GetLength() < 2) {
+        return false;
+    }
+
+    unsigned int base_index = (part_attribute.GetLength() == 3) ? 1 : 0;
+    unsigned int top_index = (part_attribute.GetLength() == 3) ? 2 : 1;
+
+    RefSpec basepart;
+    part_attribute.Get(base_index, basepart);
+
+    RefSpec endpart;
+    part_attribute.Get(top_index, endpart);
+
+    if (basepart.GetClassKey() == 0 || endpart.GetClassKey() == 0 ||
+        basepart.GetCollectionKey() == 0 || endpart.GetCollectionKey() == 0) {
+        return false;
+    }
+
+    PUPartNode node(basepart, endpart, weight);
+    if (!node.IsValid()) {
+        return false;
+    }
+
+    RefSpec newref;
+    newref.SetCollection(node.GetConstCollection());
+
+    if (newref == basepart) {
+        return true;
+    }
+
+    if (!newvehicle.IsDynamic()) {
+        const char *name = newvehicle.CollectionName();
+        Key uniqueKey = newvehicle.GenerateUniqueKey(name, false);
+        newvehicle.Modify(uniqueKey, newvehicle.LocalAttribCount());
+    }
+
+    if (!newvehicle.GetBase().AddAndSet(part_key, &newref, 1)) {
+        return false;
+    }
+
+    if (!newvehicle.GetBase().AddAndSet(p->currentkey, &level, 1)) {
+        return false;
+    }
+
+    if (had_junkman && !SetJunkman(newvehicle, type)) {
+        return false;
+    }
+
+    vehicle = newvehicle;
+    return true;
+}
+
+bool Physics::Upgrades::SetLevel(Attrib::Gen::pvehicle &vehicle, Physics::Upgrades::Type type, int level) {
+    Attrib::Gen::pvehicle newvehicle(vehicle);
+
+    int cur_level = GetLevel(vehicle, type);
+    if (cur_level == level) {
+        return true;
+    }
+
+    if (level < 1) {
+        RemovePart(vehicle, type);
+    } else {
+        int max_level = GetMaxLevel(newvehicle, type);
+        if (max_level < 1 || level > max_level) {
+            return false;
+        }
+
+        float weight = static_cast<float>(level) / static_cast<float>(max_level);
+        if (!UpgradeInternal(newvehicle, type, level, weight)) {
+            return false;
+        }
+
+        vehicle = static_cast<const Attrib::Instance &>(newvehicle);
+    }
+
+    return true;
+}
+
+void Physics::Upgrades::Clear(Attrib::Gen::pvehicle &vehicle) {
+    if (vehicle.IsDynamic()) {
+        vehicle.Unmodify();
+    }
+}
+
+bool Physics::Upgrades::MatchPerformance(Attrib::Gen::pvehicle &vehicle, const Physics::Info::Performance &matched_performance) {
+    Attrib::Gen::pvehicle newvehicle(vehicle);
+
+    Clear(newvehicle);
+
+    Physics::Info::Performance stock_performance;
+    Physics::Info::Performance upgraded_performance;
+
+    if (!Physics::Info::GetStockPerformance(newvehicle, stock_performance)) {
+        return false;
+    }
+
+    if (!Physics::Info::GetMaximumPerformance(newvehicle, upgraded_performance)) {
+        return false;
+    }
+
+    Physics::Info::Performance match_line;
+
+    float acc_range = upgraded_performance.Acceleration - stock_performance.Acceleration;
+    if (acc_range > 1e-06f) {
+        match_line.Acceleration = UMath::Ramp(
+            (matched_performance.Acceleration - stock_performance.Acceleration) / acc_range,
+            0.0f, 1.0f);
+    } else {
+        match_line.Acceleration = 0.0f;
+    }
+
+    float top_range = upgraded_performance.TopSpeed - stock_performance.TopSpeed;
+    if (top_range > 1e-06f) {
+        match_line.TopSpeed = UMath::Ramp(
+            (matched_performance.TopSpeed - stock_performance.TopSpeed) / top_range,
+            0.0f, 1.0f);
+    } else {
+        match_line.TopSpeed = 0.0f;
+    }
+
+    float hand_range = upgraded_performance.Handling - stock_performance.Handling;
+    if (hand_range > 1e-06f) {
+        match_line.Handling = UMath::Ramp(
+            (matched_performance.Handling - stock_performance.Handling) / hand_range,
+            0.0f, 1.0f);
+    } else {
+        match_line.Handling = 0.0f;
+    }
+
+    for (int i = 0; i < Physics::Upgrades::PUT_MAX; i++) {
+        Physics::Upgrades::Type type = static_cast<Physics::Upgrades::Type>(i);
+        float weight;
+
+        switch (type) {
+        case Physics::Upgrades::PUT_TIRES:
+            weight = match_line.Handling;
+            break;
+        case Physics::Upgrades::PUT_BRAKES:
+            weight = (match_line.Handling + match_line.TopSpeed) * 0.5f;
+            break;
+        case Physics::Upgrades::PUT_CHASSIS:
+            weight = match_line.Handling;
+            break;
+        case Physics::Upgrades::PUT_TRANSMISSION:
+            weight = (match_line.Acceleration + match_line.TopSpeed) * 0.5f;
+            break;
+        case Physics::Upgrades::PUT_ENGINE:
+            weight = (match_line.Acceleration + match_line.TopSpeed) * 0.5f;
+            break;
+        case Physics::Upgrades::PUT_INDUCTION:
+            weight = match_line.Acceleration;
+            break;
+        case Physics::Upgrades::PUT_NOS:
+            weight = match_line.Acceleration;
+            break;
+        default:
+            weight = (match_line.Acceleration + match_line.TopSpeed + match_line.Handling) / 3.0f;
+            break;
+        }
+
+        weight = UMath::Clamp(weight, 0.0f, 1.0f);
+
+        if (weight > 0.0f) {
+            int max_level = GetMaxLevel(vehicle, type);
+            if (max_level > 0) {
+                float f_index = UMath::Ceil(weight * static_cast<float>(max_level));
+                int level = static_cast<int>(f_index);
+                if (!UpgradeInternal(newvehicle, type, level, weight)) {
+                    return false;
+                }
+            }
+        }
+    }
+
+    vehicle = newvehicle;
+    return true;
+}
+
+void Physics::Upgrades::Flush() {
+    Database::Get().CollectGarbage();
+}
+
+PUJunkNode::PUJunkNode(const RefSpec &collection, const Attrib::Gen::junkman &junkman, unsigned int junkkey)
+    : Instance(collection, 0, nullptr) {
+    Attribute junk_attribute;
+    if (junkman.Lookup(junkkey, junk_attribute)) {
+        Key uniqueKey = GenerateUniqueKey("junk_upgrade", false);
+        Modify(uniqueKey, 0);
+        unsigned int len = junk_attribute.GetLength();
+        for (unsigned int index = 0; index < len; index++) {
+            JunkmanMod modifire;
+            junk_attribute.Get(index, modifire);
+            if (&modifire != nullptr) {
+                Attribute start_attribute = Get(modifire.DefinitionKey);
+                unsigned int count = start_attribute.GetLength();
+                if (count != 0) {
+                    Add(modifire.DefinitionKey, count);
+                    Attribute attribute = Get(modifire.DefinitionKey);
+                    unsigned int type = attribute.GetType();
+                    for (unsigned int i = 0; i < count; i++) {
+                        if (type == 0x4cb36381) {
+                            ScalePart<AxlePair>(attribute, i, modifire.Scale);
+                        } else if (type < 0x4cb36382) {
+                            if (type == 0x3c16ec5e) {
+                                ScalePart<float>(attribute, i, modifire.Scale);
+                            } else {
+                                bBreak();
+                            }
+                        } else {
+                            if (type != 0x5763da41) {
+                                bBreak();
+                                continue;
+                            }
+                            ScalePart<int>(attribute, i, modifire.Scale);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+PUPartNode::PUPartNode(const RefSpec &collection0, const RefSpec &collection1, float weight)
+    : Instance(collection0, 0, nullptr) {
+    if (weight >= 1.0f) {
+        ChangeWithDefault(collection1);
+    } else if (weight > 0.0f) {
+        ChangeWithDefault(collection0);
+        Key uniqueKey = GenerateUniqueKey("part_upgrade", false);
+        Modify(uniqueKey, 0);
+        Instance end_instance(collection1, 0, nullptr);
+        Instance start_instance(collection0, 0, nullptr);
+        AttributeIterator iter = end_instance.Iterator();
+        while (iter.Valid()) {
+            Key key = iter.GetKey();
+            Attribute end_attribute = end_instance.Get(key);
+            Attribute start_attribute = start_instance.Get(key);
+            unsigned int end_count = end_attribute.GetLength();
+            unsigned int start_count = start_attribute.GetLength();
+            unsigned int count = UMath::Max(end_count, start_count);
+            unsigned int end_type = end_attribute.GetType();
+            unsigned int start_type = start_attribute.GetType();
+            if (end_type == start_type) {
+                if (count != 0) {
+                    Add(key, count);
+                    Attribute new_attrib = Get(key);
+                    unsigned int type = start_attribute.GetType();
+                    for (unsigned int i = 0; i < count; i++) {
+                        if (type == 0x4cb36381) {
+                            BlendParts<AxlePair>(start_attribute, end_attribute, i, weight, new_attrib);
+                        } else if (type < 0x4cb36382) {
+                            if (type == 0x3c16ec5e) {
+                                BlendParts<float>(start_attribute, end_attribute, i, weight, new_attrib);
+                            } else {
+                                bBreak();
+                            }
+                        } else {
+                            if (type != 0x5763da41) {
+                                bBreak();
+                                continue;
+                            }
+                            BlendParts<int>(start_attribute, end_attribute, i, weight, new_attrib);
+                        }
+                    }
+                }
+            }
+            iter.Advance();
+        }
+    }
+}
+
+// Explicit template instantiations
+template void BlendParts<AxlePair>(const Attribute &, const Attribute &, unsigned int, float, Attribute &);
+template void BlendParts<float>(const Attribute &, const Attribute &, unsigned int, float, Attribute &);
+template void ScalePart<AxlePair>(Attribute &, unsigned int, float);
+template void ScalePart<float>(Attribute &, unsigned int, float);
+

--- a/src/Speed/Indep/Src/Physics/PhysicsUpgrades.cpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsUpgrades.cpp
@@ -584,24 +584,19 @@ bool Physics::Upgrades::SetLevel(Attrib::Gen::pvehicle &vehicle, Physics::Upgrad
 
     if (level < 1) {
         RemovePart(vehicle, type);
-    } else {
-        int max_level = GetMaxLevel(newvehicle, type);
-        if (max_level < 1) {
-            return false;
-        }
-        if (level > max_level) {
-            return false;
-        }
+        return true;
+    }
 
+    int max_level = GetMaxLevel(newvehicle, type);
+    if (max_level >= 1 && level <= max_level) {
         float weight = static_cast<float>(level) / static_cast<float>(max_level);
         if (UpgradeInternal(newvehicle, type, level, weight)) {
             vehicle = newvehicle;
-        } else {
-            return false;
+            return true;
         }
     }
 
-    return true;
+    return false;
 }
 
 void Physics::Upgrades::Clear(Attrib::Gen::pvehicle &vehicle) {

--- a/src/Speed/Indep/Src/Physics/PhysicsUpgrades.cpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsUpgrades.cpp
@@ -209,18 +209,18 @@ bool Physics::Upgrades::SetPackage(Attrib::Gen::pvehicle &vehicle, const Package
 
     for (int i = 0; i < Physics::Upgrades::PUT_MAX; i++) {
         Physics::Upgrades::Type type = static_cast<Physics::Upgrades::Type>(i);
-        int mask = 1 << type;
 
         if (!SetLevel(newvehicle, type, package.Part[i])) {
             return false;
         }
 
-        if ((package.Junkman & mask) == 0) {
-            RemoveJunkman(newvehicle, type);
-        } else {
+        int mask = 1 << type;
+        if (package.Junkman & mask) {
             if (!SetJunkman(newvehicle, type)) {
                 return false;
             }
+        } else {
+            RemoveJunkman(newvehicle, type);
         }
     }
 
@@ -250,22 +250,27 @@ bool Physics::Upgrades::CanInstallJunkman(const Attrib::Gen::pvehicle &vehicle, 
         return false;
     }
 
-    if (type == Physics::Upgrades::PUT_INDUCTION) {
-        if (Physics::Info::InductionType(vehicle) == Physics::Info::INDUCTION_NONE) {
-            return false;
-        }
-    } else if (type == Physics::Upgrades::PUT_NOS) {
+    switch (type) {
+    case Physics::Upgrades::PUT_NOS:
         if (!Physics::Info::HasNos(vehicle)) {
             return false;
         }
+        break;
+    case Physics::Upgrades::PUT_INDUCTION:
+        if (Physics::Info::InductionType(vehicle) == Physics::Info::INDUCTION_NONE) {
+            return false;
+        }
+        break;
+    default:
+        break;
     }
 
     Attrib::Gen::junkman junkman(vehicle.junkman(), 0, nullptr);
     Attribute junk_attribute;
-    bool found = junkman.Lookup(p->junkkey, junk_attribute);
-    if (found && junk_attribute.GetType() == 0x51ead18d) {
-        unsigned int len = junk_attribute.GetLength();
-        return len != 0;
+    if (junkman.Lookup(p->junkkey, junk_attribute)) {
+        if (junk_attribute.GetType() == 0x51ead18d) {
+            return junk_attribute.GetLength() != 0;
+        }
     }
 
     return false;

--- a/src/Speed/Indep/Src/Physics/PhysicsUpgrades.cpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsUpgrades.cpp
@@ -746,7 +746,7 @@ PUPartNode::PUPartNode(const RefSpec &collection0, const RefSpec &collection1, f
                 Attribute start_attribute = start_instance.Get(key);
                 unsigned int end_count = end_attribute.GetLength();
                 unsigned int start_count = start_attribute.GetLength();
-                unsigned int count = UMath::Max(end_count, start_count);
+                unsigned int count = UMath::Max(start_count, end_count);
                 unsigned int end_type = end_attribute.GetType();
                 unsigned int start_type = start_attribute.GetType();
                 if (end_type != start_type) {

--- a/src/Speed/Indep/Src/Physics/PhysicsUpgrades.hpp
+++ b/src/Speed/Indep/Src/Physics/PhysicsUpgrades.hpp
@@ -1,9 +1,15 @@
 #ifndef PHYSICSUPGRADES_HPP
 #define PHYSICSUPGRADES_HPP
 
+#include "Speed/Indep/Src/Generated/AttribSys/Classes/presetride.h"
 #include "Speed/Indep/Src/Generated/AttribSys/Classes/pvehicle.h"
+#include "Speed/Indep/bWare/Inc/bWare.hpp"
 
 namespace Physics {
+
+namespace Info {
+struct Performance;
+} // namespace Info
 
 namespace Upgrades {
 
@@ -20,12 +26,35 @@ enum Type {
 
 // total size: 0x20
 struct Package {
+    Package() {}
+
+    void Default() {
+        bMemSet(this, 0, sizeof(*this));
+        Junkman = 0;
+    }
+
     int Part[7]; // offset 0x0, size 0x1C
     int Junkman; // offset 0x1C, size 0x4
 };
 
+float GetPercent(const Attrib::Gen::pvehicle &vehicle, Type type);
 int GetLevel(const Attrib::Gen::pvehicle &vehicle, Type type);
+void GetPackage(const Attrib::Gen::pvehicle &vehicle, Package &package);
+bool SetPackage(Attrib::Gen::pvehicle &vehicle, const Package &package);
+bool GetJunkman(const Attrib::Gen::pvehicle &vehicle, Type type);
+bool CanInstallJunkman(const Attrib::Gen::pvehicle &vehicle, Type type);
+bool SetJunkman(Attrib::Gen::pvehicle &vehicle, Type type);
+bool ApplyPreset(Attrib::Gen::pvehicle &vehicle, const Attrib::Gen::presetride &presetride);
+void RemovePart(Attrib::Gen::pvehicle &vehicle, Type type);
+void RemoveJunkman(Attrib::Gen::pvehicle &vehicle, Type type);
+bool Validate(const Attrib::Gen::pvehicle &vehicle, Type type);
+bool Validate(const Attrib::Gen::pvehicle &vehicle);
 int GetMaxLevel(const Attrib::Gen::pvehicle &vehicle, Type type);
+bool SetMaximum(Attrib::Gen::pvehicle &pvehicle);
+bool SetLevel(Attrib::Gen::pvehicle &vehicle, Type type, int level);
+void Clear(Attrib::Gen::pvehicle &vehicle);
+bool MatchPerformance(Attrib::Gen::pvehicle &vehicle, const Physics::Info::Performance &matched_performance);
+void Flush();
 
 }; // namespace Upgrades
 

--- a/src/Speed/Indep/Src/Physics/PlaceableScenery.h
+++ b/src/Speed/Indep/Src/Physics/PlaceableScenery.h
@@ -1,0 +1,37 @@
+#ifndef PHYSICS_PLACEABLESCENERY_H
+#define PHYSICS_PLACEABLESCENERY_H
+
+#ifdef EA_PRAGMA_ONCE_SUPPORTED
+#pragma once
+#endif
+
+#include "Speed/Indep/Libs/Support/Utility/FastMem.h"
+#include "Speed/Indep/Src/Interfaces/SimModels/IPlaceableScenery.h"
+#include "Speed/Indep/Src/Physics/HeirarchyModel.h"
+
+struct PlaceableScenery : public HeirarchyModel, public IPlaceableScenery {
+    PlaceableScenery(bHash32 rendermesh, const CollisionGeometry::Bounds *geometry,
+                     const Attrib::Collection *attribs, const ModelHeirarchy *heirarchy);
+    ~PlaceableScenery() override;
+
+    void *operator new(std::size_t size) {
+        return gFastMem.Alloc(size, nullptr);
+    }
+
+    static PlaceableScenery *Construct(const char *name, unsigned int node);
+
+    // IPlaceableScenery
+    void PickUp() override;
+    bool Place(const UMath::Matrix4 &transform, bool snap_to_ground) override;
+    void Destroy() override {
+        Sim::Model::ReleaseModel();
+    }
+
+    // IModel
+    void ReleaseModel() override;
+    bool OnRemoveOffScreen(float dT) override {
+        return false;
+    }
+};
+
+#endif

--- a/src/Speed/Indep/Src/Physics/SceneryModel.h
+++ b/src/Speed/Indep/Src/Physics/SceneryModel.h
@@ -1,0 +1,65 @@
+#ifndef PHYSICS_SCENERYMODEL_H
+#define PHYSICS_SCENERYMODEL_H
+
+#ifdef EA_PRAGMA_ONCE_SUPPORTED
+#pragma once
+#endif
+
+#include "Speed/Indep/Libs/Support/Utility/FastMem.h"
+#include "Speed/Indep/Src/Interfaces/SimModels/ISceneryModel.h"
+#include "Speed/Indep/Src/Physics/HeirarchyModel.h"
+#include "Speed/Indep/Src/Physics/SmackableTrigger.h"
+
+class SmokeableSpawner;
+
+class SceneryModel : public HeirarchyModel, public ISceneryModel {
+  public:
+    SceneryModel(SmokeableSpawner *spawner, const CollisionGeometry::Bounds *geometry,
+                 const Attrib::Collection *attribs, bool hidden);
+    ~SceneryModel() override;
+
+    void *operator new(std::size_t size) {
+        return gFastMem.Alloc(size, nullptr);
+    }
+
+    void operator delete(void *mem, std::size_t size) {
+        if (mem) { gFastMem.Free(mem, size, nullptr); }
+    }
+
+    static SceneryModel *Construct(SmokeableSpawner *data, const Attrib::Collection *attributes, bool hidden);
+
+    static int SceneryCount() {
+        return mSceneryCount;
+    }
+
+    unsigned int GetSpawnerID() const;
+    void RestoreScene();
+    bool GetSceneryTransform(UMath::Matrix4 &matrix) const;
+    void WakeUp();
+    bool IsExcluded(unsigned int scenery_exclusion_flag) const;
+
+    void GetTransform(UMath::Matrix4 &matrix) const override;
+    void ReleaseModel() override;
+    bool IsHidden() const override;
+    void HideModel() override;
+    void OnBeginDraw() override;
+    void OnEndSimulation() override;
+
+    static void InitSystem();
+    static void RestoreSystem();
+
+  private:
+    void InitScene();
+    void StartOverride();
+    void EndOverride();
+    void ShowInstance(bool show);
+
+    bool mInstanceVisible;
+    SmokeableSpawner *mSpawner;
+
+    static int mSceneryCount;
+
+    friend class SmokeableSpawner;
+};
+
+#endif

--- a/src/Speed/Indep/Src/Physics/Smackable.h
+++ b/src/Speed/Indep/Src/Physics/Smackable.h
@@ -33,11 +33,11 @@ struct SmackableParams : public Sim::Param {
     }
 
     SmackableParams(const UMath::Matrix4 &mat, bool virginspawn, IModel *scenery, bool simple_physics)
-        : Sim::Param(UCrc32(UCRC32_BASE), this), //
-          fVirginSpawn(virginspawn),             //
-          fScenery(scenery),                     //
-          fSimplePhysics(simple_physics) {
+        : Sim::Param(UCrc32(UCRC32_BASE), this) {
         UMath::Copy(mat, fMatrix);
+        fVirginSpawn = virginspawn;
+        fScenery = scenery;
+        fSimplePhysics = simple_physics;
     }
 
     struct UMath::Matrix4 fMatrix; // offset 0x10, size 0x40

--- a/src/Speed/Indep/Src/Physics/Smackable.h
+++ b/src/Speed/Indep/Src/Physics/Smackable.h
@@ -1,6 +1,7 @@
 #ifndef PHYSICS_SMACKABLE_H
 #define PHYSICS_SMACKABLE_H
 
+#include "Speed/Indep/Src/Generated/Hash.hpp"
 #include "Speed/Indep/Libs/Support/Utility/FastMem.h"
 #include "Speed/Indep/Libs/Support/Utility/UCollections.h"
 #include "Speed/Indep/Libs/Support/Utility/UListable.h"
@@ -27,12 +28,16 @@ class HeirarchyModel;
 struct SmackableParams : public Sim::Param {
     // TODO macro
     static UCrc32 TypeName() {
-        static UCrc32 value = "SuspensionParams";
+        static UCrc32 value = "SmackableParams";
         return value;
     }
 
-    SmackableParams(const UMath::Matrix4 &mat, bool virginspawn, IModel *scenery, bool simple_physics) {
-        // TODO
+    SmackableParams(const UMath::Matrix4 &mat, bool virginspawn, IModel *scenery, bool simple_physics)
+        : Sim::Param(UCrc32(UCRC32_BASE), this), //
+          fVirginSpawn(virginspawn),             //
+          fScenery(scenery),                     //
+          fSimplePhysics(simple_physics) {
+        UMath::Copy(mat, fMatrix);
     }
 
     struct UMath::Matrix4 fMatrix; // offset 0x10, size 0x40

--- a/src/Speed/Indep/Src/Physics/Smackable.h
+++ b/src/Speed/Indep/Src/Physics/Smackable.h
@@ -1,7 +1,27 @@
 #ifndef PHYSICS_SMACKABLE_H
 #define PHYSICS_SMACKABLE_H
 
+#include "Speed/Indep/Libs/Support/Utility/FastMem.h"
+#include "Speed/Indep/Libs/Support/Utility/UCollections.h"
+#include "Speed/Indep/Libs/Support/Utility/UListable.h"
+#include "Speed/Indep/Libs/Support/Utility/UMath.h"
+#include "Speed/Indep/Src/AI/AIAvoidable.h"
+#include "Speed/Indep/Src/Generated/AttribSys/Classes/rigidbodyspecs.h"
+#include "Speed/Indep/Src/Generated/AttribSys/Classes/smackable.h"
+#include "Speed/Indep/Src/Interfaces/Simables/ICollisionBody.h"
+#include "Speed/Indep/Src/Interfaces/Simables/IDisposable.h"
+#include "Speed/Indep/Src/Interfaces/Simables/IExplodeable.h"
+#include "Speed/Indep/Src/Interfaces/Simables/IRenderable.h"
+#include "Speed/Indep/Src/Interfaces/Simables/ISimpleBody.h"
+#include "Speed/Indep/Src/Main/EventSequencer.h"
+#include "Speed/Indep/Src/Physics/Behaviors/RigidBody.h"
+#include "Speed/Indep/Src/Physics/PhysicsObject.h"
+#include "Speed/Indep/Src/Sim/Collision.h"
+#include "Speed/Indep/Src/Sim/SimActivity.h"
+
 #include "Speed/Indep/Src/Interfaces/SimModels/IModel.h"
+
+class HeirarchyModel;
 
 // total size: 0x5C
 struct SmackableParams : public Sim::Param {
@@ -20,5 +40,150 @@ struct SmackableParams : public Sim::Param {
     IModel *fScenery;              // offset 0x54, size 0x4
     bool fSimplePhysics;           // offset 0x58, size 0x1
 };
+
+
+class Smackable : public PhysicsObject,
+                  public IDisposable,
+                  public IRenderable,
+                  public Sim::Collision::IListener,
+                  public UTL::Collections::Listable<Smackable, 160>,
+                  public IExplodeable,
+                  public EventSequencer::IContext {
+  public:
+    class Manager : public Sim::Activity, public UTL::Collections::Singleton<Manager> {
+      public:
+        void *operator new(std::size_t size) { return gFastMem.Alloc(size, nullptr); }
+        void operator delete(void *mem, std::size_t size) {
+            if (mem) { gFastMem.Free(mem, size, nullptr); }
+        }
+        Manager(float rate);
+        virtual ~Manager();
+        bool OnTask(HSIMTASK htask, float dT) override;
+
+      private:
+        HSIMTASK mManageTask; // offset 0x50, size 0x4
+    };
+
+    void *operator new(std::size_t size) { return gFastMem.Alloc(size, nullptr); }
+    void operator delete(void *mem, std::size_t size) {
+        if (mem) { gFastMem.Free(mem, size, nullptr); }
+    }
+
+    static ISimable *Construct(Sim::Param params);
+    static bool SimplifySort(const Smackable *lhs, const Smackable *rhs);
+    static bool TrySimplify();
+    static Attrib::StringKey CYLINDER;
+    static Attrib::StringKey TUBE;
+    static Attrib::StringKey CONE;
+    static Attrib::StringKey SPHERE;
+
+    Smackable(const UMath::Matrix4 &matrix, const Attrib::Gen::smackable &attributes,
+              const CollisionGeometry::Bounds *geoms, bool virginspawn, IModel *scenery,
+              bool simple_physics, bool is_persistant);
+    virtual ~Smackable();
+
+    bool IsRequired() const override { return false; }
+    bool InView() const override;
+    bool IsRenderable() const override;
+    HMODEL GetModelHandle() const override {
+        HMODEL result = nullptr;
+        if (mModel != nullptr) {
+            result = mModel->GetInstanceHandle();
+        }
+        return result;
+    }
+    const IModel *GetModel() const override;
+    IModel *GetModel() override;
+    float DistanceToView() const override;
+    void OnCollision(const Sim::Collision::Info &cinfo) override;
+    bool OnExplosion(const UMath::Vector3 &normal, const UMath::Vector3 &position, float dT, IExplosion *explosion) override;
+    bool SetDynamicData(const EventSequencer::System *system, EventDynamicData *data) override;
+    void Kill() override;
+    bool OnTask(HSIMTASK htask, float dT) override;
+    void OnDetached(IAttachable *pOther) override;
+    EventSequencer::IEngine *GetEventSequencer() override {
+        if (mModel != nullptr) {
+            return mModel->GetEventSequencer();
+        }
+        return nullptr;
+    }
+
+    virtual void HidePart(const UCrc32 &name) {}
+    virtual void ShowPart(const UCrc32 &name) {}
+    virtual bool IsPartVisible(const UCrc32 &name) const { return true; }
+
+  protected:
+    bool Simplify();
+    void OnTaskSimulate(float dT) override;
+    void OnBehaviorChange(const UCrc32 &mechanic) override;
+
+  private:
+    bool Dropout();
+    bool ProcessDropout(float dT);
+    void ProcessDeath(float dT);
+    void ProcessOffWorld(float dT);
+    void Manage(float dT);
+    bool ValidateWorld();
+    bool ShouldDie();
+    bool CanRetrigger() const;
+    void OnImpact(float acceleration, float speed, Sim::Collision::Info::CollisionType type, ISimable *iother);
+    void DoImpactStimulus(unsigned int systemid, float intensity);
+    void CalcSimplificationWeight();
+
+    Attrib::Gen::smackable mAttributes;
+    float mSimplifyWeight;
+    float mAge;
+    float mLife;
+    float mDropTimer;
+    const float mDropOutTimerMax;
+    float mOffWorldTimer;
+    const float mAutoSimplify;
+    const bool mVirgin;
+    IModel *mModel;
+    const CollisionGeometry::Bounds *mGeometry;
+    HSIMTASK mManageTask;
+    bool mDroppingOut;
+    bool mPersistant;
+    ICollisionBody *mCollisionBody;
+    ISimpleBody *mSimpleBody;
+    UMath::Vector3 mLastImpactSpeed;
+    BehaviorSpecsPtr<Attrib::Gen::rigidbodyspecs> mRBSpecs;
+    UMath::Vector4 mLastCollisionPosition;
+};
+
+class RBSmackable : public RigidBody {
+  public:
+    static Behavior *Construct(const BehaviorParams &parms);
+    RBSmackable(const BehaviorParams &parms, const RBComplexParams &rp);
+    virtual ~RBSmackable();
+    bool ShouldSleep() const override;
+    void OnTaskSimulate(float dT) override;
+    bool CanCollideWith(const RigidBody &other) const override;
+    bool CanCollideWithGround() const override;
+    bool CanCollideWithWorld() const override;
+
+  private:
+    BehaviorSpecsPtr<Attrib::Gen::rigidbodyspecs> mSpecs;
+    unsigned int mFrame;
+};
+
+class SmackableAvoidable : public AIAvoidable {
+  public:
+    void *operator new(std::size_t size) { return gFastMem.Alloc(size, nullptr); }
+    void operator delete(void *mem, std::size_t size) {
+        if (mem) { gFastMem.Free(mem, size, nullptr); }
+    }
+    SmackableAvoidable(HeirarchyModel *model);
+    void SetRefrence(UTL::COM::IUnknown *pUnk) {
+        SetAvoidableObject(pUnk);
+    }
+    bool OnUpdateAvoidable(UMath::Vector3 &pos, float &sweep) override;
+
+  private:
+    HeirarchyModel *mModel;
+};
+
+extern Attrib::StringKey BEHAVIOR_MECHANIC_EFFECTS;
+extern unsigned int Smackable_RigidCount;
 
 #endif

--- a/src/Speed/Indep/Src/Physics/SmackableTrigger.cpp
+++ b/src/Speed/Indep/Src/Physics/SmackableTrigger.cpp
@@ -1,0 +1,69 @@
+#include "SmackableTrigger.h"
+#include "Speed/Indep/Libs/Support/Utility/FastMem.h"
+#include "Speed/Indep/Libs/Support/Utility/UMath.h"
+#include "Speed/Indep/Src/World/WCollisionAssets.h"
+
+SmackableTrigger::SmackableTrigger(HMODEL hmodel, bool virgin, const UMath::Matrix4 &objectmatrix, const UMath::Vector3 &dim,
+                                   unsigned int extra_flags) {
+    unsigned int flags = extra_flags | 0x40143;
+    void *eventMem = gFastMem.Alloc(0x48, "SmackTrigger");
+    CARP::EventList *el = static_cast<CARP::EventList *>(eventMem);
+    this->mTrigger = new WTrigger(objectmatrix, dim, el, flags);
+    el->fNumEvents = 1;
+    CARP::EventStaticData *es = el->Event();
+    this->mEventData = reinterpret_cast<ESpawnSmackable::StaticData *>(&es[1]);
+    es->fDataOffset = 0x10;
+    es->fEventID = ESpawnSmackable::kEventID;
+    es->fPad = 0;
+    es->fEventSize = 0x38;
+    WCollisionAssets::Get().AddTrigger(this->mTrigger);
+    if (!virgin) {
+        this->mTrigger->UpdateBox(objectmatrix, dim);
+    }
+    this->mEventData->fScenery = hmodel;
+    this->mEventData->fVirginSpawn = virgin;
+    UMath::Matrix4ToQuaternion(objectmatrix, this->mEventData->fOrientation);
+    this->mEventData->fPosition = UMath::Vector4To3(objectmatrix.v3);
+    this->mTrigger->Enable();
+}
+
+void SmackableTrigger::Fire() {
+    this->mTrigger->FireEvents(nullptr);
+}
+
+void SmackableTrigger::Disable() {
+    this->mTrigger->Disable();
+}
+
+void SmackableTrigger::Enable() {
+    this->mTrigger->Enable();
+}
+
+bool SmackableTrigger::IsEnabled() const {
+    if (this->mTrigger->IsEnabled()) {
+        return true;
+    }
+    return false;
+}
+
+void SmackableTrigger::GetObjectMatrix(UMath::Matrix4 &matrix) const {
+    UMath::Vector4 q = this->mEventData->fOrientation;
+    UMath::QuaternionToMatrix4(q, matrix);
+    matrix.v3 = UMath::Vector4Make(this->mEventData->fPosition, 1.0f);
+}
+
+void SmackableTrigger::Move(const UMath::Matrix4 &matrix, const UMath::Vector3 &dim, bool virgin) {
+    this->mTrigger->UpdateBox(matrix, dim);
+    this->mEventData->fVirginSpawn = virgin;
+    UMath::Matrix4ToQuaternion(matrix, this->mEventData->fOrientation);
+    this->mEventData->fPosition = UMath::Vector4To3(matrix.v3);
+}
+
+SmackableTrigger::~SmackableTrigger() {
+    gFastMem.Free(this->mTrigger->fEvents, 0x48, "SmackTrigger");
+    this->mTrigger->fEvents = nullptr;
+    WCollisionAssets::Get().RemoveTrigger(this->mTrigger);
+    delete this->mTrigger;
+    this->mTrigger = nullptr;
+    this->mEventData = nullptr;
+}

--- a/src/Speed/Indep/Src/Physics/SmackableTrigger.cpp
+++ b/src/Speed/Indep/Src/Physics/SmackableTrigger.cpp
@@ -2,6 +2,24 @@
 #include "Speed/Indep/Libs/Support/Utility/FastMem.h"
 #include "Speed/Indep/Libs/Support/Utility/UMath.h"
 #include "Speed/Indep/Src/World/WCollisionAssets.h"
+#include "Speed/Indep/Src/Interfaces/SimEntities/IEntity.h"
+#include "Speed/Indep/Src/Interfaces/SimEntities/IPlayer.h"
+#include "Speed/Indep/Src/Interfaces/SimModels/IModel.h"
+#include "Speed/Indep/Src/Interfaces/Simables/ICause.h"
+#include "Speed/Indep/Src/Interfaces/Simables/ICollisionBody.h"
+#include "Speed/Indep/Src/Interfaces/Simables/IDisposable.h"
+#include "Speed/Indep/Src/Interfaces/Simables/IExplosion.h"
+#include "Speed/Indep/Src/Interfaces/Simables/IRecordablePlayer.h"
+#include "Speed/Indep/Src/Interfaces/Simables/IRigidBody.h"
+#include "Speed/Indep/Src/Interfaces/Simables/ISimpleBody.h"
+#include "Speed/Indep/Src/Interfaces/Simables/IVehicle.h"
+#include "Speed/Indep/Src/Physics/PVehicle.h"
+#include "Speed/Indep/Src/Interfaces/SimActivities/IActivity.h"
+#include "Speed/Indep/Src/Interfaces/SimActivities/ITrafficCenter.h"
+#include "Speed/Indep/Src/Interfaces/Simables/IINput.h"
+#include "Speed/Indep/Src/Interfaces/Simables/ISpikeable.h"
+#include "Speed/Indep/Src/AI/AIPursuit.h"
+#include "Speed/Indep/Src/AI/AIRoadBlock.h"
 
 SmackableTrigger::SmackableTrigger(HMODEL hmodel, bool virgin, const UMath::Matrix4 &objectmatrix, const UMath::Vector3 &dim,
                                    unsigned int extra_flags) {
@@ -67,3 +85,39 @@ SmackableTrigger::~SmackableTrigger() {
     this->mTrigger = nullptr;
     this->mEventData = nullptr;
 }
+
+#define IMPL_LISTABLE(TYPE, N)                                                                                                                       \
+    template <> UTL::Collections::Listable<TYPE, N>::List UTL::Collections::Listable<TYPE, N>::_mTable = UTL::Collections::Listable<TYPE, N>::List();
+
+#define IMPL_LISTABLESET(TYPE, N, ENUM, BUCKETS)                                                                                                     \
+    template <>                                                                                                                                      \
+    UTL::Collections::ListableSet<TYPE, N, ENUM, BUCKETS>::_ListSet UTL::Collections::ListableSet<TYPE, N, ENUM, BUCKETS>::_mLists =                 \
+        UTL::Collections::ListableSet<TYPE, N, ENUM, BUCKETS>::_ListSet();
+
+#define IMPL_INSTANCABLE(HANDLE, TYPE, N)                                                                                                            \
+    template <>                                                                                                                                      \
+    UTL::Collections::Instanceable<HANDLE, TYPE, N>::_List UTL::Collections::Instanceable<HANDLE, TYPE, N>::_mList =                                 \
+        UTL::Collections::Instanceable<HANDLE, TYPE, N>::_List();                                                                                     \
+    template <> unsigned int UTL::Collections::Instanceable<HANDLE, TYPE, N>::_mHNext = 0;
+
+IMPL_LISTABLE(IExplosion, 96)
+IMPL_LISTABLE(IDisposable, 160)
+IMPL_LISTABLESET(IVehicle, 10, eVehicleList, 10)
+IMPL_LISTABLE(IRigidBody, 160)
+IMPL_LISTABLE(ICollisionBody, 160)
+IMPL_LISTABLE(ISimpleBody, 96)
+IMPL_LISTABLESET(Sim::IEntity, 8, eEntityList, 4)
+IMPL_LISTABLESET(IPlayer, 8, ePlayerList, 3)
+IMPL_LISTABLE(IRecordablePlayer, 8)
+IMPL_LISTABLE(IInputPlayer, 8)
+IMPL_LISTABLE(IModel, 434)
+IMPL_LISTABLE(IPursuit, 8)
+IMPL_LISTABLE(IRoadBlock, 8)
+IMPL_LISTABLE(IHud, 2)
+IMPL_LISTABLE(IVehicleCache, 18)
+IMPL_LISTABLE(ITrafficCenter, 8)
+IMPL_LISTABLE(ISpikeable, 10)
+IMPL_INSTANCABLE(HSIMABLE, ISimable, 160)
+IMPL_INSTANCABLE(HACTIVITY, Sim::IActivity, 40)
+IMPL_INSTANCABLE(HMODEL, IModel, 434)
+IMPL_INSTANCABLE(HCAUSE, ICause, 10)

--- a/src/Speed/Indep/Src/Physics/SmokeableInfo.hpp
+++ b/src/Speed/Indep/Src/Physics/SmokeableInfo.hpp
@@ -1,6 +1,54 @@
 #ifndef PHYSICS_SMOKEABLEINFO_H
 #define PHYSICS_SMOKEABLEINFO_H
 
+#include "Speed/Indep/Libs/Support/Utility/UBitArray.h"
+#include "Speed/Indep/Libs/Support/Utility/UCrc.h"
+#include "Speed/Indep/Libs/Support/Utility/UQueue.h"
+#include "Speed/Indep/Libs/Support/Utility/UTypes.h"
+#include "Speed/Indep/Tools/AttribSys/Runtime/Common/AttribPrivate.h"
+#include "Speed/Indep/bWare/Inc/bChunk.hpp"
+#include "Speed/Indep/bWare/Inc/bList.hpp"
+
+struct SceneryModel;
+
+struct SmokeableSection {
+    float LastLoadTime;
+    int SectionID;
+    BitArray< unsigned int, 256 > Rebuilds;
+
+    SmokeableSection() {}
+
+    SmokeableSection(int section_id)
+        : LastLoadTime(0.0f) //
+        , SectionID(section_id)
+        , Rebuilds() {}
+
+    SmokeableSection(const SmokeableSection &_ctor_arg)
+        : LastLoadTime(_ctor_arg.LastLoadTime) //
+        , SectionID(_ctor_arg.SectionID)
+        , Rebuilds(_ctor_arg.Rebuilds) {}
+
+    SmokeableSection &operator=(const SmokeableSection &_ctor_arg) {
+        LastLoadTime = _ctor_arg.LastLoadTime;
+        SectionID = _ctor_arg.SectionID;
+        Rebuilds = _ctor_arg.Rebuilds;
+        return *this;
+    }
+};
+
+class SmokeableSectionQ {
+  public:
+    SmokeableSection *FindOrAdd(int section_id);
+    SmokeableSection *Find(int section_id);
+
+    void Reset() {
+        mQueue.reset();
+    }
+
+  private:
+    UCircularQueue< SmokeableSection, 96 > mQueue;
+};
+
 #include "Speed/Indep/Libs/Support/Utility/UCrc.h"
 #include "Speed/Indep/Libs/Support/Utility/UTypes.h"
 #include "Speed/Indep/Tools/AttribSys/Runtime/Common/AttribPrivate.h"
@@ -30,17 +78,29 @@ class SmokeableSpawner {
 
     void OnLoad(unsigned int exclude_flags, bool hidden);
 
-    // UCrc32 GetModelName() const {}
+    UCrc32 GetModelName() const {
+        return mModel;
+    }
 
-    // UCrc32 GetCollisionName() const {}
+    UCrc32 GetCollisionName() const {
+        return mCollisionName;
+    }
 
-    // const UMath::Vector4 &GetOrientation() const {}
+    const UMath::Vector4 &GetOrientation() const {
+        return mOrientation;
+    }
 
-    // const UMath::Vector4 &GetPosition() const {}
+    const UMath::Vector4 &GetPosition() const {
+        return mPosition;
+    }
 
-    // unsigned int GetUniqueID() const {}
+    unsigned int GetUniqueID() const {
+        return mUniqueID;
+    }
 
-    // unsigned int GetExcludeFlags() const {}
+    unsigned int GetExcludeFlags() const {
+        return mExcludeFlags;
+    }
 
   private:
     UMath::Quaternion mOrientation;    // offset 0x0, size 0x10
@@ -53,7 +113,29 @@ class SmokeableSpawner {
     uint32 mExcludeFlags;              // offset 0x34, size 0x4
     struct SceneryModel *mSimModel;    // offset 0x38, size 0x4
     uint32 pad;                        // offset 0x3C, size 0x4
+
+    friend class SceneryModel;
 };
+
+struct SmokeableSpawnerPack : public bTNode< SmokeableSpawnerPack > {
+    short ScenerySectionNumber;
+    short FirstSmokeableSpawnerID;
+    short NumSmokeableSpawners;
+    char EndianSwapped;
+    char Pad;
+    SmokeableSpawner SmokeableSpawners[512];
+
+    void OnLoad(unsigned int exclude_flags);
+    void OnUnload();
+    void OnMoved();
+    void EndianSwap();
+
+    static int Loader(bChunk *chunk);
+    static int Unloader(bChunk *chunk);
+    static bChunkLoader mLoader;
+};
+
+extern SmokeableSectionQ TheSmokeableSections;
 
 void ResetPropTimers();
 

--- a/src/Speed/Indep/Src/Physics/SmokeableInfo.hpp
+++ b/src/Speed/Indep/Src/Physics/SmokeableInfo.hpp
@@ -16,7 +16,10 @@ struct SmokeableSection {
     int SectionID;
     BitArray< unsigned int, 256 > Rebuilds;
 
-    SmokeableSection() {}
+    SmokeableSection()
+        : LastLoadTime(0.0f) //
+        , SectionID(-1)
+        , Rebuilds() {}
 
     SmokeableSection(int section_id)
         : LastLoadTime(0.0f) //

--- a/src/Speed/Indep/Src/Physics/VehicleBehaviors.h
+++ b/src/Speed/Indep/Src/Physics/VehicleBehaviors.h
@@ -1,11 +1,12 @@
 #ifndef VEHICLEBEHAVIORS_H
 #define VEHICLEBEHAVIORS_H
 
+#include "Speed/Indep/Src/Generated/Hash.hpp"
 #include "Behavior.h"
 
 // total size: 0x10
 struct AIParams : public Sim::Param {
-    AIParams() : Sim::Param(TypeName(), static_cast<AIParams *>(nullptr)) {}
+    AIParams() : Sim::Param(UCrc32(UCRC32_BASE), static_cast<AIParams *>(nullptr)) {}
 
     static UCrc32 TypeName() {
         static UCrc32 value = "AIParams";
@@ -23,7 +24,7 @@ struct RBComplexParams : public Sim::Param {
     RBComplexParams(const UMath::Vector3 &pos, const UMath::Vector3 &vel, const UMath::Vector3 &angvel, const UMath::Matrix4 &mat, float mass,
                     const UMath::Vector3 &moment, const UMath::Vector3 &dimension, const CollisionGeometry::Bounds *geoms, bool active,
                     unsigned int collision_mask)
-        : Sim::Param(TypeName(), this), //
+        : Sim::Param(UCrc32(UCRC32_BASE), this), //
           finitPos(pos),                //
           finitVel(vel),                //
           finitAngVel(angvel),          //
@@ -56,7 +57,7 @@ struct RBSimpleParams : public Sim::Param {
 
     RBSimpleParams(const UMath::Vector3 &pos, const UMath::Vector3 &vel, const UMath::Vector3 &angvel, const UMath::Matrix4 &mat, float radius,
                    float mass)
-        : Sim::Param(TypeName(), this), //
+        : Sim::Param(UCrc32(UCRC32_BASE), this), //
           finitPos(pos),                //
           finitVel(vel),                //
           finitAngVel(angvel),          //
@@ -75,7 +76,7 @@ struct RBSimpleParams : public Sim::Param {
 // total size: 0x10
 struct SuspensionParams : public Sim::Param {
     // TODO
-    SuspensionParams() : Sim::Param(TypeName(), static_cast<SuspensionParams *>(nullptr)) {}
+    SuspensionParams() : Sim::Param(UCrc32(UCRC32_BASE), static_cast<SuspensionParams *>(nullptr)) {}
 
     // DECLARE_SIM_PARAM, but why does that one have SuspensionParams::TypeName?
     static UCrc32 TypeName() {
@@ -86,7 +87,7 @@ struct SuspensionParams : public Sim::Param {
 
 // total size: 0x10
 struct EngineParams : public Sim::Param {
-    EngineParams() : Sim::Param(TypeName(), static_cast<EngineParams *>(nullptr)) {}
+    EngineParams() : Sim::Param(UCrc32(UCRC32_BASE), static_cast<EngineParams *>(nullptr)) {}
 
     static UCrc32 TypeName() {
         static UCrc32 value = "EngineParams";
@@ -96,7 +97,7 @@ struct EngineParams : public Sim::Param {
 
 // total size: 0x10
 struct DamageParams : public Sim::Param {
-    DamageParams() : Sim::Param(TypeName(), static_cast<DamageParams *>(nullptr)) {}
+    DamageParams() : Sim::Param(UCrc32(UCRC32_BASE), static_cast<DamageParams *>(nullptr)) {}
 
     static UCrc32 TypeName() {
         static UCrc32 value = "DamageParams";

--- a/src/Speed/Indep/Src/Physics/VehicleBehaviors.h
+++ b/src/Speed/Indep/Src/Physics/VehicleBehaviors.h
@@ -3,6 +3,16 @@
 
 #include "Behavior.h"
 
+// total size: 0x10
+struct AIParams : public Sim::Param {
+    AIParams() : Sim::Param(TypeName(), static_cast<AIParams *>(nullptr)) {}
+
+    static UCrc32 TypeName() {
+        static UCrc32 value = "AIParams";
+        return value;
+    }
+};
+
 // total size: 0x38
 struct RBComplexParams : public Sim::Param {
     static UCrc32 TypeName() {

--- a/src/Speed/Indep/Src/Physics/VehicleBehaviors.h
+++ b/src/Speed/Indep/Src/Physics/VehicleBehaviors.h
@@ -29,6 +29,16 @@ struct RBSimpleParams : public Sim::Param {
         return value;
     }
 
+    RBSimpleParams(const UMath::Vector3 &pos, const UMath::Vector3 &vel, const UMath::Vector3 &angvel, const UMath::Matrix4 &mat, float radius,
+                   float mass)
+        : Sim::Param(TypeName(), this), //
+          finitPos(pos),                //
+          finitVel(vel),                //
+          finitAngVel(angvel),          //
+          finitMat(mat),                //
+          finitRadius(radius),          //
+          finitMass(mass) {}
+
     const UMath::Vector3 &finitPos;    // offset 0x10, size 0x4
     const UMath::Vector3 &finitVel;    // offset 0x14, size 0x4
     const UMath::Vector3 &finitAngVel; // offset 0x18, size 0x4

--- a/src/Speed/Indep/Src/Physics/VehicleBehaviors.h
+++ b/src/Speed/Indep/Src/Physics/VehicleBehaviors.h
@@ -10,6 +10,21 @@ struct RBComplexParams : public Sim::Param {
         return value;
     }
 
+    RBComplexParams(const UMath::Vector3 &pos, const UMath::Vector3 &vel, const UMath::Vector3 &angvel, const UMath::Matrix4 &mat, float mass,
+                    const UMath::Vector3 &moment, const UMath::Vector3 &dimension, const CollisionGeometry::Bounds *geoms, bool active,
+                    unsigned int collision_mask)
+        : Sim::Param(TypeName(), this), //
+          finitPos(pos),                //
+          finitVel(vel),                //
+          finitAngVel(angvel),          //
+          finitMat(mat),                //
+          finitMass(mass),              //
+          finitMoment(moment),          //
+          fdimension(dimension),        //
+          factive(active),              //
+          fgeoms(geoms),                //
+          fCollisionMask(collision_mask) {}
+
     const UMath::Vector3 &finitPos;          // offset 0x10, size 0x4
     const UMath::Vector3 &finitVel;          // offset 0x14, size 0x4
     const UMath::Vector3 &finitAngVel;       // offset 0x18, size 0x4

--- a/src/Speed/Indep/Src/Physics/VehicleBehaviors.h
+++ b/src/Speed/Indep/Src/Physics/VehicleBehaviors.h
@@ -6,7 +6,7 @@
 
 // total size: 0x10
 struct AIParams : public Sim::Param {
-    AIParams() : Sim::Param(UCrc32(UCRC32_BASE), static_cast<AIParams *>(nullptr)) {}
+    AIParams() : Sim::Param(UCrc32(UCRC32_BASE), this) {}
 
     static UCrc32 TypeName() {
         static UCrc32 value = "AIParams";
@@ -76,7 +76,7 @@ struct RBSimpleParams : public Sim::Param {
 // total size: 0x10
 struct SuspensionParams : public Sim::Param {
     // TODO
-    SuspensionParams() : Sim::Param(UCrc32(UCRC32_BASE), static_cast<SuspensionParams *>(nullptr)) {}
+    SuspensionParams() : Sim::Param(UCrc32(UCRC32_BASE), this) {}
 
     // DECLARE_SIM_PARAM, but why does that one have SuspensionParams::TypeName?
     static UCrc32 TypeName() {
@@ -87,7 +87,7 @@ struct SuspensionParams : public Sim::Param {
 
 // total size: 0x10
 struct EngineParams : public Sim::Param {
-    EngineParams() : Sim::Param(UCrc32(UCRC32_BASE), static_cast<EngineParams *>(nullptr)) {}
+    EngineParams() : Sim::Param(UCrc32(UCRC32_BASE), this) {}
 
     static UCrc32 TypeName() {
         static UCrc32 value = "EngineParams";
@@ -97,7 +97,7 @@ struct EngineParams : public Sim::Param {
 
 // total size: 0x10
 struct DamageParams : public Sim::Param {
-    DamageParams() : Sim::Param(UCrc32(UCRC32_BASE), static_cast<DamageParams *>(nullptr)) {}
+    DamageParams() : Sim::Param(UCrc32(UCRC32_BASE), this) {}
 
     static UCrc32 TypeName() {
         static UCrc32 value = "DamageParams";

--- a/src/Speed/Indep/Src/Render/RenderConn.h
+++ b/src/Speed/Indep/Src/Render/RenderConn.h
@@ -334,11 +334,11 @@ class Pkt_Smackable_Open : public Sim::Packet {
   public:
     DECLARE_RENDERPACKET(Pkt_Smackable_Open, SmackableRenderConn);
 
-    Pkt_Smackable_Open(bHash32 modelhash, WUID worldid, const CollisionGeometry::Bounds *collisionnode, const ModelHeirarchy *heirarchy,
+    Pkt_Smackable_Open(bHash32 rendermesh, WUID objectworldid, const CollisionGeometry::Bounds *collisionNode, const ModelHeirarchy *heirarchy,
                        uint32 rendernode)
-        : mModelHash(modelhash),         //
-          mObjectWUID(worldid),          //
-          mCollisionNode(collisionnode), //
+        : mModelHash(rendermesh),        //
+          mObjectWUID(objectworldid),    //
+          mCollisionNode(collisionNode), //
           mHeirarchy(heirarchy),         //
           mRenderNode(rendernode) {}
 

--- a/src/Speed/Indep/Src/Render/RenderConn.h
+++ b/src/Speed/Indep/Src/Render/RenderConn.h
@@ -334,6 +334,14 @@ class Pkt_Smackable_Open : public Sim::Packet {
   public:
     DECLARE_RENDERPACKET(Pkt_Smackable_Open, SmackableRenderConn);
 
+    Pkt_Smackable_Open(bHash32 modelhash, WUID worldid, const CollisionGeometry::Bounds *collisionnode, const ModelHeirarchy *heirarchy,
+                       uint32 rendernode)
+        : mModelHash(modelhash),         //
+          mObjectWUID(worldid),          //
+          mCollisionNode(collisionnode), //
+          mHeirarchy(heirarchy),         //
+          mRenderNode(rendernode) {}
+
   private:
     bHash32 mModelHash;                              // offset 0x4, size 0x4
     WUID mObjectWUID;                                // offset 0x8, size 0x4
@@ -352,6 +360,18 @@ class Pkt_Smackable_Service : public Sim::Packet {
     }
 
     DECLARE_RENDERPACKET(Pkt_Smackable_Service, SmackableRenderConn);
+
+    bool IsVisible() const {
+        return this->mVisible;
+    }
+
+    float DistanceToView() const {
+        return this->mDistanceToView;
+    }
+
+    void SetChildVisibility(uint32 visibility) {
+        this->mChildVisibility = visibility;
+    }
 
   private:
     bool mVisible;           // offset 0x4, size 0x1

--- a/src/Speed/Indep/Src/Sim/Collision.h
+++ b/src/Speed/Indep/Src/Sim/Collision.h
@@ -13,6 +13,8 @@ void AddListener(IListener *listener, HSIMABLE participant, const char *who);
 void AddListener(IListener *listener, const UTL::COM::IUnknown *participant, const char *who);
 void RemoveListener(IListener *listener, const UTL::COM::IUnknown *participant);
 void RemoveListener(IListener *listener);
+void AddParticipant(HSIMABLE participant);
+void RemoveParticipant(HSIMABLE participant);
 
 }; // namespace Collision
 

--- a/src/Speed/Indep/Src/Sim/SimModel.h
+++ b/src/Speed/Indep/Src/Sim/SimModel.h
@@ -87,7 +87,9 @@ class Model : public Sim::Object,
     }
 
     WUID GetWorldID() const override;
-    const CollisionGeometry::Bounds *GetCollisionGeometry() const override;
+    const CollisionGeometry::Bounds *GetCollisionGeometry() const override {
+        return mGeometry;
+    }
     void ReleaseModel() override;
 
     ISimable *GetSimable() const override {

--- a/src/Speed/Indep/Src/Sim/SimModel.h
+++ b/src/Speed/Indep/Src/Sim/SimModel.h
@@ -144,9 +144,13 @@ class Model : public Sim::Object,
         this->mDistanceToView = distance;
     }
 
-    bool IsRendering() const {}
+    bool IsRendering() const {
+        return mService != nullptr;
+    }
 
-    bool IsSimulating() const {}
+    bool IsSimulating() const {
+        return mSimable != nullptr;
+    }
 
     virtual void OnBeginSimulation() {}
 

--- a/src/Speed/Indep/Src/Sim/SimSubSystem.h
+++ b/src/Speed/Indep/Src/Sim/SimSubSystem.h
@@ -22,6 +22,7 @@ class SubSystem {
           mNext(mHead),        //
           mName(name) {
 #endif
+        mHead = this;
     }
 
     static void Init(const UCrc32 &sig) {

--- a/src/Speed/Indep/Src/Sim/SimSubSystem.h
+++ b/src/Speed/Indep/Src/Sim/SimSubSystem.h
@@ -19,9 +19,9 @@ class SubSystem {
         : mInit(initcb),       //
           mRestore(restorecb), //
           mSig(name),          //
-          mNext(mHead),        //
           mName(name) {
 #endif
+        mNext = mHead;
         mHead = this;
     }
 

--- a/src/Speed/Indep/Src/Sim/SimTypes.h
+++ b/src/Speed/Indep/Src/Sim/SimTypes.h
@@ -92,7 +92,9 @@ struct Info {
         objBsurface = nullptr;
     }
 
-    CollisionType Type() const {}
+    CollisionType Type() const {
+        return static_cast<CollisionType>(this->type);
+    }
 
     UMath::Vector3 position;               // offset 0x0, size 0xC
     const Attrib::Collection *objAsurface; // offset 0xC, size 0x4

--- a/src/Speed/Indep/Src/World/Scenery.hpp
+++ b/src/Speed/Indep/Src/World/Scenery.hpp
@@ -284,12 +284,11 @@ struct SceneryOverrideInfo {
     }
 
     void EnableRendering() {
-        this->ExcludeFlags &= ~0x10;
-        this->SetExcludeFlags(0, 0);
+        this->SetExcludeFlags(~0x10, 0);
     }
 
     void DisableRendering() {
-        this->SetExcludeFlags(0x10, 0x10);
+        this->SetExcludeFlags(~0, 0x10);
     }
 
     void AssignOverrides();

--- a/src/Speed/Indep/Src/World/Scenery.hpp
+++ b/src/Speed/Indep/Src/World/Scenery.hpp
@@ -227,6 +227,10 @@ class ScenerySectionHeader : public bTNode<ScenerySectionHeader> {
         return &this->pSceneryInstance[scenery_instance_number];
     }
 
+    SceneryInfo *GetSceneryInfo(SceneryInstance *scenery_instance) {
+        return &pSceneryInfo[scenery_instance->SceneryInfoNumber];
+    }
+
     SceneryInfo *GetSceneryInfo(int scenery_info_number) {
         return &this->pSceneryInfo[scenery_info_number];
     }
@@ -256,6 +260,8 @@ class ScenerySectionHeader : public bTNode<ScenerySectionHeader> {
     int32 ViewsVisibleThisFrame;           // offset 0x38, size 0x4
 };
 
+ScenerySectionHeader *GetScenerySectionHeader(int section_number);
+
 // total size: 0x6
 struct SceneryOverrideInfo {
     void EndianSwap() {
@@ -275,6 +281,15 @@ struct SceneryOverrideInfo {
     void SetExcludeFlags(unsigned short exclude_flag_mask, unsigned short exclude_flag_override) {
         this->ExcludeFlags = (this->ExcludeFlags & exclude_flag_mask) | exclude_flag_override;
         this->AssignOverrides();
+    }
+
+    void EnableRendering() {
+        this->ExcludeFlags &= ~0x10;
+        this->SetExcludeFlags(0, 0);
+    }
+
+    void DisableRendering() {
+        this->SetExcludeFlags(0x10, 0x10);
     }
 
     void AssignOverrides();

--- a/src/Speed/Indep/Tools/AttribSys/Runtime/AttribSys.h
+++ b/src/Speed/Indep/Tools/AttribSys/Runtime/AttribSys.h
@@ -571,7 +571,6 @@ class Attribute {
     unsigned int GetLength() const;
     bool SetLength(unsigned int);
     void SendChangeMsg() const;
-    // TODO
     template <typename T> const T &Get(unsigned int index) const;
 
     void operator delete(void *ptr, std::size_t bytes) {
@@ -621,6 +620,11 @@ class Attribute {
     Node *mInternal;               // offset 0x8, size 0x4
     void *mDataPointer;            // offset 0xC, size 0x4
 };
+
+template <typename T> const T &Attribute::Get(unsigned int index) const {
+    const T *resultptr = reinterpret_cast<const T *>(GetElementPointer(index));
+    return (resultptr != nullptr) ? *resultptr : *static_cast<const T *>(DefaultDataArea(sizeof(T)));
+}
 
 namespace Gen {
 class GenericAccessor;
@@ -685,16 +689,16 @@ class Instance {
     bool Remove(Key attributeKey);
 
     template <typename T> bool AddAndSet(Key attributeKey, const T *data, unsigned int count) {
-        if (!this->Add(attributeKey, count) && !this->Contains(attributeKey)) {
-            return false;
+        if (this->Add(attributeKey, count) || this->Contains(attributeKey)) {
+            Attribute newattrib = this->Get(attributeKey);
+            for (unsigned int i = 0; i < count; i++) {
+                newattrib.Set(i, data[i]);
+            }
+
+            return true;
         }
 
-        Attribute newattrib = this->Get(attributeKey);
-        for (unsigned int i = 0; i < count; i++) {
-            newattrib.Set(i, data[i]);
-        }
-
-        return true;
+        return false;
     }
 
     // TODO
@@ -971,6 +975,10 @@ class RefSpec {
 
     Key GetCollectionKey() const {
         return mCollectionKey;
+    }
+
+    bool operator==(const RefSpec &rhs) const {
+        return mClassKey == rhs.mClassKey && mCollectionKey == rhs.mCollectionKey;
     }
 
   private:

--- a/src/Speed/Indep/Tools/AttribSys/Runtime/AttribSys.h
+++ b/src/Speed/Indep/Tools/AttribSys/Runtime/AttribSys.h
@@ -981,6 +981,10 @@ class RefSpec {
         return mClassKey == rhs.mClassKey && mCollectionKey == rhs.mCollectionKey;
     }
 
+    bool operator!=(const RefSpec &rhs) const {
+        return !(*this == rhs);
+    }
+
   private:
     Key mClassKey;                            // offset 0x0, size 0x4
     Key mCollectionKey;                       // offset 0x4, size 0x4

--- a/src/Speed/Indep/Tools/AttribSys/Runtime/AttribSys.h
+++ b/src/Speed/Indep/Tools/AttribSys/Runtime/AttribSys.h
@@ -602,6 +602,17 @@ class Attribute {
         return false;
     }
 
+    template <typename T> bool Set(unsigned int index, const T &input) {
+        T *resultptr = reinterpret_cast<T *>(GetElementPointer(index));
+
+        if (resultptr != nullptr) {
+            *resultptr = input;
+            return true;
+        }
+
+        return false;
+    }
+
   private:
     void *GetInternalPointer(unsigned int index) const;
 
@@ -672,6 +683,19 @@ class Instance {
     unsigned int LocalAttribCount() const;
     bool Add(Key attributeKey, unsigned int count);
     bool Remove(Key attributeKey);
+
+    template <typename T> bool AddAndSet(Key attributeKey, const T *data, unsigned int count) {
+        if (!this->Add(attributeKey, count) && !this->Contains(attributeKey)) {
+            return false;
+        }
+
+        Attribute newattrib = this->Get(attributeKey);
+        for (unsigned int i = 0; i < count; i++) {
+            newattrib.Set(i, data[i]);
+        }
+
+        return true;
+    }
 
     // TODO
     template <typename T> TAttrib<T> GetOrClone(Key attributeKey) {}

--- a/src/Speed/Indep/bWare/Inc/Strings.hpp
+++ b/src/Speed/Indep/bWare/Inc/Strings.hpp
@@ -87,6 +87,7 @@ int bStrICmp(const char *s1, const char *s2);
 const char *bAllocateSharedString(const char *s);
 void bFreeSharedString(const char *s);
 uint32 bStringHash(const char *text);
+uint32 bStringHashUpper(const char *text);
 uint32 bStringHash(const char *text, int prefix_hash);
 int bStrToLong(const char *s);
 float bStrToFloat(const char *s);

--- a/tools/attrib_generator.py
+++ b/tools/attrib_generator.py
@@ -266,7 +266,7 @@ Key GetClass() {{
     return {strToKey[name]};
 }}
 void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {{
-    ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
+    ModifyInternal(ClassKey(), dynamicCollectionKey, LocalAttribCount() + spaceForAdditionalAttributes);
 }}
 Key GenerateUniqueKey(const char *name, bool registerName) const {{
     return GUKeyInternal(ClassKey(), name, registerName);

--- a/tools/attrib_generator.py
+++ b/tools/attrib_generator.py
@@ -266,10 +266,10 @@ Key GetClass() {{
     return {strToKey[name]};
 }}
 void Modify(Key dynamicCollectionKey, unsigned int spaceForAdditionalAttributes) {{
-    ModifyInternal({strToKey[name]}, dynamicCollectionKey, spaceForAdditionalAttributes);
+    ModifyInternal(ClassKey(), dynamicCollectionKey, spaceForAdditionalAttributes);
 }}
 Key GenerateUniqueKey(const char *name, bool registerName) const {{
-    return GenerateUniqueKey(name, registerName);
+    return GUKeyInternal(ClassKey(), name, registerName);
 }}
 void Change(const Collection *c) {{
     Instance::Change(c);


### PR DESCRIPTION
## Note for when Frontend opens up

Add to `struct FECustomizationRecord` in `src/Speed/Indep/Src/Frontend/Database/VehicleDB.hpp`, just before the `InstalledPartIndices` member:

```cpp
    void SetTuning(Physics::Tunings::Path id, float value) {
        this->Tunings[this->ActiveTuning].Value[id] = value;
    }

    float GetTuning(Physics::Tunings::Path id) const {
        return this->Tunings[this->ActiveTuning].Value[id];
    }

    const Physics::Tunings *GetTunings() const {
        return &this->Tunings[this->ActiveTuning];
    }

    Physics::Tunings *GetTunings() {
        return &this->Tunings[this->ActiveTuning];
    }

    USE_FASTALLOC(FECustomizationRecord)

    FECustomizationRecord();

    void Default();
    void BecomePreset(PresetCar *preset);
    bool WriteRecordIntoPhysics(Attrib::Gen::pvehicle &vehicle) const;
    bool WritePhysicsIntoRecord(const Attrib::Gen::pvehicle &vehicle);
```

Plus, at the top of the same file:

```cpp
#include "Speed/Indep/Libs/Support/Utility/FastMem.h"
```
```cpp
struct PresetCar;
```

Then uncomment the five `// TODO: Uncomment + add from PR 135` sites in `src/Speed/Indep/Src/Physics/Common/PVehicle.cpp` (lines ~253, ~648, ~1258, ~1261, ~1266). 